### PR TITLE
feat(postgres): Upgrade pgrx to 0.16 with pg17/pg18 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.3.4",
  "once_cell",
  "serde",
@@ -102,7 +102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4bbb2296f2525e53a52680f5c2df6de9a83b8a94cc22a8cc629301a27b5e0b7"
 dependencies = [
  "anyhow",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpu-time",
  "env_logger",
  "lazy_static",
@@ -114,12 +114,12 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.9.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
 dependencies = [
- "unicode-width 0.1.11",
- "yansi-term",
+ "anstyle",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -304,16 +304,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "atomic-traits"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29ec3788e96fb4fdb275ccb9d62811f2fa903d76c5eb4dd6fe7d09a7ed5871f"
-dependencies = [
- "cfg-if",
- "rustc_version 0.3.3",
 ]
 
 [[package]]
@@ -512,7 +502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "miniz_oxide",
  "object",
@@ -575,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "annotate-snippets",
  "bitflags 2.10.0",
@@ -670,7 +660,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "constant_time_eq",
 ]
 
@@ -861,7 +851,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.27",
+ "semver",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -869,12 +859,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.19.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be"
+checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.9.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -922,6 +912,12 @@ checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom 7.1.3",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -1054,6 +1050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,7 +1108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
- "cfg-if",
+ "cfg-if 1.0.4",
  "itoa",
  "rustversion",
  "ryu",
@@ -1156,9 +1161,15 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
@@ -1171,6 +1182,15 @@ name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1252,7 +1272,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -1280,7 +1300,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -1448,6 +1468,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,7 +1544,7 @@ version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -1510,7 +1557,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
@@ -1523,6 +1570,41 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-postgres"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
+dependencies = [
+ "async-trait",
+ "deadpool",
+ "getrandom 0.2.16",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
 
 [[package]]
 name = "debugid"
@@ -1539,6 +1621,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1654,7 +1737,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "dirs-sys-next",
 ]
 
@@ -1735,6 +1818,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dwrote"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1862,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,7 +1904,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -2019,12 +2133,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "filetime"
 version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "libredox",
  "windows-sys 0.60.2",
@@ -2053,6 +2173,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -2544,7 +2670,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "wasi",
@@ -2557,7 +2683,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi",
@@ -2603,7 +2729,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "dashmap 5.5.3",
  "futures",
  "futures-timer",
@@ -2668,22 +2794,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
  "rand 0.9.2",
  "rand_distr 0.5.1",
  "serde",
  "zerocopy",
-]
-
-[[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -2734,7 +2851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdcd9b131fd67bb827b386d0dc63d3e74196a14616ef800acf87ca5fef741a10"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.4",
  "hdf5-derive",
  "hdf5-sys",
  "hdf5-types",
@@ -2778,7 +2895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b47268c0dfb499b1ffe5638b6e7694e7a87fe49fb92eca998a4346e5483e428f"
 dependencies = [
  "ascii",
- "cfg-if",
+ "cfg-if 1.0.4",
  "hdf5-sys",
  "libc",
 ]
@@ -2798,16 +2915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2824,6 +2931,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hf-hub"
@@ -2883,7 +2996,7 @@ dependencies = [
  "anndists",
  "anyhow",
  "bincode 1.3.3",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpu-time",
  "env_logger",
  "hashbrown 0.15.5",
@@ -3404,7 +3517,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -3622,7 +3735,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "winapi",
 ]
 
@@ -3632,7 +3745,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link",
 ]
 
@@ -3790,7 +3903,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "rayon",
 ]
 
@@ -3800,7 +3913,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "digest",
 ]
 
@@ -3828,6 +3941,12 @@ checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg 1.5.0",
 ]
+
+[[package]]
+name = "memory_units"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "mime"
@@ -3905,7 +4024,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "downcast",
  "fragile",
  "mockall_derive",
