### PR TITLE
feat: Add ADR-017 temporal tensor compression with tiered quantization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8967,6 +8967,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruvector-temporal-tensor"
+version = "2.0.1"
+
+[[package]]
 name = "ruvector-tiny-dancer-core"
 version = "2.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ members = [
     "crates/ruvector-delta-graph",
     "crates/ruvector-delta-consensus",
     "crates/ruvector-crv",
+    "crates/ruvector-temporal-tensor",
 ]
 resolver = "2"
 

--- a/crates/ruvector-temporal-tensor-wasm/Cargo.toml
+++ b/crates/ruvector-temporal-tensor-wasm/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ruvector-temporal-tensor-wasm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "WASM bindings for temporal tensor compression"
+
+[dependencies]
+ruvector-temporal-tensor = { path = "../ruvector-temporal-tensor", features = ["ffi"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/crates/ruvector-temporal-tensor-wasm/src/lib.rs
+++ b/crates/ruvector-temporal-tensor-wasm/src/lib.rs
@@ -1,0 +1,5 @@
+//! WASM bindings for temporal tensor compression.
+//!
+//! Re-exports the FFI interface from ruvector-temporal-tensor for wasm32 targets.
+
+pub use ruvector_temporal_tensor::ffi::*;

--- a/crates/ruvector-temporal-tensor/Cargo.toml
+++ b/crates/ruvector-temporal-tensor/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ruvector-temporal-tensor"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Temporal tensor compression with tiered quantization for RuVector"
+
+[features]
+default = []
+ffi = []          # Enable WASM/C FFI exports
+simd = []         # Enable SIMD-accelerated quantization (future)
+
+[lib]
+crate-type = ["lib"]

--- a/crates/ruvector-temporal-tensor/README.md
+++ b/crates/ruvector-temporal-tensor/README.md
@@ -1,0 +1,279 @@
+# ruvector-temporal-tensor
+
+[![Crates.io](https://img.shields.io/crates/v/ruvector-temporal-tensor.svg)](https://crates.io/crates/ruvector-temporal-tensor)
+[![Documentation](https://docs.rs/ruvector-temporal-tensor/badge.svg)](https://docs.rs/ruvector-temporal-tensor)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Rust](https://img.shields.io/badge/rust-1.77%2B-orange.svg)](https://www.rust-lang.org)
+
+**Shrink your vector data 4-10x without losing the signal.**
+
+`ruvector-temporal-tensor` compresses streams of floating-point tensors by exploiting two properties that most vector workloads share:
+
+1. **Values within a group are similar** — so a single scale factor per group captures the range, and a small integer code captures the value. This is *groupwise symmetric quantization*.
+2. **Consecutive frames barely change** — so the same scale factors can be reused across many frames until the data drifts. This is *temporal segment reuse*.
+
+The crate automatically picks the right bit-width based on how "hot" (frequently accessed) the tensor is, giving you aggressive compression on cold data while preserving accuracy on hot data.
+
+Zero external dependencies. Compiles to WASM. Ships with a C FFI.
+
+## How It Works
+
+```
+f32 frame ──► tier policy ──► quantizer ──► bitpack ──► segment blob
+                  │
+         "How hot is this tensor?"
+          Hot  → 8-bit (lossless-ish)
+          Warm → 7 or 5-bit
+          Cold → 3-bit (10x smaller)
+```
+
+Each frame of `f32` values is divided into fixed-size groups (default 64). Per group, the compressor computes a single scale factor (`max_abs / qmax`) and maps every value to a signed integer code. Codes are packed into a tight bitstream with no byte-alignment waste.
+
+When the next frame arrives, the compressor checks whether the existing scale factors still cover the new data (within a configurable drift tolerance). If they do, the frame is appended to the current **segment** — reusing the same scales. If they don't, the segment is finalized and a new one starts.
+
+Segments are self-contained binary blobs with a 22-byte header, the f16-encoded scales, and the packed data. They can be decoded independently, or you can random-access a single frame by index.
+
+## Compression Ratios
+
+| Tier | Bits | Ratio vs f32 | Typical Error | When Used |
+|------|------|-------------|---------------|-----------|
+| Hot  | 8    | **~4x**     | < 0.5%        | Frequently accessed tensors |
+| Warm | 7    | **~4.6x**   | < 1%          | Moderate access patterns |
+| Warm | 5    | **~6.4x**   | < 3%          | Aggressively compressed warm data |
+| Cold | 3    | **~10.7x**  | < 15%         | Rarely accessed / archival |
+
+Ratios improve further with temporal reuse — the scale overhead is amortized across all frames in a segment.
+
+## Quick Start
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+ruvector-temporal-tensor = "2.0"
+```
+
+### Compress and decompress
+
+```rust
+use ruvector_temporal_tensor::{TemporalTensorCompressor, TierPolicy};
+
+// 1. Create a compressor for 128-element tensors
+let mut comp = TemporalTensorCompressor::new(TierPolicy::default(), 128, 0);
+comp.set_access(100, 0); // mark as hot → 8-bit quantization
+
+let frame = vec![1.0f32; 128];
+let mut segment = Vec::new();
+
+// 2. Push frames — segment stays empty until a boundary is crossed
+comp.push_frame(&frame, 1, &mut segment);
+
+// 3. Force-emit the current segment
+comp.flush(&mut segment);
+
+// 4. Decode back to f32
+let mut decoded = Vec::new();
+ruvector_temporal_tensor::segment::decode(&segment, &mut decoded);
+assert_eq!(decoded.len(), 128);
+```
+
+### Stream many frames
+
+```rust
+use ruvector_temporal_tensor::{TemporalTensorCompressor, TierPolicy};
+
+let mut comp = TemporalTensorCompressor::new(TierPolicy::default(), 512, 0);
+comp.set_access(100, 0);
+
+let mut segments: Vec<Vec<u8>> = Vec::new();
+let mut seg = Vec::new();
+
+for t in 0..1000 {
+    let frame: Vec<f32> = (0..512).map(|i| ((i + t) as f32 * 0.01).sin()).collect();
+    comp.push_frame(&frame, t as u32, &mut seg);
+    if !seg.is_empty() {
+        segments.push(seg.clone());
+    }
+}
+comp.flush(&mut seg);
+if !seg.is_empty() {
+    segments.push(seg);
+}
+```
+
+### Random-access a single frame
+
+```rust
+use ruvector_temporal_tensor::segment;
+# use ruvector_temporal_tensor::{TemporalTensorCompressor, TierPolicy};
+# let mut comp = TemporalTensorCompressor::new(TierPolicy::default(), 64, 0);
+# let mut seg = Vec::new();
+# comp.push_frame(&vec![1.0f32; 64], 0, &mut seg);
+# comp.flush(&mut seg);
+
+// Decode only frame 0 — skips all other frames in the segment
+let values = segment::decode_single_frame(&seg, 0).unwrap();
+assert_eq!(values.len(), 64);
+
+// Check compression ratio
+let ratio = segment::compression_ratio(&seg);
+assert!(ratio > 1.0);
+```
+
+### Custom tier policy
+
+```rust
+use ruvector_temporal_tensor::{TemporalTensorCompressor, TierPolicy};
+
+let policy = TierPolicy {
+    hot_min_score: 512,   // score threshold for 8-bit
+    warm_min_score: 64,   // score threshold for warm tier
+    warm_bits: 5,         // use 5-bit instead of default 7 for warm
+    drift_pct_q8: 26,     // ~10% drift tolerance (Q8 fixed-point)
+    group_len: 32,        // smaller groups = more scales, tighter fit
+};
+
+let mut comp = TemporalTensorCompressor::new(policy, 256, 0);
+```
+
+## Feature Flags
+
+```toml
+[dependencies]
+ruvector-temporal-tensor = { version = "2.0", features = ["ffi"] }
+```
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `ffi`   | off     | Enable `extern "C"` exports for WASM and C interop |
+| `simd`  | off     | Reserved for future SIMD-accelerated quantization |
+
+## API Reference
+
+### Core Types
+
+| Type | Description |
+|------|-------------|
+| `TemporalTensorCompressor` | Main entry point — push frames, get segments |
+| `TierPolicy` | Controls bit-width selection and drift tolerance |
+
+### Compressor Methods
+
+| Method | Description |
+|--------|-------------|
+| `new(policy, len, now_ts)` | Create a compressor for tensors of `len` elements |
+| `push_frame(frame, now_ts, out)` | Compress a frame; emits a segment on boundary crossings |
+| `flush(out)` | Force-emit the current segment |
+| `touch(now_ts)` | Record an access event (increments count + updates timestamp) |
+| `set_access(count, ts)` | Set access stats directly (for restoring state) |
+| `active_bits()` | Current quantization bit-width |
+| `active_frame_count()` | Frames buffered in the current segment |
+| `len()` / `is_empty()` | Tensor length |
+
+### Segment Functions
+
+| Function | Description |
+|----------|-------------|
+| `segment::decode(bytes, out)` | Decode all frames from a segment |
+| `segment::decode_single_frame(bytes, idx)` | Decode one frame by index |
+| `segment::parse_header(bytes)` | Read segment metadata without decoding |
+| `segment::compression_ratio(bytes)` | Compute raw-to-compressed ratio |
+| `segment::encode(...)` | Low-level segment encoder (used internally) |
+
+### Low-Level Modules
+
+| Module | Description |
+|--------|-------------|
+| `quantizer` | Groupwise symmetric quantization and dequantization |
+| `bitpack` | Arbitrary-width bitstream packer and unpacker |
+| `f16` | Software IEEE 754 half-precision conversion |
+| `tier_policy` | Access-pattern scoring and bit-width selection |
+
+## Segment Binary Format
+
+Segments are self-contained, portable, and version-tagged:
+
+```
+Offset  Size  Field
+──────  ────  ─────────────────
+0       4     Magic: 0x43545154 ("TQTC")
+4       1     Version (currently 1)
+5       1     Bits per code (3, 5, 7, or 8)
+6       4     Group length
+10      4     Tensor length (elements per frame)
+14      4     Frame count
+18      4     Scale count (S)
+22      2*S   Scales (f16, little-endian)
+22+2S   4     Data length (D)
+26+2S   D     Packed quantization codes
+```
+
+## FFI / WASM Usage
+
+Enable the `ffi` feature and compile with `--target wasm32-unknown-unknown`:
+
+```bash
+cargo build --release --target wasm32-unknown-unknown --features ffi
+```
+
+Exported C functions:
+
+| Function | Description |
+|----------|-------------|
+| `ttc_create(len, now_ts, out_handle)` | Create compressor, get handle |
+| `ttc_create_with_policy(...)` | Create with custom tier policy |
+| `ttc_free(handle)` | Free a compressor |
+| `ttc_touch(handle, now_ts)` | Record access |
+| `ttc_set_access(handle, count, ts)` | Set access stats |
+| `ttc_push_frame(handle, ts, in, len, out, cap, written)` | Compress a frame |
+| `ttc_flush(handle, out, cap, written)` | Flush current segment |
+| `ttc_decode_segment(seg, len, out, cap, written)` | Decode a segment |
+| `ttc_alloc(size, out_ptr)` | Allocate WASM linear memory |
+| `ttc_dealloc(ptr, cap)` | Free allocated memory |
+
+## Design Decisions
+
+See **[ADR-017](../../docs/adr/ADR-017-temporal-tensor-compression.md)** for the full architecture decision record, including SOTA survey, compression math, safety analysis, and integration guidance.
+
+Key decisions:
+
+- **Groupwise symmetric** (no zero-point) — simpler, faster, well-suited for normally-distributed embeddings
+- **f16 scales** — 2 bytes per group vs 4 for f32, with negligible accuracy loss
+- **64-bit bitstream accumulator** — handles any sub-byte width without byte-alignment waste
+- **Score-based tiering** — `access_count * 1024 / age` balances recency and frequency
+- **~10% drift tolerance** — Q8 fixed-point configurable, default 26/256
+
+## Building and Testing
+
+```bash
+# Build
+cargo build -p ruvector-temporal-tensor --release
+
+# Run all tests (41 unit + 3 doc-tests)
+cargo test -p ruvector-temporal-tensor
+
+# Clippy
+cargo clippy -p ruvector-temporal-tensor -- -W clippy::all
+
+# Build WASM target
+cargo build -p ruvector-temporal-tensor --release --target wasm32-unknown-unknown --features ffi
+```
+
+## Related Crates
+
+| Crate | Relationship |
+|-------|-------------|
+| [ruvector-core](../ruvector-core/) | Parent vector database engine; temporal tensors integrate as a storage backend |
+| [ruvector-temporal-tensor-wasm](../ruvector-temporal-tensor-wasm/) | Thin WASM re-export wrapper |
+
+## License
+
+MIT License — see [LICENSE](../../LICENSE) for details.
+
+---
+
+<div align="center">
+
+**Part of [Ruvector](https://github.com/ruvnet/ruvector)**
+
+</div>

--- a/crates/ruvector-temporal-tensor/src/bitpack.rs
+++ b/crates/ruvector-temporal-tensor/src/bitpack.rs
@@ -1,0 +1,126 @@
+/// Bitstream packer/unpacker for arbitrary bit widths (1-8).
+///
+/// Uses a 64-bit accumulator for sub-byte codes with no alignment padding.
+
+/// Pack unsigned codes of `bits` width into a byte stream.
+pub fn pack(codes: &[u32], bits: u32, out: &mut Vec<u8>) {
+    let mut acc: u64 = 0;
+    let mut acc_bits: u32 = 0;
+
+    for &code in codes {
+        acc |= (code as u64) << acc_bits;
+        acc_bits += bits;
+        while acc_bits >= 8 {
+            out.push((acc & 0xFF) as u8);
+            acc >>= 8;
+            acc_bits -= 8;
+        }
+    }
+
+    if acc_bits > 0 {
+        out.push((acc & 0xFF) as u8);
+    }
+}
+
+/// Unpack `count` unsigned codes of `bits` width from a byte stream.
+pub fn unpack(data: &[u8], bits: u32, count: usize, out: &mut Vec<u32>) {
+    let mask = (1u64 << bits) - 1;
+    let mut acc: u64 = 0;
+    let mut acc_bits: u32 = 0;
+    let mut byte_idx = 0usize;
+    let mut decoded = 0usize;
+
+    while decoded < count {
+        // Fill accumulator
+        while acc_bits < bits && byte_idx < data.len() {
+            acc |= (data[byte_idx] as u64) << acc_bits;
+            acc_bits += 8;
+            byte_idx += 1;
+        }
+        if acc_bits < bits {
+            break; // Insufficient data
+        }
+
+        out.push((acc & mask) as u32);
+        acc >>= bits;
+        acc_bits -= bits;
+        decoded += 1;
+    }
+}
+
+/// Compute qmax for a given bit width: 2^(bits-1) - 1
+pub fn qmax_from_bits(bits: u8) -> i32 {
+    if bits == 0 || bits > 8 {
+        return 0;
+    }
+    (1i32 << (bits - 1)) - 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_roundtrip_8bit() {
+        let codes: Vec<u32> = (0..256).collect();
+        let mut packed = Vec::new();
+        pack(&codes, 8, &mut packed);
+        assert_eq!(packed.len(), 256); // 8-bit = 1 byte each
+
+        let mut unpacked = Vec::new();
+        unpack(&packed, 8, 256, &mut unpacked);
+        assert_eq!(codes, unpacked);
+    }
+
+    #[test]
+    fn test_roundtrip_3bit() {
+        let codes: Vec<u32> = (0..7).collect(); // 3-bit range: 0-6
+        let mut packed = Vec::new();
+        pack(&codes, 3, &mut packed);
+
+        let mut unpacked = Vec::new();
+        unpack(&packed, 3, 7, &mut unpacked);
+        assert_eq!(codes, unpacked);
+    }
+
+    #[test]
+    fn test_roundtrip_5bit() {
+        let codes: Vec<u32> = (0..31).collect();
+        let mut packed = Vec::new();
+        pack(&codes, 5, &mut packed);
+
+        let mut unpacked = Vec::new();
+        unpack(&packed, 5, 31, &mut unpacked);
+        assert_eq!(codes, unpacked);
+    }
+
+    #[test]
+    fn test_roundtrip_7bit() {
+        let codes: Vec<u32> = (0..127).collect();
+        let mut packed = Vec::new();
+        pack(&codes, 7, &mut packed);
+
+        let mut unpacked = Vec::new();
+        unpack(&packed, 7, 127, &mut unpacked);
+        assert_eq!(codes, unpacked);
+    }
+
+    #[test]
+    fn test_packing_density() {
+        // 100 3-bit codes = 300 bits = 38 bytes (ceil(300/8))
+        let codes = vec![5u32; 100];
+        let mut packed = Vec::new();
+        pack(&codes, 3, &mut packed);
+        assert_eq!(packed.len(), 38); // ceil(300/8) = 38
+    }
+
+    #[test]
+    fn test_qmax() {
+        assert_eq!(qmax_from_bits(8), 127);
+        assert_eq!(qmax_from_bits(7), 63);
+        assert_eq!(qmax_from_bits(5), 15);
+        assert_eq!(qmax_from_bits(3), 3);
+        assert_eq!(qmax_from_bits(1), 0);
+        assert_eq!(qmax_from_bits(0), 0);
+    }
+}

--- a/crates/ruvector-temporal-tensor/src/bitpack.rs
+++ b/crates/ruvector-temporal-tensor/src/bitpack.rs
@@ -49,6 +49,7 @@ pub fn unpack(data: &[u8], bits: u32, count: usize, out: &mut Vec<u32>) {
 }
 
 /// Compute qmax for a given bit width: 2^(bits-1) - 1
+#[inline]
 pub fn qmax_from_bits(bits: u8) -> i32 {
     if bits == 0 || bits > 8 {
         return 0;

--- a/crates/ruvector-temporal-tensor/src/compressor.rs
+++ b/crates/ruvector-temporal-tensor/src/compressor.rs
@@ -1,7 +1,7 @@
-/// TemporalTensorCompressor: the main entry point.
-///
-/// Manages temporal segments, drift detection, and tier transitions.
-/// Caches f32-converted scales to avoid repeated f16 conversion in hot paths.
+//! TemporalTensorCompressor: the main entry point.
+//!
+//! Manages temporal segments, drift detection, and tier transitions.
+//! Caches f32-converted scales to avoid repeated f16 conversion in hot paths.
 
 use crate::quantizer;
 use crate::segment;
@@ -70,6 +70,11 @@ impl TemporalTensorCompressor {
     /// Tensor length.
     pub fn len(&self) -> u32 {
         self.len
+    }
+
+    /// Returns `true` if the tensor length is zero.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     /// Bytes currently buffered in the active segment data.

--- a/crates/ruvector-temporal-tensor/src/compressor.rs
+++ b/crates/ruvector-temporal-tensor/src/compressor.rs
@@ -1,0 +1,259 @@
+/// TemporalTensorCompressor: the main entry point.
+///
+/// Manages temporal segments, drift detection, and tier transitions.
+
+use crate::quantizer;
+use crate::segment;
+use crate::tier_policy::TierPolicy;
+
+pub struct TemporalTensorCompressor {
+    policy: TierPolicy,
+    len: u32,
+
+    access_count: u32,
+    last_access_ts: u32,
+
+    active_bits: u8,
+    active_group_len: usize,
+    active_scales: Vec<u16>,
+    active_frames: u32,
+    active_data: Vec<u8>,
+}
+
+impl TemporalTensorCompressor {
+    /// Create a new compressor for tensors of the given length.
+    pub fn new(policy: TierPolicy, len: u32, now_ts: u32) -> Self {
+        let bits = policy.select_bits(0, now_ts, now_ts);
+        Self {
+            policy,
+            len,
+            access_count: 0,
+            last_access_ts: now_ts,
+            active_bits: bits,
+            active_group_len: policy.group_len.max(1) as usize,
+            active_scales: Vec::new(),
+            active_frames: 0,
+            active_data: Vec::new(),
+        }
+    }
+
+    /// Record an access (increments count, updates timestamp).
+    pub fn touch(&mut self, now_ts: u32) {
+        self.access_count = self.access_count.wrapping_add(1);
+        self.last_access_ts = now_ts;
+    }
+
+    /// Set access stats directly (for restoring state).
+    pub fn set_access(&mut self, access_count: u32, last_access_ts: u32) {
+        self.access_count = access_count;
+        self.last_access_ts = last_access_ts;
+    }
+
+    /// Current tier bits.
+    pub fn active_bits(&self) -> u8 {
+        self.active_bits
+    }
+
+    /// Number of frames in the current segment.
+    pub fn active_frame_count(&self) -> u32 {
+        self.active_frames
+    }
+
+    /// Push a frame. If a segment boundary is crossed, the completed segment
+    /// bytes are written to `out_segment`. Otherwise `out_segment` is cleared.
+    pub fn push_frame(&mut self, frame: &[f32], now_ts: u32, out_segment: &mut Vec<u8>) {
+        out_segment.clear();
+
+        if frame.len() != self.len as usize {
+            return;
+        }
+
+        let desired_bits = self.policy.select_bits(
+            self.access_count,
+            self.last_access_ts,
+            now_ts,
+        );
+        let drift_factor = self.policy.drift_factor();
+
+        let need_new_segment = self.active_frames == 0
+            || desired_bits != self.active_bits
+            || !quantizer::frame_fits_scales(
+                frame,
+                &self.active_scales,
+                self.active_group_len,
+                self.active_bits,
+                drift_factor,
+            );
+
+        if need_new_segment {
+            self.flush(out_segment);
+            self.active_bits = desired_bits;
+            self.active_group_len = self.policy.group_len.max(1) as usize;
+            self.active_scales = quantizer::compute_scales(
+                frame,
+                self.active_group_len,
+                self.active_bits,
+            );
+        }
+
+        quantizer::quantize_and_pack(
+            frame,
+            &self.active_scales,
+            self.active_group_len,
+            self.active_bits,
+            &mut self.active_data,
+        );
+        self.active_frames = self.active_frames.wrapping_add(1);
+    }
+
+    /// Flush the current segment. Writes segment bytes to `out_segment`.
+    /// Resets internal state for the next segment.
+    pub fn flush(&mut self, out_segment: &mut Vec<u8>) {
+        if self.active_frames == 0 {
+            return;
+        }
+
+        segment::encode(
+            self.active_bits,
+            self.active_group_len as u32,
+            self.len,
+            self.active_frames,
+            &self.active_scales,
+            &self.active_data,
+            out_segment,
+        );
+
+        self.active_frames = 0;
+        self.active_scales.clear();
+        self.active_data.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_policy() -> TierPolicy {
+        TierPolicy::default()
+    }
+
+    #[test]
+    fn test_create_and_push() {
+        let mut comp = TemporalTensorCompressor::new(default_policy(), 64, 0);
+        let frame = vec![1.0f32; 64];
+        let mut seg = Vec::new();
+
+        comp.push_frame(&frame, 0, &mut seg);
+        assert!(seg.is_empty()); // First frame, no completed segment
+        assert_eq!(comp.active_frame_count(), 1);
+    }
+
+    #[test]
+    fn test_flush_produces_segment() {
+        let mut comp = TemporalTensorCompressor::new(default_policy(), 64, 0);
+        let frame = vec![1.0f32; 64];
+        let mut seg = Vec::new();
+
+        comp.push_frame(&frame, 0, &mut seg);
+        comp.flush(&mut seg);
+
+        assert!(!seg.is_empty());
+        // Verify we can decode it
+        let mut decoded = Vec::new();
+        segment::decode(&seg, &mut decoded);
+        assert_eq!(decoded.len(), 64);
+    }
+
+    #[test]
+    fn test_tier_transition_flushes() {
+        let policy = TierPolicy {
+            hot_min_score: 512,
+            warm_min_score: 64,
+            warm_bits: 7,
+            drift_pct_q8: 26,
+            group_len: 64,
+        };
+
+        let mut comp = TemporalTensorCompressor::new(policy, 64, 0);
+        comp.set_access(100, 0); // Hot
+        let frame = vec![1.0f32; 64];
+        let mut seg = Vec::new();
+
+        comp.push_frame(&frame, 1, &mut seg);
+        assert_eq!(comp.active_bits(), 8); // Hot
+
+        // Make it cold
+        comp.set_access(1, 0);
+        comp.push_frame(&frame, 10000, &mut seg);
+        // Should have flushed the hot segment
+        assert!(!seg.is_empty());
+        assert_eq!(comp.active_bits(), 3); // Cold
+    }
+
+    #[test]
+    fn test_drift_triggers_new_segment() {
+        let mut comp = TemporalTensorCompressor::new(default_policy(), 64, 0);
+        let mut seg = Vec::new();
+
+        let frame1 = vec![1.0f32; 64];
+        comp.push_frame(&frame1, 0, &mut seg);
+
+        // Frame with values that exceed drift threshold
+        let frame2 = vec![5.0f32; 64];
+        comp.push_frame(&frame2, 0, &mut seg);
+
+        // Drift should have triggered a new segment
+        assert!(!seg.is_empty());
+    }
+
+    #[test]
+    fn test_multi_frame_same_segment() {
+        let mut comp = TemporalTensorCompressor::new(default_policy(), 64, 0);
+        let mut seg = Vec::new();
+
+        let frame = vec![1.0f32; 64];
+        comp.push_frame(&frame, 0, &mut seg);
+        assert!(seg.is_empty());
+
+        // Slightly different frame within drift
+        let frame2 = vec![1.05f32; 64];
+        comp.push_frame(&frame2, 0, &mut seg);
+        assert!(seg.is_empty()); // Same segment, no flush
+        assert_eq!(comp.active_frame_count(), 2);
+    }
+
+    #[test]
+    fn test_full_roundtrip() {
+        let mut comp = TemporalTensorCompressor::new(default_policy(), 128, 0);
+        // Make compressor hot (8-bit) for tight accuracy test
+        comp.set_access(100, 0);
+        let frame: Vec<f32> = (0..128).map(|i| (i as f32 - 64.0) * 0.01).collect();
+        let mut seg = Vec::new();
+
+        // Push several similar frames
+        for _ in 0..10 {
+            comp.push_frame(&frame, 1, &mut seg);
+        }
+        comp.flush(&mut seg);
+
+        let mut decoded = Vec::new();
+        segment::decode(&seg, &mut decoded);
+        assert_eq!(decoded.len(), 128 * 10);
+
+        // Check first frame's values (8-bit: max error < 0.8%)
+        let max_abs = frame.iter().map(|v| v.abs()).fold(0.0f32, f32::max);
+        for i in 0..128 {
+            let err = (decoded[i] - frame[i]).abs();
+            assert!(err < max_abs * 0.02, "i={i} orig={} dec={} err={err}", frame[i], decoded[i]);
+        }
+    }
+
+    #[test]
+    fn test_wrong_length_frame_rejected() {
+        let mut comp = TemporalTensorCompressor::new(default_policy(), 64, 0);
+        let frame = vec![1.0f32; 32]; // Wrong length
+        let mut seg = Vec::new();
+        comp.push_frame(&frame, 0, &mut seg);
+        assert_eq!(comp.active_frame_count(), 0);
+    }
+}

--- a/crates/ruvector-temporal-tensor/src/compressor.rs
+++ b/crates/ruvector-temporal-tensor/src/compressor.rs
@@ -1,6 +1,7 @@
 /// TemporalTensorCompressor: the main entry point.
 ///
 /// Manages temporal segments, drift detection, and tier transitions.
+/// Caches f32-converted scales to avoid repeated f16 conversion in hot paths.
 
 use crate::quantizer;
 use crate::segment;
@@ -15,7 +16,8 @@ pub struct TemporalTensorCompressor {
 
     active_bits: u8,
     active_group_len: usize,
-    active_scales: Vec<u16>,
+    active_scales_f16: Vec<u16>,
+    active_scales_f32: Vec<f32>, // Cached f32 conversion of scales
     active_frames: u32,
     active_data: Vec<u8>,
 }
@@ -31,7 +33,8 @@ impl TemporalTensorCompressor {
             last_access_ts: now_ts,
             active_bits: bits,
             active_group_len: policy.group_len.max(1) as usize,
-            active_scales: Vec::new(),
+            active_scales_f16: Vec::new(),
+            active_scales_f32: Vec::new(),
             active_frames: 0,
             active_data: Vec::new(),
         }
@@ -59,6 +62,21 @@ impl TemporalTensorCompressor {
         self.active_frames
     }
 
+    /// Current policy.
+    pub fn policy(&self) -> &TierPolicy {
+        &self.policy
+    }
+
+    /// Tensor length.
+    pub fn len(&self) -> u32 {
+        self.len
+    }
+
+    /// Bytes currently buffered in the active segment data.
+    pub fn active_data_bytes(&self) -> usize {
+        self.active_data.len()
+    }
+
     /// Push a frame. If a segment boundary is crossed, the completed segment
     /// bytes are written to `out_segment`. Otherwise `out_segment` is cleared.
     pub fn push_frame(&mut self, frame: &[f32], now_ts: u32, out_segment: &mut Vec<u8>) {
@@ -75,11 +93,12 @@ impl TemporalTensorCompressor {
         );
         let drift_factor = self.policy.drift_factor();
 
+        // Use cached f32 scales for drift check (avoids f16 conversion per group)
         let need_new_segment = self.active_frames == 0
             || desired_bits != self.active_bits
-            || !quantizer::frame_fits_scales(
+            || !quantizer::frame_fits_scales_f32(
                 frame,
-                &self.active_scales,
+                &self.active_scales_f32,
                 self.active_group_len,
                 self.active_bits,
                 drift_factor,
@@ -89,16 +108,18 @@ impl TemporalTensorCompressor {
             self.flush(out_segment);
             self.active_bits = desired_bits;
             self.active_group_len = self.policy.group_len.max(1) as usize;
-            self.active_scales = quantizer::compute_scales(
+            self.active_scales_f16 = quantizer::compute_scales(
                 frame,
                 self.active_group_len,
                 self.active_bits,
             );
+            self.active_scales_f32 = quantizer::scales_to_f32(&self.active_scales_f16);
         }
 
-        quantizer::quantize_and_pack(
+        // Use cached f32 scales for quantization (avoids f16 conversion per group)
+        quantizer::quantize_and_pack_f32(
             frame,
-            &self.active_scales,
+            &self.active_scales_f32,
             self.active_group_len,
             self.active_bits,
             &mut self.active_data,
@@ -118,13 +139,14 @@ impl TemporalTensorCompressor {
             self.active_group_len as u32,
             self.len,
             self.active_frames,
-            &self.active_scales,
+            &self.active_scales_f16,
             &self.active_data,
             out_segment,
         );
 
         self.active_frames = 0;
-        self.active_scales.clear();
+        self.active_scales_f16.clear();
+        self.active_scales_f32.clear();
         self.active_data.clear();
     }
 }
@@ -158,7 +180,6 @@ mod tests {
         comp.flush(&mut seg);
 
         assert!(!seg.is_empty());
-        // Verify we can decode it
         let mut decoded = Vec::new();
         segment::decode(&seg, &mut decoded);
         assert_eq!(decoded.len(), 64);
@@ -180,14 +201,13 @@ mod tests {
         let mut seg = Vec::new();
 
         comp.push_frame(&frame, 1, &mut seg);
-        assert_eq!(comp.active_bits(), 8); // Hot
+        assert_eq!(comp.active_bits(), 8);
 
         // Make it cold
         comp.set_access(1, 0);
         comp.push_frame(&frame, 10000, &mut seg);
-        // Should have flushed the hot segment
         assert!(!seg.is_empty());
-        assert_eq!(comp.active_bits(), 3); // Cold
+        assert_eq!(comp.active_bits(), 3);
     }
 
     #[test]
@@ -198,11 +218,9 @@ mod tests {
         let frame1 = vec![1.0f32; 64];
         comp.push_frame(&frame1, 0, &mut seg);
 
-        // Frame with values that exceed drift threshold
         let frame2 = vec![5.0f32; 64];
         comp.push_frame(&frame2, 0, &mut seg);
 
-        // Drift should have triggered a new segment
         assert!(!seg.is_empty());
     }
 
@@ -215,22 +233,19 @@ mod tests {
         comp.push_frame(&frame, 0, &mut seg);
         assert!(seg.is_empty());
 
-        // Slightly different frame within drift
         let frame2 = vec![1.05f32; 64];
         comp.push_frame(&frame2, 0, &mut seg);
-        assert!(seg.is_empty()); // Same segment, no flush
+        assert!(seg.is_empty());
         assert_eq!(comp.active_frame_count(), 2);
     }
 
     #[test]
-    fn test_full_roundtrip() {
+    fn test_full_roundtrip_hot() {
         let mut comp = TemporalTensorCompressor::new(default_policy(), 128, 0);
-        // Make compressor hot (8-bit) for tight accuracy test
         comp.set_access(100, 0);
         let frame: Vec<f32> = (0..128).map(|i| (i as f32 - 64.0) * 0.01).collect();
         let mut seg = Vec::new();
 
-        // Push several similar frames
         for _ in 0..10 {
             comp.push_frame(&frame, 1, &mut seg);
         }
@@ -240,7 +255,6 @@ mod tests {
         segment::decode(&seg, &mut decoded);
         assert_eq!(decoded.len(), 128 * 10);
 
-        // Check first frame's values (8-bit: max error < 0.8%)
         let max_abs = frame.iter().map(|v| v.abs()).fold(0.0f32, f32::max);
         for i in 0..128 {
             let err = (decoded[i] - frame[i]).abs();
@@ -249,11 +263,75 @@ mod tests {
     }
 
     #[test]
+    fn test_full_roundtrip_cold() {
+        let mut comp = TemporalTensorCompressor::new(default_policy(), 64, 0);
+        // Default: access_count=0, cold -> 3-bit
+        let frame: Vec<f32> = (0..64).map(|i| (i as f32 - 32.0) * 0.1).collect();
+        let mut seg = Vec::new();
+
+        comp.push_frame(&frame, 0, &mut seg);
+        comp.flush(&mut seg);
+
+        let header = segment::parse_header(&seg).unwrap();
+        assert_eq!(header.bits, 3);
+
+        let mut decoded = Vec::new();
+        segment::decode(&seg, &mut decoded);
+        assert_eq!(decoded.len(), 64);
+
+        let max_abs = frame.iter().map(|v| v.abs()).fold(0.0f32, f32::max);
+        for (i, (&orig, &dec)) in frame.iter().zip(decoded.iter()).enumerate() {
+            let err = (orig - dec).abs();
+            // 3-bit: qmax=3, max relative error ~33%
+            assert!(err < max_abs * 0.4, "i={i} orig={orig} dec={dec} err={err}");
+        }
+    }
+
+    #[test]
     fn test_wrong_length_frame_rejected() {
         let mut comp = TemporalTensorCompressor::new(default_policy(), 64, 0);
-        let frame = vec![1.0f32; 32]; // Wrong length
+        let frame = vec![1.0f32; 32];
         let mut seg = Vec::new();
         comp.push_frame(&frame, 0, &mut seg);
         assert_eq!(comp.active_frame_count(), 0);
+    }
+
+    #[test]
+    fn test_accessor_methods() {
+        let policy = TierPolicy::default();
+        let comp = TemporalTensorCompressor::new(policy, 256, 42);
+        assert_eq!(comp.len(), 256);
+        assert_eq!(comp.active_frame_count(), 0);
+        assert_eq!(comp.active_data_bytes(), 0);
+        assert_eq!(comp.policy().group_len, 64);
+    }
+
+    #[test]
+    fn test_large_tensor_multi_group() {
+        let mut comp = TemporalTensorCompressor::new(default_policy(), 512, 0);
+        comp.set_access(100, 0); // hot -> 8-bit
+        let frame: Vec<f32> = (0..512).map(|i| ((i as f32) * 0.731).sin()).collect();
+        let mut seg = Vec::new();
+
+        for _ in 0..50 {
+            comp.push_frame(&frame, 1, &mut seg);
+        }
+        comp.flush(&mut seg);
+
+        let header = segment::parse_header(&seg).unwrap();
+        assert_eq!(header.bits, 8);
+        assert_eq!(header.tensor_len, 512);
+        assert_eq!(header.frame_count, 50);
+        assert_eq!(header.scale_count, 8); // 512/64 = 8 groups
+
+        let mut decoded = Vec::new();
+        segment::decode(&seg, &mut decoded);
+        assert_eq!(decoded.len(), 512 * 50);
+
+        // Verify compression ratio
+        let raw = 512 * 4 * 50;
+        let compressed = seg.len();
+        let ratio = raw as f32 / compressed as f32;
+        assert!(ratio > 3.5, "ratio={ratio:.2}x, expected >3.5x");
     }
 }

--- a/crates/ruvector-temporal-tensor/src/f16.rs
+++ b/crates/ruvector-temporal-tensor/src/f16.rs
@@ -1,8 +1,13 @@
-/// Software IEEE 754 half-precision (f16) conversion.
-///
-/// No external crate dependencies. Handles normals, denormals, infinity, and NaN.
+//! Software IEEE 754 half-precision (f16) conversion.
+//!
+//! No external crate dependencies. Handles normals, denormals, infinity, and NaN.
+//! Round-to-nearest with ties-to-even for normal values.
 
 /// Convert f32 to f16 bit representation.
+///
+/// Handles all IEEE 754 special cases: infinity, NaN, denormals, and zero (both signs).
+/// Values outside f16 range saturate to infinity. Values too small for f16 denormals
+/// flush to zero.
 #[inline]
 pub fn f32_to_f16_bits(x: f32) -> u16 {
     let b = x.to_bits();
@@ -13,9 +18,8 @@ pub fn f32_to_f16_bits(x: f32) -> u16 {
     // Infinity or NaN
     if exp == 255 {
         if mant == 0 {
-            return sign | 0x7C00; // Infinity
+            return sign | 0x7C00;
         }
-        // NaN: preserve some mantissa bits
         let nan_m = (mant >> 13) as u16;
         return sign | 0x7C00 | nan_m | 1;
     }
@@ -30,11 +34,10 @@ pub fn f32_to_f16_bits(x: f32) -> u16 {
     // Underflow -> denormal or zero
     if exp16 <= 0 {
         if exp16 < -10 {
-            return sign; // Too small, flush to zero
+            return sign;
         }
         let shift = (14 - exp16) as u32;
         let mut mant32 = mant | 0x80_0000;
-        // Round to nearest
         let round_bit = 1u32.wrapping_shl(shift.wrapping_sub(1));
         mant32 = mant32.wrapping_add(round_bit);
         let sub = (mant32 >> shift) as u16;
@@ -52,6 +55,9 @@ pub fn f32_to_f16_bits(x: f32) -> u16 {
 }
 
 /// Convert f16 bit representation to f32.
+///
+/// Exactly reconstructs the f32 value represented by the f16 bit pattern.
+/// Handles denormals by normalizing the mantissa before constructing the f32 bits.
 #[inline]
 pub fn f16_bits_to_f32(h: u16) -> f32 {
     let sign = ((h & 0x8000) as u32) << 16;
@@ -63,7 +69,6 @@ pub fn f16_bits_to_f32(h: u16) -> f32 {
         if mant == 0 {
             return f32::from_bits(sign);
         }
-        // Denormal: normalize
         let mut e = 1i32;
         let mut m = mant;
         while (m & 0x0400) == 0 {
@@ -109,8 +114,7 @@ mod tests {
     fn test_infinity() {
         let h = f32_to_f16_bits(f32::INFINITY);
         assert_eq!(h, 0x7C00);
-        let back = f16_bits_to_f32(h);
-        assert!(back.is_infinite() && back > 0.0);
+        assert!(f16_bits_to_f32(h).is_infinite());
     }
 
     #[test]
@@ -124,21 +128,17 @@ mod tests {
     #[test]
     fn test_nan() {
         let h = f32_to_f16_bits(f32::NAN);
-        let back = f16_bits_to_f32(h);
-        assert!(back.is_nan());
+        assert!(f16_bits_to_f32(h).is_nan());
     }
 
     #[test]
     fn test_zero_signs() {
-        let pos = f32_to_f16_bits(0.0f32);
-        let neg = f32_to_f16_bits(-0.0f32);
-        assert_eq!(pos, 0x0000);
-        assert_eq!(neg, 0x8000);
+        assert_eq!(f32_to_f16_bits(0.0f32), 0x0000);
+        assert_eq!(f32_to_f16_bits(-0.0f32), 0x8000);
     }
 
     #[test]
     fn test_scale_range_accuracy() {
-        // Scales typically fall in [1e-4, 1e4]
         for exp in -4..=4i32 {
             let v = 10.0f32.powi(exp);
             let h = f32_to_f16_bits(v);

--- a/crates/ruvector-temporal-tensor/src/f16.rs
+++ b/crates/ruvector-temporal-tensor/src/f16.rs
@@ -1,0 +1,148 @@
+/// Software IEEE 754 half-precision (f16) conversion.
+///
+/// No external crate dependencies. Handles normals, denormals, infinity, and NaN.
+
+/// Convert f32 to f16 bit representation.
+pub fn f32_to_f16_bits(x: f32) -> u16 {
+    let b = x.to_bits();
+    let sign = ((b >> 16) & 0x8000) as u16;
+    let exp = ((b >> 23) & 0xFF) as i32;
+    let mant = b & 0x7F_FFFF;
+
+    // Infinity or NaN
+    if exp == 255 {
+        if mant == 0 {
+            return sign | 0x7C00; // Infinity
+        }
+        // NaN: preserve some mantissa bits
+        let nan_m = (mant >> 13) as u16;
+        return sign | 0x7C00 | nan_m | 1;
+    }
+
+    let exp16 = exp - 127 + 15;
+
+    // Overflow -> Infinity
+    if exp16 >= 31 {
+        return sign | 0x7C00;
+    }
+
+    // Underflow -> denormal or zero
+    if exp16 <= 0 {
+        if exp16 < -10 {
+            return sign; // Too small, flush to zero
+        }
+        let shift = (14 - exp16) as u32;
+        let mut mant32 = mant | 0x80_0000;
+        // Round to nearest
+        let round_bit = 1u32.wrapping_shl(shift.wrapping_sub(1));
+        mant32 = mant32.wrapping_add(round_bit);
+        let sub = (mant32 >> shift) as u16;
+        return sign | sub;
+    }
+
+    // Normal case
+    let mant16 = (mant >> 13) as u16;
+    let round = (mant >> 12) & 1;
+    let mut res = sign | ((exp16 as u16) << 10) | mant16;
+    if round != 0 {
+        res = res.wrapping_add(1);
+    }
+    res
+}
+
+/// Convert f16 bit representation to f32.
+pub fn f16_bits_to_f32(h: u16) -> f32 {
+    let sign = ((h & 0x8000) as u32) << 16;
+    let exp = ((h >> 10) & 0x1F) as i32;
+    let mant = (h & 0x03FF) as u32;
+
+    // Zero or denormal
+    if exp == 0 {
+        if mant == 0 {
+            return f32::from_bits(sign);
+        }
+        // Denormal: normalize
+        let mut e = 1i32;
+        let mut m = mant;
+        while (m & 0x0400) == 0 {
+            m <<= 1;
+            e += 1;
+        }
+        m &= 0x03FF;
+        let exp32 = 127 - 15 - e + 1;
+        let mant32 = m << 13;
+        return f32::from_bits(sign | ((exp32 as u32) << 23) | mant32);
+    }
+
+    // Infinity or NaN
+    if exp == 31 {
+        return f32::from_bits(sign | 0x7F80_0000 | (mant << 13));
+    }
+
+    // Normal
+    let exp32 = exp - 15 + 127;
+    let mant32 = mant << 13;
+    f32::from_bits(sign | ((exp32 as u32) << 23) | mant32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_roundtrip_normal() {
+        for &v in &[0.0f32, 1.0, -1.0, 0.5, 65504.0, -65504.0, 0.0001] {
+            let h = f32_to_f16_bits(v);
+            let back = f16_bits_to_f32(h);
+            if v == 0.0 {
+                assert_eq!(back, 0.0);
+            } else {
+                let rel_err = ((back - v) / v).abs();
+                assert!(rel_err < 0.01, "v={v}, back={back}, rel_err={rel_err}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_infinity() {
+        let h = f32_to_f16_bits(f32::INFINITY);
+        assert_eq!(h, 0x7C00);
+        let back = f16_bits_to_f32(h);
+        assert!(back.is_infinite() && back > 0.0);
+    }
+
+    #[test]
+    fn test_neg_infinity() {
+        let h = f32_to_f16_bits(f32::NEG_INFINITY);
+        assert_eq!(h, 0xFC00);
+        let back = f16_bits_to_f32(h);
+        assert!(back.is_infinite() && back < 0.0);
+    }
+
+    #[test]
+    fn test_nan() {
+        let h = f32_to_f16_bits(f32::NAN);
+        let back = f16_bits_to_f32(h);
+        assert!(back.is_nan());
+    }
+
+    #[test]
+    fn test_zero_signs() {
+        let pos = f32_to_f16_bits(0.0f32);
+        let neg = f32_to_f16_bits(-0.0f32);
+        assert_eq!(pos, 0x0000);
+        assert_eq!(neg, 0x8000);
+    }
+
+    #[test]
+    fn test_scale_range_accuracy() {
+        // Scales typically fall in [1e-4, 1e4]
+        for exp in -4..=4i32 {
+            let v = 10.0f32.powi(exp);
+            let h = f32_to_f16_bits(v);
+            let back = f16_bits_to_f32(h);
+            let rel_err = ((back - v) / v).abs();
+            assert!(rel_err < 0.002, "v={v}, back={back}, rel_err={rel_err}");
+        }
+    }
+}

--- a/crates/ruvector-temporal-tensor/src/f16.rs
+++ b/crates/ruvector-temporal-tensor/src/f16.rs
@@ -3,6 +3,7 @@
 /// No external crate dependencies. Handles normals, denormals, infinity, and NaN.
 
 /// Convert f32 to f16 bit representation.
+#[inline]
 pub fn f32_to_f16_bits(x: f32) -> u16 {
     let b = x.to_bits();
     let sign = ((b >> 16) & 0x8000) as u16;
@@ -51,6 +52,7 @@ pub fn f32_to_f16_bits(x: f32) -> u16 {
 }
 
 /// Convert f16 bit representation to f32.
+#[inline]
 pub fn f16_bits_to_f32(h: u16) -> f32 {
     let sign = ((h & 0x8000) as u32) << 16;
     let exp = ((h >> 10) & 0x1F) as i32;

--- a/crates/ruvector-temporal-tensor/src/ffi.rs
+++ b/crates/ruvector-temporal-tensor/src/ffi.rs
@@ -1,10 +1,10 @@
-/// WASM/C FFI interface with handle-based resource management.
-///
-/// Exports extern "C" functions for:
-/// - Compressor lifecycle (create, free, touch, set_access)
-/// - Frame compression (push_frame, flush)
-/// - Segment decoding (decode_segment)
-/// - Memory management (alloc, dealloc)
+//! WASM/C FFI interface with handle-based resource management.
+//!
+//! Exports `extern "C"` functions for:
+//! - Compressor lifecycle (`ttc_create`, `ttc_free`, `ttc_touch`, `ttc_set_access`)
+//! - Frame compression (`ttc_push_frame`, `ttc_flush`)
+//! - Segment decoding (`ttc_decode_segment`)
+//! - Memory management (`ttc_alloc`, `ttc_dealloc`)
 
 use crate::compressor::TemporalTensorCompressor;
 use crate::segment;

--- a/crates/ruvector-temporal-tensor/src/ffi.rs
+++ b/crates/ruvector-temporal-tensor/src/ffi.rs
@@ -1,0 +1,250 @@
+/// WASM/C FFI interface with handle-based resource management.
+///
+/// Exports extern "C" functions for:
+/// - Compressor lifecycle (create, free, touch, set_access)
+/// - Frame compression (push_frame, flush)
+/// - Segment decoding (decode_segment)
+/// - Memory management (alloc, dealloc)
+
+use crate::compressor::TemporalTensorCompressor;
+use crate::segment;
+use crate::tier_policy::TierPolicy;
+
+static mut STORE: Option<Vec<Option<TemporalTensorCompressor>>> = None;
+
+fn store_init() {
+    unsafe {
+        if STORE.is_none() {
+            STORE = Some(Vec::new());
+        }
+    }
+}
+
+fn with_store<F, R>(f: F) -> R
+where
+    F: FnOnce(&mut Vec<Option<TemporalTensorCompressor>>) -> R,
+{
+    store_init();
+    unsafe { f(STORE.as_mut().unwrap()) }
+}
+
+fn with_compressor<F>(handle: u32, f: F)
+where
+    F: FnOnce(&mut TemporalTensorCompressor),
+{
+    with_store(|store| {
+        let idx = handle as usize;
+        if idx < store.len() {
+            if let Some(comp) = store[idx].as_mut() {
+                f(comp);
+            }
+        }
+    });
+}
+
+/// Create a new compressor. Returns handle via out_handle.
+#[no_mangle]
+pub extern "C" fn ttc_create(len: u32, now_ts: u32, out_handle: *mut u32) {
+    let policy = TierPolicy::default();
+    let comp = TemporalTensorCompressor::new(policy, len, now_ts);
+
+    with_store(|store| {
+        // Find a free slot
+        for (i, slot) in store.iter_mut().enumerate() {
+            if slot.is_none() {
+                *slot = Some(comp);
+                if !out_handle.is_null() {
+                    unsafe { *out_handle = i as u32 };
+                }
+                return;
+            }
+        }
+        // No free slot, push
+        let idx = store.len();
+        store.push(Some(comp));
+        if !out_handle.is_null() {
+            unsafe { *out_handle = idx as u32 };
+        }
+    });
+}
+
+/// Create a compressor with custom policy parameters.
+#[no_mangle]
+pub extern "C" fn ttc_create_with_policy(
+    len: u32,
+    now_ts: u32,
+    hot_min_score: u32,
+    warm_min_score: u32,
+    warm_bits: u8,
+    drift_pct_q8: u32,
+    group_len: u32,
+    out_handle: *mut u32,
+) {
+    let policy = TierPolicy {
+        hot_min_score,
+        warm_min_score,
+        warm_bits,
+        drift_pct_q8,
+        group_len,
+    };
+    let comp = TemporalTensorCompressor::new(policy, len, now_ts);
+
+    with_store(|store| {
+        for (i, slot) in store.iter_mut().enumerate() {
+            if slot.is_none() {
+                *slot = Some(comp);
+                if !out_handle.is_null() {
+                    unsafe { *out_handle = i as u32 };
+                }
+                return;
+            }
+        }
+        let idx = store.len();
+        store.push(Some(comp));
+        if !out_handle.is_null() {
+            unsafe { *out_handle = idx as u32 };
+        }
+    });
+}
+
+/// Free a compressor.
+#[no_mangle]
+pub extern "C" fn ttc_free(handle: u32) {
+    with_store(|store| {
+        let idx = handle as usize;
+        if idx < store.len() {
+            store[idx] = None;
+        }
+    });
+}
+
+/// Record an access event.
+#[no_mangle]
+pub extern "C" fn ttc_touch(handle: u32, now_ts: u32) {
+    with_compressor(handle, |comp| comp.touch(now_ts));
+}
+
+/// Set access stats directly.
+#[no_mangle]
+pub extern "C" fn ttc_set_access(handle: u32, access_count: u32, last_access_ts: u32) {
+    with_compressor(handle, |comp| comp.set_access(access_count, last_access_ts));
+}
+
+/// Push a frame. If a segment boundary is crossed, the completed segment
+/// is written to out_ptr/out_cap, and out_written is set to the byte count.
+#[no_mangle]
+pub extern "C" fn ttc_push_frame(
+    handle: u32,
+    now_ts: u32,
+    in_ptr: *const f32,
+    len: u32,
+    out_ptr: *mut u8,
+    out_cap: u32,
+    out_written: *mut u32,
+) {
+    if out_written.is_null() {
+        return;
+    }
+    unsafe { *out_written = 0 };
+    if in_ptr.is_null() || out_ptr.is_null() {
+        return;
+    }
+
+    let frame = unsafe { std::slice::from_raw_parts(in_ptr, len as usize) };
+    let mut seg = Vec::new();
+
+    with_compressor(handle, |comp| {
+        comp.push_frame(frame, now_ts, &mut seg);
+    });
+
+    if seg.is_empty() || (seg.len() as u32) > out_cap {
+        return;
+    }
+
+    unsafe {
+        let out = std::slice::from_raw_parts_mut(out_ptr, out_cap as usize);
+        out[..seg.len()].copy_from_slice(&seg);
+        *out_written = seg.len() as u32;
+    }
+}
+
+/// Flush the current segment.
+#[no_mangle]
+pub extern "C" fn ttc_flush(handle: u32, out_ptr: *mut u8, out_cap: u32, out_written: *mut u32) {
+    if out_written.is_null() {
+        return;
+    }
+    unsafe { *out_written = 0 };
+
+    let mut seg = Vec::new();
+    with_compressor(handle, |comp| {
+        comp.flush(&mut seg);
+    });
+
+    if seg.is_empty() || out_ptr.is_null() || (seg.len() as u32) > out_cap {
+        return;
+    }
+
+    unsafe {
+        let out = std::slice::from_raw_parts_mut(out_ptr, out_cap as usize);
+        out[..seg.len()].copy_from_slice(&seg);
+        *out_written = seg.len() as u32;
+    }
+}
+
+/// Decode a segment into f32 values.
+#[no_mangle]
+pub extern "C" fn ttc_decode_segment(
+    seg_ptr: *const u8,
+    seg_len: u32,
+    out_ptr: *mut f32,
+    out_cap_f32: u32,
+    out_written_f32: *mut u32,
+) {
+    if out_written_f32.is_null() {
+        return;
+    }
+    unsafe { *out_written_f32 = 0 };
+    if seg_ptr.is_null() || out_ptr.is_null() {
+        return;
+    }
+
+    let seg = unsafe { std::slice::from_raw_parts(seg_ptr, seg_len as usize) };
+    let mut values = Vec::new();
+    segment::decode(seg, &mut values);
+
+    if values.is_empty() || (values.len() as u32) > out_cap_f32 {
+        return;
+    }
+
+    unsafe {
+        let out = std::slice::from_raw_parts_mut(out_ptr, out_cap_f32 as usize);
+        out[..values.len()].copy_from_slice(&values);
+        *out_written_f32 = values.len() as u32;
+    }
+}
+
+/// Allocate a buffer in WASM linear memory.
+#[no_mangle]
+pub extern "C" fn ttc_alloc(size: u32, out_ptr: *mut u32) {
+    if out_ptr.is_null() {
+        return;
+    }
+    let mut v: Vec<u8> = Vec::with_capacity(size as usize);
+    let p = v.as_mut_ptr();
+    std::mem::forget(v);
+    unsafe {
+        *out_ptr = p as u32;
+    }
+}
+
+/// Free a buffer previously allocated with ttc_alloc.
+#[no_mangle]
+pub extern "C" fn ttc_dealloc(ptr: u32, cap: u32) {
+    if ptr == 0 || cap == 0 {
+        return;
+    }
+    unsafe {
+        let _ = Vec::<u8>::from_raw_parts(ptr as *mut u8, 0, cap as usize);
+    }
+}

--- a/crates/ruvector-temporal-tensor/src/lib.rs
+++ b/crates/ruvector-temporal-tensor/src/lib.rs
@@ -22,6 +22,55 @@
 //! # Zero Dependencies
 //!
 //! This crate has no external dependencies, making it fully WASM-compatible.
+//!
+//! # Quick Start
+//!
+//! ```rust
+//! use ruvector_temporal_tensor::{TemporalTensorCompressor, TierPolicy};
+//!
+//! // Create a compressor for 128-element tensors
+//! let mut comp = TemporalTensorCompressor::new(TierPolicy::default(), 128, 0);
+//! comp.set_access(100, 0); // hot tensor -> 8-bit quantization
+//!
+//! let frame = vec![1.0f32; 128];
+//! let mut segment = Vec::new();
+//!
+//! // Push frames; segment is populated when a boundary is crossed
+//! comp.push_frame(&frame, 1, &mut segment);
+//! comp.flush(&mut segment); // force-emit the current segment
+//!
+//! // Decode the segment back to f32
+//! let mut decoded = Vec::new();
+//! ruvector_temporal_tensor::segment::decode(&segment, &mut decoded);
+//! assert_eq!(decoded.len(), 128);
+//! ```
+//!
+//! # Random-Access Decode
+//!
+//! ```rust
+//! # use ruvector_temporal_tensor::{TemporalTensorCompressor, TierPolicy};
+//! # let mut comp = TemporalTensorCompressor::new(TierPolicy::default(), 64, 0);
+//! # let frame = vec![1.0f32; 64];
+//! # let mut seg = Vec::new();
+//! # comp.push_frame(&frame, 0, &mut seg);
+//! # comp.flush(&mut seg);
+//! // Decode only frame 0 without decoding the entire segment
+//! let single = ruvector_temporal_tensor::segment::decode_single_frame(&seg, 0);
+//! assert!(single.is_some());
+//! ```
+//!
+//! # Compression Ratio Inspection
+//!
+//! ```rust
+//! # use ruvector_temporal_tensor::{TemporalTensorCompressor, TierPolicy};
+//! # let mut comp = TemporalTensorCompressor::new(TierPolicy::default(), 64, 0);
+//! # let frame = vec![1.0f32; 64];
+//! # let mut seg = Vec::new();
+//! # comp.push_frame(&frame, 0, &mut seg);
+//! # comp.flush(&mut seg);
+//! let ratio = ruvector_temporal_tensor::segment::compression_ratio(&seg);
+//! assert!(ratio > 1.0);
+//! ```
 
 pub mod bitpack;
 pub mod compressor;

--- a/crates/ruvector-temporal-tensor/src/lib.rs
+++ b/crates/ruvector-temporal-tensor/src/lib.rs
@@ -1,0 +1,37 @@
+//! Temporal Tensor Compression with Tiered Quantization
+//!
+//! Implements ADR-017: groupwise symmetric quantization with temporal segment
+//! reuse and access-pattern-driven tier selection (8/7/5/3 bit).
+//!
+//! # Architecture
+//!
+//! ```text
+//! f32 frame → tier_policy → quantizer → bitpack → segment
+//! segment → bitpack → quantizer → f32 output
+//! ```
+//!
+//! # Compression Ratios
+//!
+//! | Tier | Bits | Ratio vs f32 | Use Case |
+//! |------|------|-------------|----------|
+//! | Hot  | 8    | ~4.0x       | Frequently accessed tensors |
+//! | Warm | 7    | ~4.57x      | Moderately accessed |
+//! | Warm | 5    | ~6.4x       | Aggressively compressed warm |
+//! | Cold | 3    | ~10.67x     | Rarely accessed |
+//!
+//! # Zero Dependencies
+//!
+//! This crate has no external dependencies, making it fully WASM-compatible.
+
+pub mod bitpack;
+pub mod compressor;
+pub mod f16;
+pub mod quantizer;
+pub mod segment;
+pub mod tier_policy;
+
+#[cfg(feature = "ffi")]
+pub mod ffi;
+
+pub use compressor::TemporalTensorCompressor;
+pub use tier_policy::TierPolicy;

--- a/crates/ruvector-temporal-tensor/src/quantizer.rs
+++ b/crates/ruvector-temporal-tensor/src/quantizer.rs
@@ -1,0 +1,267 @@
+/// Groupwise symmetric quantization with f16 scales.
+///
+/// For each group of `group_len` values:
+///   scale = max(|v_i|) / qmax
+///   q_i = round(v_i / scale), clamped to [-qmax, +qmax]
+///   u_i = q_i + qmax  (bias to unsigned for packing)
+
+use crate::bitpack::qmax_from_bits;
+use crate::f16;
+
+/// Compute f16 group scales for a frame.
+pub fn compute_scales(frame: &[f32], group_len: usize, bits: u8) -> Vec<u16> {
+    let qmax = qmax_from_bits(bits);
+    if qmax == 0 {
+        return Vec::new();
+    }
+    let qmax_f = qmax as f32;
+
+    let mut scales = Vec::with_capacity((frame.len() + group_len - 1) / group_len);
+    let mut idx = 0;
+
+    while idx < frame.len() {
+        let end = (idx + group_len).min(frame.len());
+        let mut max_abs = 0.0f32;
+
+        for &v in &frame[idx..end] {
+            if v.is_finite() {
+                let a = v.abs();
+                if a > max_abs {
+                    max_abs = a;
+                }
+            }
+        }
+
+        let scale = if max_abs == 0.0 { 0.0 } else { max_abs / qmax_f };
+        scales.push(f16::f32_to_f16_bits(scale));
+        idx = end;
+    }
+
+    scales
+}
+
+/// Check if a frame fits within existing scales (within drift tolerance).
+pub fn frame_fits_scales(
+    frame: &[f32],
+    scales: &[u16],
+    group_len: usize,
+    bits: u8,
+    drift_factor: f32,
+) -> bool {
+    let qmax = qmax_from_bits(bits);
+    if qmax == 0 || scales.is_empty() {
+        return false;
+    }
+    let qmax_f = qmax as f32;
+
+    let mut group_idx = 0;
+    let mut idx = 0;
+
+    while idx < frame.len() {
+        if group_idx >= scales.len() {
+            return false;
+        }
+
+        let scale = f16::f16_bits_to_f32(scales[group_idx]);
+        let allowed = scale * qmax_f * drift_factor;
+
+        let end = (idx + group_len).min(frame.len());
+        for &v in &frame[idx..end] {
+            if v.is_finite() && v.abs() > allowed {
+                return false;
+            }
+        }
+
+        group_idx += 1;
+        idx = end;
+    }
+
+    true
+}
+
+/// Quantize a frame using pre-computed scales and pack into bitstream.
+pub fn quantize_and_pack(
+    frame: &[f32],
+    scales: &[u16],
+    group_len: usize,
+    bits: u8,
+    out: &mut Vec<u8>,
+) {
+    let qmax = qmax_from_bits(bits);
+    if qmax == 0 {
+        return;
+    }
+    let qmax_i = qmax;
+    let bias = qmax;
+    let bits_u32 = bits as u32;
+
+    let mut acc: u64 = 0;
+    let mut acc_bits: u32 = 0;
+
+    let mut group_idx = 0;
+    let mut idx = 0;
+
+    while idx < frame.len() {
+        let end = (idx + group_len).min(frame.len());
+        let scale = f16::f16_bits_to_f32(scales[group_idx]);
+        let inv_scale = if scale == 0.0 { 0.0 } else { 1.0 / scale };
+
+        for &v in &frame[idx..end] {
+            let mut q: i32 = 0;
+            if v.is_finite() {
+                let scaled = v * inv_scale;
+                q = scaled.round() as i32;
+                q = q.clamp(-qmax_i, qmax_i);
+            }
+
+            let u = (q + bias) as u32;
+            acc |= (u as u64) << acc_bits;
+            acc_bits += bits_u32;
+
+            while acc_bits >= 8 {
+                out.push((acc & 0xFF) as u8);
+                acc >>= 8;
+                acc_bits -= 8;
+            }
+        }
+
+        group_idx += 1;
+        idx = end;
+    }
+
+    if acc_bits > 0 {
+        out.push((acc & 0xFF) as u8);
+    }
+}
+
+/// Dequantize packed codes using scales, writing f32 values.
+pub fn dequantize(
+    data: &[u8],
+    scales: &[u16],
+    group_len: usize,
+    bits: u8,
+    tensor_len: usize,
+    frame_count: usize,
+    out: &mut Vec<f32>,
+) {
+    let qmax = qmax_from_bits(bits);
+    if qmax == 0 {
+        return;
+    }
+    let bias = qmax;
+    let bits_u32 = bits as u32;
+    let mask = (1u64 << bits_u32) - 1;
+
+    let total = tensor_len * frame_count;
+    out.resize(total, 0.0);
+
+    let mut acc: u64 = 0;
+    let mut acc_bits: u32 = 0;
+    let mut byte_idx = 0;
+    let mut val_idx = 0;
+
+    while val_idx < total {
+        // Fill accumulator
+        while acc_bits < bits_u32 && byte_idx < data.len() {
+            acc |= (data[byte_idx] as u64) << acc_bits;
+            acc_bits += 8;
+            byte_idx += 1;
+        }
+        if acc_bits < bits_u32 {
+            break;
+        }
+
+        let u = (acc & mask) as u32;
+        acc >>= bits_u32;
+        acc_bits -= bits_u32;
+
+        let q = (u as i32) - bias;
+        let within_frame = val_idx % tensor_len;
+        let group_idx = within_frame / group_len;
+
+        let scale = if group_idx < scales.len() {
+            f16::f16_bits_to_f32(scales[group_idx])
+        } else {
+            0.0
+        };
+
+        out[val_idx] = (q as f32) * scale;
+        val_idx += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_quantize_roundtrip_8bit() {
+        let frame: Vec<f32> = (0..128).map(|i| (i as f32 - 64.0) * 0.1).collect();
+        let group_len = 64;
+        let bits = 8;
+
+        let scales = compute_scales(&frame, group_len, bits);
+        let mut packed = Vec::new();
+        quantize_and_pack(&frame, &scales, group_len, bits, &mut packed);
+
+        let mut decoded = Vec::new();
+        dequantize(&packed, &scales, group_len, bits, frame.len(), 1, &mut decoded);
+
+        assert_eq!(decoded.len(), frame.len());
+        for (i, (&orig, &dec)) in frame.iter().zip(decoded.iter()).enumerate() {
+            let err = (orig - dec).abs();
+            let max_err = if orig.abs() > 0.01 { orig.abs() * 0.02 } else { 0.1 };
+            assert!(err < max_err, "i={i}, orig={orig}, dec={dec}, err={err}");
+        }
+    }
+
+    #[test]
+    fn test_quantize_roundtrip_3bit() {
+        let frame: Vec<f32> = (0..64).map(|i| (i as f32 - 32.0) * 0.5).collect();
+        let group_len = 64;
+        let bits = 3;
+
+        let scales = compute_scales(&frame, group_len, bits);
+        let mut packed = Vec::new();
+        quantize_and_pack(&frame, &scales, group_len, bits, &mut packed);
+
+        let mut decoded = Vec::new();
+        dequantize(&packed, &scales, group_len, bits, frame.len(), 1, &mut decoded);
+
+        assert_eq!(decoded.len(), frame.len());
+        // 3-bit has higher error but should be bounded
+        let max_val = frame.iter().map(|v| v.abs()).fold(0.0f32, f32::max);
+        for (&orig, &dec) in frame.iter().zip(decoded.iter()) {
+            let err = (orig - dec).abs();
+            assert!(err < max_val * 0.35, "orig={orig}, dec={dec}, err={err}");
+        }
+    }
+
+    #[test]
+    fn test_drift_detection() {
+        let frame1: Vec<f32> = vec![1.0; 64];
+        let frame2: Vec<f32> = vec![1.05; 64]; // 5% drift
+        let frame3: Vec<f32> = vec![2.0; 64]; // 100% drift
+
+        let scales = compute_scales(&frame1, 64, 8);
+        let drift_factor = 1.0 + 26.0 / 256.0; // ~10%
+
+        assert!(frame_fits_scales(&frame2, &scales, 64, 8, drift_factor));
+        assert!(!frame_fits_scales(&frame3, &scales, 64, 8, drift_factor));
+    }
+
+    #[test]
+    fn test_zero_frame() {
+        let frame = vec![0.0f32; 128];
+        let scales = compute_scales(&frame, 64, 8);
+        let mut packed = Vec::new();
+        quantize_and_pack(&frame, &scales, 64, 8, &mut packed);
+
+        let mut decoded = Vec::new();
+        dequantize(&packed, &scales, 64, 8, 128, 1, &mut decoded);
+
+        for &v in &decoded {
+            assert_eq!(v, 0.0);
+        }
+    }
+}

--- a/crates/ruvector-temporal-tensor/src/segment.rs
+++ b/crates/ruvector-temporal-tensor/src/segment.rs
@@ -1,0 +1,238 @@
+/// Segment binary format: encode and decode.
+///
+/// Format:
+///   [magic:4][version:1][bits:1][group_len:4][tensor_len:4][frames:4]
+///   [scale_count:4][scales:2*S][data_len:4][data:D]
+///
+/// Magic: 0x43545154 ("TQTC" in LE)
+
+use crate::quantizer;
+
+pub const MAGIC: u32 = 0x4354_5154; // "TQTC"
+pub const VERSION: u8 = 1;
+pub const HEADER_SIZE: usize = 26; // Fixed header before scales
+
+/// Encode a segment from metadata, scales, and packed data.
+pub fn encode(
+    bits: u8,
+    group_len: u32,
+    tensor_len: u32,
+    frame_count: u32,
+    scales: &[u16],
+    data: &[u8],
+    out: &mut Vec<u8>,
+) {
+    out.clear();
+    let estimated = HEADER_SIZE + scales.len() * 2 + data.len();
+    out.reserve(estimated);
+
+    // Header
+    out.extend_from_slice(&MAGIC.to_le_bytes());
+    out.push(VERSION);
+    out.push(bits);
+    out.extend_from_slice(&group_len.to_le_bytes());
+    out.extend_from_slice(&tensor_len.to_le_bytes());
+    out.extend_from_slice(&frame_count.to_le_bytes());
+
+    // Scales
+    let scale_count = scales.len() as u32;
+    out.extend_from_slice(&scale_count.to_le_bytes());
+    for &s in scales {
+        out.extend_from_slice(&s.to_le_bytes());
+    }
+
+    // Data
+    let data_len = data.len() as u32;
+    out.extend_from_slice(&data_len.to_le_bytes());
+    out.extend_from_slice(data);
+}
+
+/// Decoded segment header.
+#[derive(Debug, Clone)]
+pub struct SegmentHeader {
+    pub bits: u8,
+    pub group_len: u32,
+    pub tensor_len: u32,
+    pub frame_count: u32,
+    pub scale_count: u32,
+}
+
+/// Decode a segment, returning all frames as f32 values.
+pub fn decode(segment: &[u8], out: &mut Vec<f32>) {
+    out.clear();
+    if segment.len() < HEADER_SIZE {
+        return;
+    }
+
+    let mut off = 0;
+
+    let magic = read_u32_le(segment, &mut off);
+    if magic != MAGIC {
+        return;
+    }
+
+    let version = segment[off];
+    off += 1;
+    if version != VERSION {
+        return;
+    }
+
+    let bits = segment[off];
+    off += 1;
+
+    let group_len = read_u32_le(segment, &mut off);
+    let tensor_len = read_u32_le(segment, &mut off);
+    let frame_count = read_u32_le(segment, &mut off);
+    let scale_count = read_u32_le(segment, &mut off);
+
+    // Read scales
+    let scales_end = off + (scale_count as usize) * 2;
+    if scales_end > segment.len() {
+        return;
+    }
+    let mut scales = Vec::with_capacity(scale_count as usize);
+    for _ in 0..scale_count {
+        scales.push(read_u16_le(segment, &mut off));
+    }
+
+    // Read data
+    if off + 4 > segment.len() {
+        return;
+    }
+    let data_len = read_u32_le(segment, &mut off) as usize;
+    if off + data_len > segment.len() {
+        return;
+    }
+    let data = &segment[off..off + data_len];
+
+    // Dequantize
+    quantizer::dequantize(
+        data,
+        &scales,
+        group_len as usize,
+        bits,
+        tensor_len as usize,
+        frame_count as usize,
+        out,
+    );
+}
+
+/// Parse only the segment header (no data decoding).
+pub fn parse_header(segment: &[u8]) -> Option<SegmentHeader> {
+    if segment.len() < HEADER_SIZE {
+        return None;
+    }
+    let mut off = 0;
+    let magic = read_u32_le(segment, &mut off);
+    if magic != MAGIC {
+        return None;
+    }
+    let version = segment[off];
+    off += 1;
+    if version != VERSION {
+        return None;
+    }
+    let bits = segment[off];
+    off += 1;
+    let group_len = read_u32_le(segment, &mut off);
+    let tensor_len = read_u32_le(segment, &mut off);
+    let frame_count = read_u32_le(segment, &mut off);
+    let scale_count = read_u32_le(segment, &mut off);
+
+    Some(SegmentHeader {
+        bits,
+        group_len,
+        tensor_len,
+        frame_count,
+        scale_count,
+    })
+}
+
+fn read_u32_le(bytes: &[u8], offset: &mut usize) -> u32 {
+    let o = *offset;
+    let arr = [bytes[o], bytes[o + 1], bytes[o + 2], bytes[o + 3]];
+    *offset = o + 4;
+    u32::from_le_bytes(arr)
+}
+
+fn read_u16_le(bytes: &[u8], offset: &mut usize) -> u16 {
+    let o = *offset;
+    let arr = [bytes[o], bytes[o + 1]];
+    *offset = o + 2;
+    u16::from_le_bytes(arr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quantizer;
+
+    #[test]
+    fn test_encode_decode_roundtrip() {
+        let frame: Vec<f32> = (0..128).map(|i| (i as f32 - 64.0) * 0.1).collect();
+        let group_len = 64usize;
+        let bits = 8u8;
+
+        let scales = quantizer::compute_scales(&frame, group_len, bits);
+        let mut packed = Vec::new();
+        quantizer::quantize_and_pack(&frame, &scales, group_len, bits, &mut packed);
+
+        let mut seg = Vec::new();
+        encode(bits, group_len as u32, frame.len() as u32, 1, &scales, &packed, &mut seg);
+
+        let mut decoded = Vec::new();
+        decode(&seg, &mut decoded);
+
+        assert_eq!(decoded.len(), frame.len());
+        for (i, (&orig, &dec)) in frame.iter().zip(decoded.iter()).enumerate() {
+            let err = (orig - dec).abs();
+            assert!(err < 0.1, "i={i} orig={orig} dec={dec} err={err}");
+        }
+    }
+
+    #[test]
+    fn test_magic_validation() {
+        let mut decoded = Vec::new();
+        decode(&[0, 0, 0, 0], &mut decoded);
+        assert!(decoded.is_empty()); // Wrong magic
+    }
+
+    #[test]
+    fn test_parse_header() {
+        let frame = vec![1.0f32; 64];
+        let scales = quantizer::compute_scales(&frame, 64, 7);
+        let mut packed = Vec::new();
+        quantizer::quantize_and_pack(&frame, &scales, 64, 7, &mut packed);
+
+        let mut seg = Vec::new();
+        encode(7, 64, 64, 1, &scales, &packed, &mut seg);
+
+        let header = parse_header(&seg).unwrap();
+        assert_eq!(header.bits, 7);
+        assert_eq!(header.group_len, 64);
+        assert_eq!(header.tensor_len, 64);
+        assert_eq!(header.frame_count, 1);
+    }
+
+    #[test]
+    fn test_multi_frame_roundtrip() {
+        let group_len = 32usize;
+        let bits = 5u8;
+        let tensor_len = 64;
+
+        let frame1: Vec<f32> = (0..tensor_len).map(|i| (i as f32) * 0.1).collect();
+        let frame2: Vec<f32> = (0..tensor_len).map(|i| (i as f32) * 0.09).collect();
+
+        let scales = quantizer::compute_scales(&frame1, group_len, bits);
+        let mut packed = Vec::new();
+        quantizer::quantize_and_pack(&frame1, &scales, group_len, bits, &mut packed);
+        quantizer::quantize_and_pack(&frame2, &scales, group_len, bits, &mut packed);
+
+        let mut seg = Vec::new();
+        encode(bits, group_len as u32, tensor_len as u32, 2, &scales, &packed, &mut seg);
+
+        let mut decoded = Vec::new();
+        decode(&seg, &mut decoded);
+        assert_eq!(decoded.len(), tensor_len * 2);
+    }
+}

--- a/crates/ruvector-temporal-tensor/src/tier_policy.rs
+++ b/crates/ruvector-temporal-tensor/src/tier_policy.rs
@@ -1,12 +1,12 @@
-/// Tier policy for access-pattern-driven bit-width selection.
-///
-/// Score = access_count * 1024 / (now_ts - last_access_ts + 1)
-///
-/// | Tier | Condition | Bits |
-/// |------|-----------|------|
-/// | Hot  | score >= hot_min_score | 8 |
-/// | Warm | score >= warm_min_score | warm_bits (7 or 5) |
-/// | Cold | otherwise | 3 |
+//! Tier policy for access-pattern-driven bit-width selection.
+//!
+//! Score = `access_count * 1024 / (now_ts - last_access_ts + 1)`
+//!
+//! | Tier | Condition | Bits |
+//! |------|-----------|------|
+//! | Hot  | score >= hot_min_score | 8 |
+//! | Warm | score >= warm_min_score | warm_bits (7 or 5) |
+//! | Cold | otherwise | 3 |
 
 #[derive(Clone, Copy, Debug)]
 pub struct TierPolicy {

--- a/crates/ruvector-temporal-tensor/src/tier_policy.rs
+++ b/crates/ruvector-temporal-tensor/src/tier_policy.rs
@@ -1,0 +1,104 @@
+/// Tier policy for access-pattern-driven bit-width selection.
+///
+/// Score = access_count * 1024 / (now_ts - last_access_ts + 1)
+///
+/// | Tier | Condition | Bits |
+/// |------|-----------|------|
+/// | Hot  | score >= hot_min_score | 8 |
+/// | Warm | score >= warm_min_score | warm_bits (7 or 5) |
+/// | Cold | otherwise | 3 |
+
+#[derive(Clone, Copy, Debug)]
+pub struct TierPolicy {
+    pub hot_min_score: u32,
+    pub warm_min_score: u32,
+    pub warm_bits: u8,
+    /// Drift tolerance as Q8 fixed-point. 26 means ~10.2% (26/256).
+    pub drift_pct_q8: u32,
+    pub group_len: u32,
+}
+
+impl Default for TierPolicy {
+    fn default() -> Self {
+        Self {
+            hot_min_score: 512,
+            warm_min_score: 64,
+            warm_bits: 7,
+            drift_pct_q8: 26,
+            group_len: 64,
+        }
+    }
+}
+
+impl TierPolicy {
+    /// Select bit width based on access pattern.
+    pub fn select_bits(&self, access_count: u32, last_access_ts: u32, now_ts: u32) -> u8 {
+        let age = now_ts.wrapping_sub(last_access_ts).wrapping_add(1);
+        let score = access_count.saturating_mul(1024).wrapping_div(age);
+
+        if score >= self.hot_min_score {
+            8
+        } else if score >= self.warm_min_score {
+            self.warm_bits
+        } else {
+            3
+        }
+    }
+
+    /// Compute the drift factor as 1.0 + drift_pct_q8/256.
+    pub fn drift_factor(&self) -> f32 {
+        1.0 + (self.drift_pct_q8 as f32) / 256.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_policy() {
+        let p = TierPolicy::default();
+        assert_eq!(p.hot_min_score, 512);
+        assert_eq!(p.warm_min_score, 64);
+        assert_eq!(p.warm_bits, 7);
+        assert_eq!(p.drift_pct_q8, 26);
+        assert_eq!(p.group_len, 64);
+    }
+
+    #[test]
+    fn test_tier_selection_hot() {
+        let p = TierPolicy::default();
+        // 100 accesses, age=10 -> score = 100*1024/10 = 10240 >= 512
+        assert_eq!(p.select_bits(100, 0, 9), 8);
+    }
+
+    #[test]
+    fn test_tier_selection_warm() {
+        let p = TierPolicy::default();
+        // 10 accesses, age=100 -> score = 10*1024/100 = 102 >= 64, < 512
+        assert_eq!(p.select_bits(10, 0, 99), 7);
+    }
+
+    #[test]
+    fn test_tier_selection_cold() {
+        let p = TierPolicy::default();
+        // 1 access, age=1000 -> score = 1024/1000 = 1 < 64
+        assert_eq!(p.select_bits(1, 0, 999), 3);
+    }
+
+    #[test]
+    fn test_drift_factor() {
+        let p = TierPolicy::default();
+        let df = p.drift_factor();
+        assert!((df - 1.1015625).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_warm_bits_5() {
+        let p = TierPolicy {
+            warm_bits: 5,
+            ..Default::default()
+        };
+        assert_eq!(p.select_bits(10, 0, 99), 5);
+    }
+}

--- a/docs/adr/ADR-017-temporal-tensor-compression.md
+++ b/docs/adr/ADR-017-temporal-tensor-compression.md
@@ -1,0 +1,703 @@
+# ADR-017: Temporal Tensor Compression with Tiered Quantization
+
+**Status**: Proposed
+**Date**: 2026-02-06
+**Parent**: ADR-001 RuVector Core Architecture, ADR-004 KV Cache Management, ADR-005 WASM Runtime Integration
+**Author**: System Architecture Team
+**SDK**: Claude-Flow
+
+## Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1 | 2026-02-06 | Architecture Team | Initial SOTA research and design proposal |
+
+---
+
+## Abstract
+
+This ADR introduces a **temporal tensor compression** system with **tiered quantization** for RuVector. The system exploits two key observations: (1) tensors accessed at different frequencies can tolerate different precision levels, and (2) quantization parameters (scales) can be amortized across consecutive time frames when the underlying distribution is stable. Together these yield 4x-10.67x compression over f32 while keeping reconstruction error within configurable bounds.
+
+The implementation targets Rust with a zero-dependency WASM-compatible core, matching the sandboxed execution model established in ADR-005.
+
+---
+
+## 1. Context and Motivation
+
+### 1.1 The Memory-Bandwidth Wall
+
+Memory size and memory bandwidth dominate deployment cost for tensor-heavy workloads. ADR-004 established a three-tier KV cache (FP16 / 4-bit / 2-bit) but addresses only static snapshots of key-value pairs. Modern agent systems (RuVector's primary workload) produce **streams of tensor frames** - embeddings, activations, gradient sketches, coherence vectors - that evolve over time. Storing each frame independently wastes metadata and misses temporal redundancy.
+
+**Memory scaling for agent tensor streams:**
+
+| Tensor Dim | Frames/sec | Duration | Raw f32 | 8-bit | 5-bit | 3-bit |
+|-----------|------------|----------|---------|-------|-------|-------|
+| 512 | 10 | 1 hour | 73.7 MB | 18.4 MB | 11.5 MB | 6.9 MB |
+| 2048 | 10 | 1 hour | 294.9 MB | 73.7 MB | 46.1 MB | 27.6 MB |
+| 4096 | 50 | 1 hour | 2.95 GB | 737 MB | 461 MB | 276 MB |
+
+### 1.2 Limitations of Current Quantization (ruvector-core)
+
+The existing `quantization.rs` in `ruvector-core` provides:
+
+| Method | Compression | Limitation |
+|--------|-------------|------------|
+| Scalar (u8) | 4x | Per-vector min/max scales; no temporal reuse |
+| Int4 | 8x | Fixed 4-bit; no adaptive tier selection |
+| Product | 8-16x | Requires codebook training; high latency |
+| Binary | 32x | Too lossy for reconstruction-sensitive paths |
+
+**Missing capabilities:**
+- No temporal scale reuse across frames
+- No access-pattern-driven tier selection
+- No sub-byte bit packing (5-bit, 7-bit)
+- No drift-aware segment boundaries
+- No WASM-native compression path
+
+### 1.3 Why Temporal Compression
+
+The core insight: when a tensor's value distribution is stable over consecutive frames, the quantization scales computed for frame *t* remain valid for frames *t+1, t+2, ..., t+k*. Reusing scales across *k* frames amortizes the per-group scale overhead by *k*x and avoids redundant calibration passes.
+
+This is the same principle behind:
+- **Video codecs** (H.264/H.265): I-frames carry full parameters; P-frames reuse them until a scene change
+- **Time-series databases** (Gorilla, InfluxDB): Delta-of-delta encoding reuses a base until drift exceeds a threshold
+- **Streaming quantization** (QuaRot, KIVI): Per-channel parameters reused across tokens until attention pattern shifts
+
+---
+
+## 2. SOTA Research Summary
+
+### 2.1 Groupwise Quantization (State of the Art 2024-2026)
+
+Modern quantization systems converge on **per-group symmetric quantization** as the optimal accuracy-metadata tradeoff:
+
+| System | Year | Approach | Key Innovation |
+|--------|------|----------|----------------|
+| **GPTQ** | 2023 | Per-column Hessian-weighted quantization | OBQ with lazy batch updates; group_size=128 standard |
+| **AWQ** | 2024 | Activation-aware weight quantization | Protects salient channels via per-channel scaling |
+| **SqueezeLLM** | 2024 | Non-uniform with sensitivity grouping | Dense-and-sparse decomposition for outliers |
+| **QuIP#** | 2024 | Incoherence via random Hadamard | Enables high-quality 2-bit with lattice codebooks |
+| **AQLM** | 2024 | Additive multi-codebook quantization | 2-bit with learned codebooks; beam search optimization |
+| **SpinQuant** | 2024 | Rotation-based Cayley optimization | Learnable rotation matrices; Llama-2-7B 4-bit = FP16 parity |
+| **KIVI** | 2024 | Per-channel key, per-token value | 2-bit KV cache with <0.1 ppl increase on Llama-2 |
+| **Atom** | 2024 | Mixed-precision with reordering | Handles activation outliers via channel reordering |
+
+**Consensus finding**: Group sizes of 32-128 provide the best accuracy-metadata tradeoff. Symmetric quantization (no zero-point) is sufficient when distribution is roughly centered, which holds for most intermediate tensors. The scale storage cost is `ceil(tensor_len / group_len) * sizeof(scale)`.
+
+### 2.2 Sub-4-Bit Quantization Viability
+
+| Bits | Compression vs f32 | Typical Quality Impact | Viable For |
+|------|-------------------|----------------------|------------|
+| 8 | 4.00x | Negligible (<0.01 ppl) | Hot path, full fidelity |
+| 7 | 4.57x | Negligible (<0.02 ppl) | Warm path, near-lossless |
+| 5 | 6.40x | Minor (0.05-0.1 ppl) | Warm path, acceptable loss |
+| 4 | 8.00x | Moderate (0.1-0.3 ppl) | Well-studied; GPTQ/AWQ standard |
+| 3 | 10.67x | Significant (0.3-1.0 ppl) | Cold path with bounded error |
+| 2 | 16.00x | Large (1.0-3.0 ppl) | Archive only; KIVI/QuIP# needed |
+
+**Key finding**: 3-bit symmetric quantization is the practical floor for reconstruction-required tensors. Below 3-bit, non-uniform or lattice codebook methods (QuIP#, AQLM) are needed to maintain quality, at much higher complexity.
+
+### 2.3 Temporal Scale Reuse
+
+No widely published system directly addresses temporal reuse of quantization scales for streaming tensor data. The closest analogs are:
+
+1. **Gorilla (Facebook, 2015)**: XOR-based delta encoding for time-series floats; reuses a base encoding until delta exceeds threshold
+2. **KIVI token reuse**: Per-channel scales for keys are computed once and applied to all tokens in the channel
+3. **QuaRot (2024)**: Rotation matrices computed once per layer, reused for all tokens
+4. **Streaming quantization in video**: DCT coefficients reused across P-frames until I-frame refresh
+
+Our temporal segment approach generalizes these: compute group scales once per segment, emit packed codes for each frame, start a new segment on tier change or drift exceedance.
+
+### 2.4 Bit-Packing Techniques
+
+Standard bitstream packing (accumulator + shift) is the established approach for arbitrary-width codes:
+
+```
+For each code of width B bits:
+  accumulator |= code << acc_bits
+  acc_bits += B
+  while acc_bits >= 8:
+    emit(accumulator & 0xFF)
+    accumulator >>= 8
+    acc_bits -= 8
+```
+
+**SIMD acceleration**: For fixed widths (3, 5, 7, 8), vectorized pack/unpack can process 16-32 codes per SIMD iteration using shuffles and masks. The `bitpacking` crate achieves 4-8 GB/s on AVX2 for fixed-width packing. For WASM, the 128-bit SIMD proposal (widely supported since 2023) enables similar throughput.
+
+### 2.5 Rust + WASM Performance Landscape
+
+| Aspect | Status (2026) |
+|--------|---------------|
+| wasm32-unknown-unknown | Stable, widely deployed |
+| WASM SIMD (128-bit) | Supported in all major browsers and runtimes |
+| wasm32-wasi | Stable, server-side WASM standard |
+| Linear memory model | Single contiguous address space; 32-bit pointers |
+| `#[no_mangle] extern "C"` | Standard FFI pattern for WASM exports |
+| Static mut in single-threaded WASM | Sound (no data races possible) but future-fragile |
+
+**Relevant Rust WASM tensor libraries**: candle (Hugging Face), burn, tract. All demonstrate that high-performance tensor operations are viable in Rust/WASM with careful memory management.
+
+---
+
+## 3. Decision
+
+### 3.1 Introduce Temporal Tensor Compression as a New Crate
+
+We introduce `ruvector-temporal-tensor` (with WASM variant `ruvector-temporal-tensor-wasm`) implementing:
+
+1. **Groupwise symmetric quantization** with f16 scales
+2. **Temporal segments** that amortize scales across frames
+3. **Three-tier access-driven bit-width selection** (8/7-or-5/3)
+4. **Bitstream packing** with no byte-alignment waste
+5. **WASM-compatible FFI** with handle-based resource management
+
+### 3.2 Architecture Overview
+
+```
++===========================================================================+
+|               TEMPORAL TENSOR COMPRESSION ARCHITECTURE                     |
++===========================================================================+
+|                                                                            |
+|  Input Frame (f32[N])                                                      |
+|       |                                                                    |
+|       v                                                                    |
+|  +----------------+     +-----------------+     +--------------------+     |
+|  | Tier Policy    |---->| Segment Manager |---->| Segment Store      |     |
+|  |                |     |                 |     | (Vec<u8> blobs)    |     |
+|  | score = count  |     | - drift check   |     |                    |     |
+|  |   * 1024 / age |     | - scale reuse   |     | Magic: TQTC        |     |
+|  |                |     | - bit-width sel  |     | Version: 1         |     |
+|  | Hot:  8-bit    |     |                 |     | Bits, GroupLen,     |     |
+|  | Warm: 7/5-bit  |     +---------+-------+     | TensorLen, Frames, |     |
+|  | Cold: 3-bit    |               |             | Scales[], Data[]   |     |
+|  +----------------+               |             +--------------------+     |
+|                                   v                                        |
+|  +----------------------------------------------------------------+       |
+|  |                    QUANTIZATION PIPELINE                        |       |
+|  |                                                                 |       |
+|  |  f32 values                                                     |       |
+|  |    |                                                            |       |
+|  |    v                                                            |       |
+|  |  [Group 0: max_abs -> scale_f16] [Group 1: ...] [Group K: ...] |       |
+|  |    |                                                            |       |
+|  |    v                                                            |       |
+|  |  q_i = round(v_i / scale)    // symmetric, no zero-point       |       |
+|  |  q_i = clamp(q_i, -qmax, +qmax)                                |       |
+|  |    |                                                            |       |
+|  |    v                                                            |       |
+|  |  u_i = q_i + bias            // signed -> unsigned mapping      |       |
+|  |    |                                                            |       |
+|  |    v                                                            |       |
+|  |  [Bitstream Packer: B-bit codes, no alignment padding]          |       |
+|  +----------------------------------------------------------------+       |
+|                                                                            |
+|  Decode: bitstream unpack -> unsigned -> signed -> scale multiply          |
++===========================================================================+
+```
+
+### 3.3 Segment Binary Format
+
+```
+Offset  Size    Field           Description
+------  ------  --------------- -----------------------------------------
+0       4       magic           0x43545154 ("TQTC" in LE ASCII)
+4       1       version         Format version (currently 1)
+5       1       bits            Bit width for this segment (3, 5, 7, or 8)
+6       4       group_len       Elements per quantization group
+10      4       tensor_len      Number of f32 elements per frame
+14      4       frame_count     Number of frames in this segment
+18      4       scale_count     Number of f16 group scales
+22      2*S     scales          f16 scale values (S = scale_count)
+22+2S   4       data_len        Length of packed bitstream in bytes
+26+2S   D       data            Packed quantized codes (D = data_len)
+```
+
+**Segment size formula:**
+```
+segment_bytes = 26 + 2*ceil(tensor_len/group_len) + ceil(tensor_len * frame_count * bits / 8)
+```
+
+### 3.4 Tier Policy Design
+
+```
+Score = access_count * 1024 / (now_ts - last_access_ts + 1)
+
+Tier 1 (Hot):   score >= hot_min_score   -> 8-bit  (~4.0x compression)
+Tier 2 (Warm):  score >= warm_min_score  -> 7-bit  (~4.57x) or 5-bit (~6.4x)
+Tier 3 (Cold):  score < warm_min_score   -> 3-bit  (~10.67x compression)
+```
+
+**Default thresholds:**
+
+| Parameter | Default | Rationale |
+|-----------|---------|-----------|
+| `hot_min_score` | 512 | ~2 accesses/sec for recent data |
+| `warm_min_score` | 64 | ~1 access every 16 seconds |
+| `warm_bits` | 7 | Conservative warm tier; set to 5 for aggressive |
+| `drift_pct_q8` | 26 | ~10.2% drift tolerance (26/256) |
+| `group_len` | 64 | 64 elements per group; 128 bytes of f16 scales per 256 values |
+
+**Drift detection**: Before appending a frame to the current segment, compute `max_abs` per group and compare against `scale * qmax * drift_factor`. If any group exceeds this, flush the current segment and start a new one with recomputed scales. This bounds reconstruction error to `drift_factor * original_error`.
+
+### 3.5 Compression Math
+
+Effective compression ratios including scale overhead (group_len=64, f16 scales):
+
+| Bits | Raw Ratio | Scale Overhead | Effective Ratio | Effective Ratio (100 frames) |
+|------|-----------|----------------|-----------------|------------------------------|
+| 8 | 4.00x | 1 f16 per 64 vals | 3.76x | 3.99x |
+| 7 | 4.57x | same | 4.27x | 4.56x |
+| 5 | 6.40x | same | 5.82x | 6.38x |
+| 3 | 10.67x | same | 9.14x | 10.63x |
+
+Temporal amortization: with 100 frames per segment, scale overhead becomes negligible (~0.03% of segment size).
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module Architecture
+
+```
+crates/ruvector-temporal-tensor/
+├── Cargo.toml
+└── src/
+    ├── lib.rs              # Public API, re-exports
+    ├── tier_policy.rs      # TierPolicy: score calculation, tier selection
+    ├── f16.rs              # Software f32<->f16 conversion (no external deps)
+    ├── bitpack.rs          # Bitstream packer/unpacker for arbitrary widths
+    ├── quantizer.rs        # Groupwise symmetric quantization + dequantization
+    ├── segment.rs          # Segment encode/decode, binary format
+    ├── compressor.rs       # TemporalTensorCompressor: drift, segmentation
+    └── ffi.rs              # WASM/C FFI: handle store, extern "C" exports
+
+crates/ruvector-temporal-tensor-wasm/
+├── Cargo.toml              # wasm32-unknown-unknown target
+└── src/
+    └── lib.rs              # Re-exports FFI functions, WASM-specific config
+```
+
+### 4.2 Groupwise Symmetric Quantization
+
+For a group of `G` values from frame `f`:
+
+```
+scale = max(|v_i| for i in group) / qmax
+qmax  = 2^(bits-1) - 1      // e.g., bits=8 -> qmax=127, bits=3 -> qmax=3
+q_i   = round(v_i / scale)
+q_i   = clamp(q_i, -qmax, +qmax)
+u_i   = q_i + qmax           // bias to unsigned for packing
+```
+
+Reconstruction:
+```
+q_i   = u_i - qmax           // unbias
+v_i'  = q_i * scale          // dequantize
+```
+
+**Why symmetric**: No zero-point storage needed. For centered distributions (which agent tensors typically are), symmetric quantization loses minimal accuracy vs asymmetric while halving metadata and simplifying the dequantize multiply.
+
+**Why f16 scales**: 2 bytes per group vs 4 bytes for f32. For typical tensor magnitudes (1e-3 to 1e3), f16 provides sufficient precision for scales. The f16 dynamic range (6.1e-5 to 65504) covers the relevant scale values. Software f16 conversion is fast (~5ns per conversion) and avoids external crate dependencies.
+
+### 4.3 Temporal Segment Lifecycle
+
+```
+  Frame 0       Frame 1       Frame 2       ...       Frame K       Frame K+1
+  ┌─────┐       ┌─────┐       ┌─────┐                 ┌─────┐       ┌─────┐
+  │ f32 │       │ f32 │       │ f32 │                 │ f32 │       │ f32 │
+  └──┬──┘       └──┬──┘       └──┬──┘                 └──┬──┘       └──┬──┘
+     │              │              │                       │              │
+     v              v              v                       v              v
+  ┌────────────────────────────────────────────────────────┐       ┌──────────
+  │              SEGMENT 1 (same scales)                   │       │ SEGMENT 2
+  │                                                        │       │ (new
+  │  scales: [s0, s1, ..., sG]  (computed from frame 0)   │       │  scales)
+  │  data:   [packed frame 0][packed frame 1]...[frame K]  │       │
+  └────────────────────────────────────────────────────────┘       └──────────
+                                                     ^
+                                                     |
+                                              Drift exceeded OR
+                                              tier changed at K+1
+```
+
+**Segment boundary triggers:**
+1. First frame (no active segment)
+2. Tier bit-width changed (e.g., tensor went from hot to warm)
+3. Any group's `max_abs > scale * qmax * drift_factor`
+
+### 4.4 Drift Detection Algorithm
+
+```rust
+fn frame_fits_current_scales(frame, scales, qmax, drift_factor) -> bool {
+    for each group (idx, scale) in scales:
+        max_abs = max(|v| for v in group_slice(frame, idx))
+        allowed = f16_to_f32(scale) * qmax * drift_factor
+        if max_abs > allowed:
+            return false  // Distribution has drifted
+    return true
+}
+```
+
+The `drift_factor` is `1 + drift_pct_q8/256`. With `drift_pct_q8=26`, this is `1.1015625` (~10% tolerance). This means a group's maximum absolute value can grow by up to ~10% beyond the original calibration before triggering a new segment.
+
+**Tradeoff**: Lower drift tolerance = more segment boundaries = more accurate but more metadata. Higher drift tolerance = fewer segments = better compression but more quantization error. The 10% default is conservative; for cold tensors, 20-30% may be acceptable.
+
+### 4.5 Bit-Packing Implementation
+
+The packer uses a 64-bit accumulator for sub-byte codes:
+
+```
+For each quantized unsigned code u of width B bits:
+    acc |= (u as u64) << acc_bits
+    acc_bits += B
+    while acc_bits >= 8:
+        emit byte: acc & 0xFF
+        acc >>= 8
+        acc_bits -= 8
+// After all codes: flush remaining bits
+if acc_bits > 0:
+    emit byte: acc & 0xFF
+```
+
+**Packing density** (no wasted bits):
+
+| Bits | Codes per 8 bytes | Utilization |
+|------|-------------------|-------------|
+| 8 | 8 | 100% |
+| 7 | 9.14 | 100% (no padding) |
+| 5 | 12.8 | 100% (no padding) |
+| 3 | 21.33 | 100% (no padding) |
+
+### 4.6 f16 Software Conversion
+
+The implementation provides bit-exact IEEE 754 half-precision conversion without external crates:
+
+- **f32 -> f16**: Extract sign/exponent/mantissa, remap exponent bias (127 -> 15), handle denormals with rounding, infinity, NaN propagation
+- **f16 -> f32**: Reverse the bias remapping, reconstruct denormals, handle special values
+
+**Accuracy**: Round-to-nearest-even for normals. Denormal handling preserves gradual underflow. The conversion pair is not bit-exact round-trip for all f32 values (f16 has 10 mantissa bits vs f32's 23), but for scale values in the range [1e-4, 1e4], relative error is bounded by 2^-10 (~0.1%).
+
+### 4.7 WASM FFI Design
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    WASM Linear Memory                │
+│                                                      │
+│  Host allocates via ttc_alloc()                      │
+│  Host writes f32 frames into allocated buffers       │
+│  Host calls ttc_push_frame(handle, ts, ptr, len,     │
+│             out_ptr, out_cap, &out_written)           │
+│  Host reads segment bytes from out_ptr               │
+│  Host frees via ttc_dealloc()                        │
+│                                                      │
+│  ┌──────────────────────────────┐                    │
+│  │ STORE: Vec<Option<Compressor>>│                   │
+│  │  [0] = Some(comp_a)          │                    │
+│  │  [1] = None (freed)          │                    │
+│  │  [2] = Some(comp_b)          │                    │
+│  └──────────────────────────────┘                    │
+└─────────────────────────────────────────────────────┘
+```
+
+**FFI function table:**
+
+| Function | Purpose | Parameters |
+|----------|---------|------------|
+| `ttc_create` | Create compressor | `(len, now_ts, &out_handle)` |
+| `ttc_free` | Destroy compressor | `(handle)` |
+| `ttc_touch` | Record access | `(handle, now_ts)` |
+| `ttc_set_access` | Set access stats | `(handle, count, last_ts)` |
+| `ttc_push_frame` | Compress a frame | `(handle, ts, in_ptr, len, out_ptr, out_cap, &out_written)` |
+| `ttc_flush` | Flush current segment | `(handle, out_ptr, out_cap, &out_written)` |
+| `ttc_decode_segment` | Decompress segment | `(seg_ptr, seg_len, out_ptr, out_cap, &out_written)` |
+| `ttc_alloc` | Allocate WASM memory | `(size, &out_ptr)` |
+| `ttc_dealloc` | Free WASM memory | `(ptr, cap)` |
+
+**Handle-based store**: Compressors are stored in a global `Vec<Option<TemporalTensorCompressor>>`. Handles are indices. Freed slots are reused. This pattern is standard for WASM FFI where the host cannot hold Rust references.
+
+---
+
+## 5. Integration with RuVector
+
+### 5.1 Crate Dependency Graph
+
+```
+ruvector-temporal-tensor
+    (no external deps - pure Rust, WASM-safe)
+
+ruvector-temporal-tensor-wasm
+    └── ruvector-temporal-tensor
+
+ruvector-core (future integration)
+    └── ruvector-temporal-tensor (optional feature)
+         extends QuantizedVector trait
+```
+
+### 5.2 AgenticDB Integration
+
+Compressed segments are stored as byte blobs in AgenticDB, keyed by:
+```
+Key:   {tensor_id}:{segment_start_ts}:{segment_end_ts}
+Value: segment bytes (TQTC format)
+Tags:  tier={hot|warm|cold}, bits={3|5|7|8}, frames={N}
+```
+
+AgenticDB's HNSW index is not used for segment lookup (segments are accessed by time range, not similarity). Instead, a B-tree or time-range index over segment keys provides O(log N) lookup.
+
+### 5.3 Coherence Engine Integration
+
+The coherence engine (ADR-014, ADR-015) can trigger segment boundaries via a **coherence-gated refresh**:
+
+```
+if coherence_score(tensor_id) < coherence_threshold:
+    compressor.flush()  // Force segment boundary
+    // New segment will recompute scales from fresh data
+```
+
+This ensures that when the coherence engine detects structural disagreement (e.g., between an agent's embedding and the graph's expected embedding), the compression system refreshes its calibration even if drift is still within the numerical threshold.
+
+### 5.4 Graph Lineage
+
+Each segment can be represented as a node in RuVector's DAG (ADR-016 delta system):
+- **Edges**: `tensor_id -> segment_1 -> segment_2 -> ...` (temporal lineage)
+- **Metadata**: Which agent/workflow produced the tensor, tier at time of compression
+- **Provenance**: Full reconstruction path from segments back to original f32 data
+
+---
+
+## 6. Implementation Review and Safety Analysis
+
+### 6.1 Correctness Assessment
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Groupwise symmetric quant | Correct | `qmax = 2^(bits-1) - 1`; symmetric range [-qmax, +qmax] |
+| f16 conversion | Correct with caveats | Rounding mode is round-half-up (not round-half-even); acceptable for scales |
+| Bit-packing | Correct | 64-bit accumulator handles all widths 1-8 without overflow |
+| Drift detection | Correct | Per-group max-abs comparison against scaled threshold |
+| Segment encode/decode | Correct | Round-trip verified for all tier widths |
+| Bias mapping | Correct | `bias = qmax`; unsigned range is `[0, 2*qmax]` which fits in `bits` bits |
+
+### 6.2 Safety Analysis
+
+| Pattern | Risk | Mitigation |
+|---------|------|------------|
+| `static mut STORE` | UB in multi-threaded context | WASM is single-threaded; safe in practice. Migrate to `thread_local!` or `OnceCell` for native targets. |
+| `from_raw_parts` in FFI | UB if host passes invalid pointers | Host is responsible for valid pointers; standard WASM FFI contract. Add debug assertions. |
+| `std::mem::forget` in `ttc_alloc` | Memory managed by host | Correct pattern; host calls `ttc_dealloc` to reconstruct and drop the Vec. |
+| Null pointer checks | Partial | FFI functions check `out_written.is_null()` but not all `out_ptr`. Add null checks. |
+
+**Recommended safety improvements for production:**
+1. Replace `static mut` with `thread_local!` for native target compatibility
+2. Add `#[cfg(debug_assertions)]` bounds checks in decode loops
+3. Validate segment magic/version before parsing
+4. Add `ttc_last_error` function for error reporting to host
+
+### 6.3 Performance Characteristics
+
+| Operation | Complexity | Estimated Latency (512-dim tensor) |
+|-----------|------------|-----------------------------------|
+| Tier selection | O(1) | <10ns |
+| Drift check | O(N/G) where G=group_len | ~50ns |
+| Scale computation | O(N) | ~100ns |
+| Quantize + pack | O(N) | ~200ns |
+| Decode + unpack | O(N) | ~200ns |
+| f16 conversion | O(1) per scale | ~5ns |
+
+**SIMD opportunity**: The inner quantize loop (`v * inv_scale`, round, clamp, pack) is highly vectorizable. With WASM SIMD (128-bit), processing 4 f32s per iteration yields ~4x speedup on the hot loop.
+
+---
+
+## 7. Alternatives Considered
+
+### 7.1 Extend Existing ruvector-core Quantization
+
+**Rejected**: The existing `QuantizedVector` trait assumes single-frame quantization with per-vector scales. Temporal segments require fundamentally different state management (multi-frame, drift-aware). Adding this to `ruvector-core` would violate single-responsibility and complicate the existing, well-tested code.
+
+### 7.2 Use GPTQ/AWQ-style Weight Quantization
+
+**Rejected**: GPTQ and AWQ are designed for static weight quantization with Hessian-based sensitivity. Our use case is streaming activations/embeddings that change every frame. The calibration cost of GPTQ (~minutes per layer) is prohibitive for real-time streams.
+
+### 7.3 Delta Encoding Between Frames
+
+**Considered but deferred**: XOR-based or arithmetic delta encoding (frame[t] - frame[t-1]) could further compress within a segment. However, this adds complexity and makes random access within a segment O(N) instead of O(1). We may add this as an optional mode in a future version.
+
+### 7.4 Asymmetric Quantization
+
+**Rejected for default**: Asymmetric quantization (with zero-point) adds 2 bytes of metadata per group and requires an additional subtraction in the dequantize path. For centered distributions (typical of embeddings and activations), the accuracy improvement is marginal (<0.5% relative error reduction) while the metadata cost is significant at small group sizes.
+
+### 7.5 Using the `half` Crate for f16
+
+**Rejected**: Adding an external dependency for f16 conversion would complicate WASM builds and increase binary size. The software f16 conversion is ~50 lines and has no performance-critical path (scales are converted once per segment, not per frame).
+
+---
+
+## 8. Acceptance Criteria
+
+### 8.1 Compression Targets
+
+| Tier | Bits | Target Compression (vs f32) | Measurement |
+|------|------|-----------------------------|-------------|
+| Hot | 8 | >= 3.7x (single frame), >= 3.99x (100 frames) | Segment size / raw f32 size |
+| Warm (7-bit) | 7 | >= 4.2x (single frame), >= 4.56x (100 frames) | Same |
+| Warm (5-bit) | 5 | >= 5.8x (single frame), >= 6.38x (100 frames) | Same |
+| Cold | 3 | >= 9.0x (single frame), >= 10.6x (100 frames) | Same |
+
+**Primary target**: On a representative 1-hour trace, achieve **>= 6x** reduction for warm tensors and **>= 10x** for cold tensors in resident bytes.
+
+### 8.2 Accuracy Targets
+
+| Tier | Max Relative Error | Measurement |
+|------|-------------------|-------------|
+| Hot (8-bit) | < 0.8% | max(|v - v'|) / max(|v|) per frame |
+| Warm (7-bit) | < 1.6% | Same |
+| Warm (5-bit) | < 6.5% | Same |
+| Cold (3-bit) | < 30% | Same; bounded error, not bit-exact |
+
+### 8.3 Performance Targets
+
+| Metric | Target |
+|--------|--------|
+| Quantize latency (512-dim, native) | < 500ns per frame |
+| Quantize latency (512-dim, WASM) | < 2us per frame |
+| Decode latency (512-dim, native) | < 500ns per frame |
+| WASM binary size | < 100KB (release, wasm-opt) |
+| Memory overhead per compressor | < 1KB + segment data |
+
+### 8.4 Functional Requirements
+
+- [ ] Round-trip encode/decode produces correct results for all tier widths (3, 5, 7, 8)
+- [ ] Drift detection correctly triggers segment boundaries
+- [ ] Tier transitions produce valid segment boundaries
+- [ ] Multiple compressors can coexist via handle system
+- [ ] Segment binary format is platform-independent (little-endian)
+- [ ] WASM FFI functions handle null pointers and size mismatches gracefully
+- [ ] No external crate dependencies in core library
+
+---
+
+## 9. Risks and Mitigations
+
+| Risk | Severity | Likelihood | Mitigation |
+|------|----------|------------|------------|
+| 3-bit quantization too lossy for some tensor types | High | Medium | Make tier policy configurable; allow per-tensor overrides; add quality monitoring |
+| Drift detection false positives cause excessive segments | Medium | Medium | Tune drift_pct_q8; add hysteresis (require N consecutive drifts) |
+| f16 scale precision insufficient for very small tensors | Medium | Low | Detect near-zero scales; fall back to f32 scales when f16 underflows |
+| WASM performance 3-5x slower than native | Medium | High | Expected; optimize hot loops with WASM SIMD; acceptable for non-realtime paths |
+| `static mut` unsound if WASM threading arrives | Low | Low | Replace with `thread_local!` or atomic cell before enabling shared memory |
+| Segment format not forward-compatible | Medium | Low | Version field enables format evolution; decode rejects unknown versions |
+
+---
+
+## 10. Open Questions
+
+1. **Typical tensor dimensions**: What are the representative dimensions for RuVector agent tensors? (Impacts group_len tuning and SIMD strategy)
+2. **Update frequency**: How many frames per second for hot vs warm vs cold tensors? (Impacts segment size expectations)
+3. **Cold tier error tolerance**: Is bounded relative error (up to 30% at 3-bit) acceptable, or do some cold tensors need bit-exact reversibility?
+4. **Integration priority**: Should AgenticDB integration (segment storage) or coherence engine integration (drift gating) come first?
+5. **SIMD tier**: Should the initial implementation include WASM SIMD, or start scalar-only and add SIMD in a follow-up?
+
+---
+
+## 11. Implementation Roadmap
+
+### Phase 1: Core Engine (Week 1-2)
+- [ ] Create `ruvector-temporal-tensor` crate with zero dependencies
+- [ ] Implement `tier_policy.rs`, `f16.rs`, `bitpack.rs`, `quantizer.rs`
+- [ ] Implement `segment.rs` (encode/decode) and `compressor.rs`
+- [ ] Unit tests: round-trip correctness for all bit widths
+- [ ] Unit tests: drift detection boundary conditions
+- [ ] Unit tests: segment binary format parsing
+
+### Phase 2: WASM FFI (Week 2-3)
+- [ ] Implement `ffi.rs` with handle-based store
+- [ ] Create `ruvector-temporal-tensor-wasm` crate
+- [ ] WASM integration tests via wasm-pack
+- [ ] Binary size validation (< 100KB target)
+- [ ] Performance benchmarks (native vs WASM)
+
+### Phase 3: Integration (Week 3-4)
+- [ ] AgenticDB segment storage adapter
+- [ ] Coherence engine refresh hook
+- [ ] DAG lineage edges for segments
+- [ ] End-to-end benchmark on representative trace
+- [ ] Acceptance test: 6x warm, 10x cold compression
+
+### Phase 4: Optimization (Week 4+)
+- [ ] WASM SIMD for quantize/dequantize hot loops
+- [ ] Native AVX2/NEON specialization
+- [ ] Optional delta encoding within segments
+- [ ] Streaming decode (partial segment access)
+- [ ] Add to workspace `Cargo.toml`
+
+---
+
+## 12. References
+
+1. Frantar, E., et al. "GPTQ: Accurate Post-Training Quantization for Generative Pre-trained Transformers." ICLR 2023.
+2. Lin, J., et al. "AWQ: Activation-aware Weight Quantization for LLM Compression and Acceleration." MLSys 2024.
+3. Kim, S., et al. "SqueezeLLM: Dense-and-Sparse Quantization." ICML 2024.
+4. Chee, J., et al. "QuIP#: Even Better LLM Quantization with Hadamard Incoherence and Lattice Codebooks." ICML 2024.
+5. Egiazarian, V., et al. "AQLM: Extreme Compression of Large Language Models via Additive Quantization." ICML 2024.
+6. Liu, Z., et al. "KIVI: A Tuning-Free Asymmetric 2bit Quantization for KV Cache." ICML 2024.
+7. Zhao, Y., et al. "Atom: Low-bit Quantization for Efficient and Accurate LLM Serving." MLSys 2024.
+8. Liu, R., et al. "SpinQuant: LLM Quantization with Learned Rotations." NeurIPS 2024.
+9. Ma, S., et al. "The Era of 1-bit LLMs: All Large Language Models are in 1.58 Bits." arXiv:2402.17764, 2024.
+10. Pelkonen, T., et al. "Gorilla: A Fast, Scalable, In-Memory Time Series Database." VLDB 2015.
+11. Ashkboos, S., et al. "QuaRot: Outlier-Free 4-Bit Inference in Rotated LLMs." NeurIPS 2024.
+
+---
+
+## Appendix A: Compression Ratio Derivation
+
+For a tensor of dimension `N` with group size `G`, bit width `B`, and `F` frames per segment:
+
+```
+raw_size    = N * 4 * F                              // f32 bytes per segment
+scale_size  = ceil(N/G) * 2                           // f16 scales (shared across frames)
+header_size = 26                                      // fixed segment header
+data_size   = ceil(N * F * B / 8)                     // packed bitstream
+segment_size = header_size + scale_size + data_size
+
+compression_ratio = raw_size / segment_size
+```
+
+**Example**: N=512, G=64, B=3, F=100:
+```
+raw_size    = 512 * 4 * 100         = 204,800 bytes
+scale_size  = ceil(512/64) * 2      = 16 bytes
+header_size = 26                     = 26 bytes
+data_size   = ceil(512 * 100 * 3/8) = 19,200 bytes
+segment_size = 26 + 16 + 19,200     = 19,242 bytes
+
+ratio = 204,800 / 19,242 = 10.64x
+```
+
+## Appendix B: Tier Score Examples
+
+| Scenario | access_count | age (ticks) | Score | Tier |
+|----------|-------------|-------------|-------|------|
+| Actively used | 100 | 10 | 10,240 | Hot (8-bit) |
+| Recently used | 50 | 100 | 512 | Hot (8-bit) |
+| Moderate use | 10 | 100 | 102 | Warm (7-bit) |
+| Infrequent | 5 | 200 | 25 | Cold (3-bit) |
+| Stale | 1 | 1000 | 1 | Cold (3-bit) |
+
+## Appendix C: Error Bound Analysis
+
+For symmetric quantization with bit width `B` and group scale `s`:
+
+```
+quantization_step = s / qmax = s / (2^(B-1) - 1)
+max_error         = quantization_step / 2        // from rounding
+relative_error    = max_error / s = 1 / (2 * qmax)
+```
+
+| Bits | qmax | Max Relative Error |
+|------|------|--------------------|
+| 8 | 127 | 0.39% |
+| 7 | 63 | 0.79% |
+| 5 | 15 | 3.33% |
+| 3 | 3 | 16.7% |
+
+Note: These are worst-case per-element errors. RMS error across a group is typically sqrt(1/12) * quantization_step, which is ~0.29x the max error.


### PR DESCRIPTION
Introduces a complete temporal tensor compression system with:

- ADR-017: SOTA research-backed architecture decision record covering
  groupwise symmetric quantization, temporal segment reuse, access-pattern
  driven tier selection (8/7/5/3 bit), and WASM-compatible design

- ruvector-temporal-tensor crate (zero external dependencies):
  - tier_policy: Score-based hot/warm/cold bit-width selection
  - f16: Software IEEE 754 half-precision conversion
  - bitpack: Arbitrary bit-width stream packing (no alignment waste)
  - quantizer: Groupwise symmetric quantization with f16 scales
  - segment: Binary segment format (TQTC) encode/decode
  - compressor: Temporal segment manager with drift detection
  - ffi: WASM/C FFI with handle-based resource management

- ruvector-temporal-tensor-wasm crate for wasm32 targets

- 33 passing unit tests covering all modules

Compression targets: 4x (hot/8-bit), 4.57x (warm/7-bit),
6.4x (warm/5-bit), 10.67x (cold/3-bit) vs f32 baseline.

https://claude.ai/code/session_01U63xtGd5Q8mUevyY7nUSfJ