@@ -3919,7 +4038,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -3940,7 +4059,7 @@ dependencies = [
  "futures-util",
  "parking_lot 0.12.5",
  "portable-atomic",
- "rustc_version 0.4.1",
+ "rustc_version",
  "smallvec 1.15.1",
  "tagptr",
  "uuid",
@@ -4085,8 +4204,8 @@ version = "2.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cbe2585d8ac223f7d34f13701434b9d5f4eb9c332cccce8dee57ea18ab8ab0c"
 dependencies = [
- "cfg-if",
- "convert_case",
+ "cfg-if 1.0.4",
+ "convert_case 0.6.0",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
@@ -4099,12 +4218,12 @@ version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1639aaa9eeb76e91c6ae66da8ce3e89e921cd3885e99ec85f4abacae72fc91bf"
 dependencies = [
- "convert_case",
+ "convert_case 0.6.0",
  "once_cell",
  "proc-macro2",
  "quote",
  "regex",
- "semver 1.0.27",
+ "semver",
  "syn 2.0.111",
 ]
 
@@ -4191,7 +4310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "memoffset",
  "pin-utils",
@@ -4457,6 +4576,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4512,7 +4640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags 2.10.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "foreign-types 0.3.2",
  "libc",
  "once_cell",
@@ -4614,8 +4742,7 @@ version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 dependencies = [
- "supports-color 2.1.0",
- "supports-color 3.0.2",
+ "supports-color",
 ]
 
 [[package]]
@@ -4672,7 +4799,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "instant",
  "libc",
  "redox_syscall 0.2.16",
@@ -4686,7 +4813,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall 0.5.18",
  "smallvec 1.15.1",
@@ -4721,7 +4848,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
 dependencies = [
- "rustc_version 0.4.1",
+ "rustc_version",
 ]
 
 [[package]]
@@ -4798,23 +4925,32 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "indexmap 2.12.1",
 ]
 
 [[package]]
-name = "pgrx"
-version = "0.12.9"
+name = "petgraph"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227bf7e162ce710994306a97bc56bb3fe305f21120ab6692e2151c48416f5c0d"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "atomic-traits",
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
+ "indexmap 2.12.1",
+ "serde",
+]
+
+[[package]]
+name = "pgrx"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdcfb88f7fa9ba42b4ea9d1f85a1d968bbb407cc30308b35f73bdfe6c966f64b"
+dependencies = [
  "bitflags 2.10.0",
  "bitvec",
  "enum-map",
- "heapless",
  "libc",
- "once_cell",
  "pgrx-macros",
  "pgrx-pg-sys",
  "pgrx-sql-entity-graph",
@@ -4822,15 +4958,15 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "uuid",
 ]
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.12.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cbcd956c2da35baaf0a116e6f6a49a6c2fbc8f6b332f66d6fd060bfd00615f"
+checksum = "00e35193b7e71e2f612d336cecd00db0f049f4cc609f2b1c9a34755b5ec559d7"
 dependencies = [
  "bindgen",
  "cc",
@@ -4839,6 +4975,7 @@ dependencies = [
  "pgrx-pg-config",
  "proc-macro2",
  "quote",
+ "regex",
  "shlex",
  "syn 2.0.111",
  "walkdir",
@@ -4846,9 +4983,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.12.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f4291450d65e4deb770ce57ea93e22353d97950566222429cd166ebdf6f938"
+checksum = "dab542dd4041773874f90cd8e3448195749548dc3fb1daf501e7e11ebfb1dd22"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -4858,27 +4995,29 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.12.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a64a4c6e4e43e73cf8d3379d9533df98ded45c920e1ba8131c979633d74132"
+checksum = "eff9b29df94c3f9fcb0cde220f92eea6975ed05962784a98fb557754ad663501"
 dependencies = [
  "cargo_toml",
+ "codepage",
+ "encoding_rs",
  "eyre",
- "home",
  "owo-colors",
  "pathsearch",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
- "toml",
+ "thiserror 2.0.17",
+ "toml 0.9.11+spec-1.1.0",
  "url",
+ "winapi",
 ]
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.12.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a5dc64f2a8226434118aa2c4700450fa42b04f29488ad98268848b21c1a4ec"
+checksum = "934f2536953ccb6722bef2cfdfb1f8d6d3cd4a4f2c508d56ec85b649c5680c2b"
 dependencies = [
  "cee-scape",
  "libc",
@@ -4886,30 +5025,29 @@ dependencies = [
  "pgrx-macros",
  "pgrx-sql-entity-graph",
  "serde",
- "sptr",
 ]
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.12.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81cc2e851c7e36b2f47c03e22d64d56c1d0e762fbde0039ba2cd490cfef3615"
+checksum = "07a767cb9faa612f1ba7f13718136d4006950d6f253b414ef487a03e85c47a94"
 dependencies = [
- "convert_case",
+ "convert_case 0.8.0",
  "eyre",
- "petgraph",
+ "petgraph 0.8.3",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "unescape",
 ]
 
 [[package]]
 name = "pgrx-tests"
-version = "0.12.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2dd5d674cb7d92024709543da06d26723a2f7450c02083116b232587160929"
+checksum = "e0d5d5f614a32310af2cc1b9587c69e041d97e8ab812d8d31fdcd3d33d27325c"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -4921,12 +5059,15 @@ dependencies = [
  "pgrx-pg-config",
  "postgres",
  "proptest",
- "rand 0.8.5",
+ "rand 0.9.2",
  "regex",
  "serde",
  "serde_json",
- "sysinfo 0.30.13",
- "thiserror 1.0.69",
+ "shlex",
+ "sysinfo 0.34.2",
+ "tempfile",
+ "thiserror 2.0.17",
+ "winapi",
 ]
 
 [[package]]
@@ -4979,6 +5120,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -5138,7 +5289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
 dependencies = [
  "backtrace",
- "cfg-if",
+ "cfg-if 1.0.4",
  "criterion",
  "findshlibs",
  "inferno",
@@ -5161,6 +5312,50 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "pqcrypto-dilithium"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685de0fa68c6786559d5fcdaa414f0cd68ef3f5d162f61823bd7424cd276726f"
+dependencies = [
+ "cc",
+ "glob",
+ "libc",
+ "pqcrypto-internals",
+ "pqcrypto-traits",
+]
+
+[[package]]
+name = "pqcrypto-internals"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a326caf27cbf2ac291ca7fd56300497ba9e76a8cc6a7d95b7a18b57f22b61d"
+dependencies = [
+ "cc",
+ "dunce",
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "pqcrypto-kyber"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c00293cf898859d0c771455388054fd69ab712263c73fdc7f287a39b1ba000"
+dependencies = [
+ "cc",
+ "glob",
+ "libc",
+ "pqcrypto-internals",
+ "pqcrypto-traits",
+]
+
+[[package]]
+name = "pqcrypto-traits"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
 
 [[package]]
 name = "predicates"
@@ -5294,7 +5489,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "fnv",
  "lazy_static",
  "memchr",
@@ -5390,7 +5585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
 dependencies = [
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libm",
  "num-complex 0.4.6",
  "reborrow",
@@ -5702,7 +5897,7 @@ dependencies = [
  "av1-grain",
  "bitstream-io",
  "built",
- "cfg-if",
+ "cfg-if 1.0.4",
  "interpolate_name",
  "itertools 0.14.0",
  "libc",
@@ -5770,6 +5965,7 @@ checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -5802,6 +5998,7 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -6042,7 +6239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.16",
  "libc",
  "untrusted",
@@ -6127,18 +6324,9 @@ checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -6146,7 +6334,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.27",
+ "semver",
 ]
 
 [[package]]
@@ -6258,7 +6446,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-attention"
-version = "0.1.0"
+version = "0.1.31"
 dependencies = [
  "approx",
  "criterion",
@@ -6266,6 +6454,7 @@ dependencies = [
  "napi-derive",
  "rand 0.8.5",
  "rayon",
+ "ruvector-math",
  "serde",
  "thiserror 1.0.69",
 ]
@@ -6284,8 +6473,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruvector-attention-wasm"
+name = "ruvector-attention-unified-wasm"
 version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "getrandom 0.2.16",
+ "js-sys",
+ "ruvector-attention",
+ "ruvector-dag",
+ "ruvector-gnn",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "web-sys",
+ "wee_alloc",
+]
+
+[[package]]
+name = "ruvector-attention-wasm"
+version = "0.1.31"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.16",
@@ -6300,7 +6508,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-bench"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6331,7 +6539,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-cli"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6343,6 +6551,8 @@ dependencies = [
  "colored",
  "console",
  "csv",
+ "deadpool-postgres",
+ "flate2",
  "futures",
  "http-body-util",
  "hyper 1.8.1",
@@ -6363,7 +6573,8 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
- "toml",
+ "tokio-postgres",
+ "toml 0.8.23",
  "tower 0.5.2",
  "tower-http 0.6.8",
  "tracing",
@@ -6402,7 +6613,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-cluster"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
@@ -6422,7 +6633,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-collections"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "bincode 2.0.1",
  "chrono",
@@ -6437,7 +6648,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-core"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -6469,8 +6680,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruvector-dag"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "crossbeam",
+ "dashmap 5.5.3",
+ "getrandom 0.2.16",
+ "ndarray 0.16.1",
+ "parking_lot 0.12.5",
+ "pqcrypto-dilithium",
+ "pqcrypto-kyber",
+ "proptest",
+ "rand 0.8.5",
+ "ruvector-core",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-test",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "ruvector-dag-wasm"
+version = "0.1.0"
+dependencies = [
+ "bincode 1.3.3",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "wee_alloc",
+]
+
+[[package]]
+name = "ruvector-economy-wasm"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "sha2",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "ruvector-exotic-wasm"
+version = "0.1.31"
+dependencies = [
+ "console_error_panic_hook",
+ "getrandom 0.2.16",
+ "getrandom 0.3.4",
+ "js-sys",
+ "rand 0.8.5",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "ruvector-filter"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "chrono",
  "dashmap 6.1.0",
@@ -6483,8 +6761,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruvector-fpga-transformer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "criterion",
+ "ed25519-dalek",
+ "getrandom 0.2.16",
+ "hex",
+ "js-sys",
+ "memmap2",
+ "proptest",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ruvector-fpga-transformer-wasm"
+version = "0.1.0"
+dependencies = [
+ "getrandom 0.2.16",
+ "js-sys",
+ "ruvector-fpga-transformer",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "ruvector-gnn"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "criterion",
@@ -6509,7 +6824,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-gnn-node"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "napi",
  "napi-build",
@@ -6535,7 +6850,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-graph"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -6564,7 +6879,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "pest_generator",
- "petgraph",
+ "petgraph 0.6.5",
  "prometheus",
  "proptest",
  "prost",
@@ -6596,7 +6911,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-graph-node"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "futures",
@@ -6615,7 +6930,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-graph-wasm"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -6639,8 +6954,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruvector-learning-wasm"
+version = "0.1.0"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde-wasm-bindgen",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "ruvector-math"
+version = "0.1.31"
+dependencies = [
+ "approx",
+ "criterion",
+ "nalgebra 0.33.2",
+ "proptest",
+ "rand 0.8.5",
+ "rand_distr 0.4.3",
+ "rayon",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "ruvector-math-wasm"
+version = "0.1.31"
+dependencies = [
+ "console_error_panic_hook",
+ "getrandom 0.2.16",
+ "js-sys",
+ "rayon",
+ "ruvector-math",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-rayon",
+ "wasm-bindgen-test",
+ "web-sys",
+]
+
+[[package]]
 name = "ruvector-metrics"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "chrono",
  "lazy_static",
@@ -6651,7 +7010,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-mincut"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "criterion",
@@ -6660,7 +7019,7 @@ dependencies = [
  "mockall",
  "ordered-float",
  "parking_lot 0.12.5",
- "petgraph",
+ "petgraph 0.6.5",
  "proptest",
  "rand 0.8.5",
  "rayon",
@@ -6674,8 +7033,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruvector-mincut-gated-transformer"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "getrandom 0.2.16",
+ "proptest",
+ "rand 0.8.5",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "ruvector-mincut-gated-transformer-wasm"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "ruvector-mincut-gated-transformer",
+ "serde",
+ "serde-wasm-bindgen",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "ruvector-mincut-node"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "napi",
  "napi-build",
@@ -6687,7 +7071,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-mincut-wasm"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.16",
@@ -6701,8 +7085,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruvector-nervous-system"
+version = "0.1.31"
+dependencies = [
+ "anyhow",
+ "approx",
+ "bincode 2.0.1",
+ "criterion",
+ "ndarray 0.16.1",
+ "parking_lot 0.12.5",
+ "proptest",
+ "rand 0.8.5",
+ "rand_distr 0.4.3",
+ "rayon",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "ruvector-nervous-system-wasm"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "getrandom 0.2.16",
+ "js-sys",
+ "rand 0.8.5",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "web-sys",
+]
+
+[[package]]
 name = "ruvector-node"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "napi",
@@ -6726,6 +7144,7 @@ dependencies = [
  "approx",
  "bincode 1.3.3",
  "bitvec",
+ "chrono",
  "criterion",
  "crossbeam",
  "dashmap 6.1.0",
@@ -6745,6 +7164,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "rkyv",
+ "ruvector-mincut-gated-transformer",
  "serde",
  "serde_json",
  "simsimd",
@@ -6755,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-raft"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "bincode 2.0.1",
  "chrono",
@@ -6774,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-replication"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "bincode 2.0.1",
  "chrono",
@@ -6793,7 +7213,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-router-cli"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6808,7 +7228,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-router-core"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -6816,7 +7236,7 @@ dependencies = [
  "criterion",
  "crossbeam",
  "memmap2",
- "ndarray 0.15.6",
+ "ndarray 0.16.1",
  "parking_lot 0.12.5",
  "proptest",
  "rand 0.8.5",
@@ -6835,7 +7255,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-router-ffi"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6850,7 +7270,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-router-wasm"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "js-sys",
  "ruvector-router-core",
@@ -6864,7 +7284,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-scipix"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -6922,7 +7342,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "tower 0.4.13",
  "tower-http 0.5.2",
  "tracing",
@@ -6937,7 +7357,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-server"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "axum",
  "dashmap 6.1.0",
@@ -6955,7 +7375,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-snapshot"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
@@ -6992,8 +7412,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruvector-sparse-inference"
+version = "0.1.31"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "criterion",
+ "half 2.7.1",
+ "memmap2",
+ "mockall",
+ "ndarray 0.16.1",
+ "parking_lot 0.12.5",
+ "proptest",
+ "rand 0.8.5",
+ "rand_distr 0.4.3",
+ "rayon",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "ruvector-sparse-inference-wasm"
+version = "0.1.31"
+dependencies = [
+ "console_error_panic_hook",
+ "getrandom 0.3.4",
+ "js-sys",
+ "ruvector-sparse-inference",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
+]
+
+[[package]]
 name = "ruvector-tiny-dancer-core"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -7023,7 +7483,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-tiny-dancer-node"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7040,7 +7500,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-tiny-dancer-wasm"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "js-sys",
  "ruvector-tiny-dancer-core",
@@ -7054,7 +7514,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-wasm"
-version = "0.1.29"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -7122,7 +7582,7 @@ dependencies = [
  "tokenizers 0.20.4",
  "tokio",
  "tokio-test",
- "toml",
+ "toml 0.8.23",
  "tower 0.4.13",
  "tower-http 0.5.2",
  "tracing",
@@ -7241,30 +7701,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 dependencies = [
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -7292,6 +7734,16 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -7367,6 +7819,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7384,7 +7845,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest",
 ]
@@ -7395,7 +7856,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest",
 ]
@@ -7437,6 +7898,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7566,6 +8036,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "spm_precompiled"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7576,12 +8056,6 @@ dependencies = [
  "serde",
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "stable_deref_trait"
@@ -7641,16 +8115,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "supports-color"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
-dependencies = [
- "is-terminal",
- "is_ci",
-]
 
 [[package]]
 name = "supports-color"
@@ -7762,21 +8226,6 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "windows 0.52.0",
-]
-
-[[package]]
-name = "sysinfo"
 version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
@@ -7786,6 +8235,19 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
  "windows 0.57.0",
 ]
 
@@ -7963,7 +8425,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -8251,9 +8713,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+dependencies = [
+ "indexmap 2.12.1",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -8267,9 +8744,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
 ]
@@ -8282,7 +8759,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.12.1",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow",
@@ -8295,16 +8772,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
 dependencies = [
  "indexmap 2.12.1",
- "toml_datetime 0.7.3",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
@@ -8314,6 +8791,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
@@ -8907,7 +9390,7 @@ version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -8920,7 +9403,7 @@ version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -8948,6 +9431,18 @@ dependencies = [
  "quote",
  "syn 2.0.111",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-rayon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a16c60a56c81e4dc3b9c43d76ba5633e1c0278211d59a9cb07d61b6cd1c6583"
+dependencies = [
+ "crossbeam-channel",
+ "js-sys",
+ "rayon",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -9005,6 +9500,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm_sync"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff360cade7fec41ff0e9d2cda57fe58258c5f16def0e21302394659e6bbb0ea"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9055,6 +9561,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wee_alloc"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "memory_units",
+ "winapi",
 ]
 
 [[package]]
@@ -9132,30 +9650,11 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -9528,7 +10027,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-sys 0.48.0",
 ]
 
@@ -9589,15 +10088,6 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "yansi-term"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "yeslogic-fontconfig-sys"
@@ -9703,6 +10193,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "zerotrie"

--- a/crates/ruvector-postgres/Cargo.toml
+++ b/crates/ruvector-postgres/Cargo.toml
@@ -22,6 +22,7 @@ pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
 pg_test = []
 
 # SIMD features for compile-time selection
@@ -64,7 +65,7 @@ all-features = ["ai-complete", "graph-complete", "embeddings"]
 
 [dependencies]
 # PostgreSQL extension framework
-pgrx = "0.12"
+pgrx = "0.16"
 
 # Pin home to avoid edition2024 issues
 home = "=0.5.9"
@@ -123,7 +124,7 @@ fastembed = { version = "5", optional = true }
 # ruvector-core = { path = "../ruvector-core", optional = true }
 
 [dev-dependencies]
-pgrx-tests = "0.12"
+pgrx-tests = "0.16"
 criterion = "0.5"
 proptest = "1.4"
 approx = "0.5"
@@ -173,3 +174,4 @@ pg14 = "pg14"
 pg15 = "pg15"
 pg16 = "pg16"
 pg17 = "pg17"
+pg18 = "pg18"

--- a/crates/ruvector-postgres/src/healing/worker.rs
+++ b/crates/ruvector-postgres/src/healing/worker.rs
@@ -372,7 +372,7 @@ impl HealingWorker {
 
 /// PostgreSQL background worker entry point
 #[pgrx::pg_guard]
-pub extern "C" fn healing_bgworker_main(_arg: pgrx::pg_sys::Datum) {
+pub extern "C-unwind" fn healing_bgworker_main(_arg: pgrx::pg_sys::Datum) {
     pgrx::log!("RuVector healing background worker starting");
 
     let config = HealingWorkerConfig::default();

--- a/crates/ruvector-postgres/src/index/bgworker.rs
+++ b/crates/ruvector-postgres/src/index/bgworker.rs
@@ -140,7 +140,7 @@ fn get_worker_state() -> &'static Arc<BgWorkerState> {
 ///
 /// This is registered with PostgreSQL and runs in a separate background process.
 #[pg_guard]
-pub extern "C" fn ruvector_bgworker_main(_arg: pg_sys::Datum) {
+pub extern "C-unwind" fn ruvector_bgworker_main(_arg: pg_sys::Datum) {
     // Initialize worker
     pgrx::log!("RuVector background worker starting");
 

--- a/crates/ruvector-postgres/src/lib.rs
+++ b/crates/ruvector-postgres/src/lib.rs
@@ -66,15 +66,15 @@ static HYBRID_PREFETCH_K: GucSetting<i32> = GucSetting::<i32>::new(100);
 
 /// Called when the extension is loaded
 #[pg_guard]
-pub extern "C" fn _PG_init() {
+pub extern "C-unwind" fn _PG_init() {
     // Initialize SIMD dispatch
     distance::init_simd_dispatch();
 
     // Register GUCs
     GucRegistry::define_int_guc(
-        "ruvector.ef_search",
-        "HNSW ef_search parameter for query time",
-        "Higher values improve recall at the cost of speed",
+        c"ruvector.ef_search",
+        c"HNSW ef_search parameter for query time",
+        c"Higher values improve recall at the cost of speed",
         &EF_SEARCH,
         1,
         1000,
@@ -83,9 +83,9 @@ pub extern "C" fn _PG_init() {
     );
 
     GucRegistry::define_int_guc(
-        "ruvector.probes",
-        "IVFFlat number of lists to probe",
-        "Higher values improve recall at the cost of speed",
+        c"ruvector.probes",
+        c"IVFFlat number of lists to probe",
+        c"Higher values improve recall at the cost of speed",
         &PROBES,
         1,
         10000,
@@ -95,9 +95,9 @@ pub extern "C" fn _PG_init() {
 
     // Hybrid search GUCs
     GucRegistry::define_float_guc(
-        "ruvector.hybrid_alpha",
-        "Default alpha for hybrid linear fusion (0=keyword only, 1=vector only)",
-        "Controls the blend between vector and keyword search",
+        c"ruvector.hybrid_alpha",
+        c"Default alpha for hybrid linear fusion (0=keyword only, 1=vector only)",
+        c"Controls the blend between vector and keyword search",
         &HYBRID_ALPHA,
         0.0,
         1.0,
@@ -106,9 +106,9 @@ pub extern "C" fn _PG_init() {
     );
 
     GucRegistry::define_int_guc(
-        "ruvector.hybrid_rrf_k",
-        "RRF constant for hybrid search (default 60)",
-        "Lower values give more weight to top-ranked results",
+        c"ruvector.hybrid_rrf_k",
+        c"RRF constant for hybrid search (default 60)",
+        c"Lower values give more weight to top-ranked results",
         &HYBRID_RRF_K,
         1,
         1000,
@@ -117,9 +117,9 @@ pub extern "C" fn _PG_init() {
     );
 
     GucRegistry::define_int_guc(
-        "ruvector.hybrid_prefetch_k",
-        "Number of results to prefetch from each branch",
-        "Higher values improve recall but increase latency",
+        c"ruvector.hybrid_prefetch_k",
+        c"Number of results to prefetch from each branch",
+        c"Higher values improve recall but increase latency",
         &HYBRID_PREFETCH_K,
         1,
         10000,

--- a/crates/ruvector-postgres/src/types/vector.rs
+++ b/crates/ruvector-postgres/src/types/vector.rs
@@ -405,7 +405,7 @@ pub fn ruvector_out_fn(v: RuVector) -> String {
 /// This is the PostgreSQL IN function for the ruvector type.
 #[pg_guard]
 #[no_mangle]
-pub extern "C" fn ruvector_in(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+pub extern "C-unwind" fn ruvector_in(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
     unsafe {
         let datum = (*fcinfo).args.as_ptr().add(0).read().value;
         let input_cstr = datum.cast_mut_ptr::<std::os::raw::c_char>();
@@ -435,7 +435,7 @@ pub extern "C" fn pg_finfo_ruvector_in() -> &'static pg_sys::Pg_finfo_record {
 /// Text output function: Convert RuVector to '[1.0, 2.0, 3.0]'
 #[pg_guard]
 #[no_mangle]
-pub extern "C" fn ruvector_out(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+pub extern "C-unwind" fn ruvector_out(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
     unsafe {
         let datum = (*fcinfo).args.as_ptr().add(0).read().value;
         let varlena_ptr = datum.cast_mut_ptr::<pg_sys::varlena>();
@@ -467,7 +467,7 @@ pub extern "C" fn pg_finfo_ruvector_out() -> &'static pg_sys::Pg_finfo_record {
 /// Binary input function: Receive vector from network in binary format
 #[pg_guard]
 #[no_mangle]
-pub extern "C" fn ruvector_recv(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+pub extern "C-unwind" fn ruvector_recv(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
     unsafe {
         let datum = (*fcinfo).args.as_ptr().add(0).read().value;
         let buf = datum.cast_mut_ptr::<pg_sys::StringInfoData>();
@@ -609,7 +609,7 @@ fn ruvector_typmod_in_fn(list: pgrx::Array<&CStr>) -> i32 {
 /// It uses PostgreSQL's array accessor macros for robust array element access.
 #[pg_guard]
 #[no_mangle]
-pub extern "C" fn ruvector_typmod_in(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+pub extern "C-unwind" fn ruvector_typmod_in(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
     unsafe {
         // Get the cstring array argument
         let array_datum = (*fcinfo).args.as_ptr().add(0).read().value;
@@ -703,7 +703,7 @@ pub extern "C" fn pg_finfo_ruvector_typmod_in() -> &'static pg_sys::Pg_finfo_rec
 /// Typmod output function: format dimension specification for display
 #[pg_guard]
 #[no_mangle]
-pub extern "C" fn ruvector_typmod_out(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+pub extern "C-unwind" fn ruvector_typmod_out(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
     unsafe {
         let typmod = (*fcinfo).args.as_ptr().add(0).read().value.value() as i32;
 

--- a/crates/ruvector-postgres/src/workers/engine.rs
+++ b/crates/ruvector-postgres/src/workers/engine.rs
@@ -790,7 +790,7 @@ impl EngineWorker {
 
 /// Main background worker function for engine
 #[pg_guard]
-pub extern "C" fn ruvector_engine_worker_main(arg: pg_sys::Datum) {
+pub extern "C-unwind" fn ruvector_engine_worker_main(arg: pg_sys::Datum) {
     let worker_id = arg.value() as u64;
 
     pgrx::log!("RuVector engine worker {} starting", worker_id);

--- a/crates/ruvector-postgres/src/workers/maintenance.rs
+++ b/crates/ruvector-postgres/src/workers/maintenance.rs
@@ -612,7 +612,7 @@ impl MaintenanceWorker {
 
 /// Main background worker function for maintenance
 #[pg_guard]
-pub extern "C" fn ruvector_maintenance_worker_main(arg: pg_sys::Datum) {
+pub extern "C-unwind" fn ruvector_maintenance_worker_main(arg: pg_sys::Datum) {
     let worker_id = arg.value() as u64;
 
     pgrx::log!("RuVector maintenance worker {} starting", worker_id);

--- a/crates/ruvector-router-core/Cargo.toml
+++ b/crates/ruvector-router-core/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 
 # Additional dependencies
-ndarray = "0.15"
+ndarray = { workspace = true }
 rand = "0.8"
 uuid = { version = "1.10", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
## Summary

- Upgraded pgrx from 0.12 to 0.16 for modern PostgreSQL support
- Added pg18 feature flag for PostgreSQL 18 compatibility
- Fixed all pgrx 0.16 API breaking changes

## Changes

### pgrx 0.16 Migration
- Updated all `extern "C"` to `extern "C-unwind"` for pg_guard functions (43 functions across 9 files)
- Converted GUC strings to C string literals (`c"..."`)
- Updated SPI select parameters (`None` → `&[]`)

### PostgreSQL Version Support
| Version | Status |
|---------|--------|
| pg14 | ✅ Supported |
| pg15 | ✅ Supported |
| pg16 | ✅ Supported |
| pg17 | ✅ Supported (default) |
| pg18 | ✅ Supported (new) |

### Build Notes
On macOS, build with:
```bash
RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" \
  cargo build --lib --no-default-features --features pg17 --release
```

## Test plan
- [x] `cargo check --features pg17` passes
- [x] Release build produces 3.3MB extension library
- [ ] Extension loads in PostgreSQL 17
- [ ] Basic vector operations work

🤖 Generated with [Claude Code](https://claude.ai/code)