### PR TITLE
fix(esm): add .js extensions to dist module specifiers for Node.js ESM compatibility

### DIFF
--- a/npm/packages/rudag/src/index.ts
+++ b/npm/packages/rudag/src/index.ts
@@ -13,7 +13,7 @@ export {
   type DagEdge,
   type CriticalPath,
   type RuDagOptions,
-} from './dag';
+} from './dag.js';
 
 export {
   DagStorage,
@@ -22,7 +22,7 @@ export {
   isIndexedDBAvailable,
   type StoredDag,
   type DagStorageOptions,
-} from './storage';
+} from './storage.js';
 
 // Version info
 export const VERSION = '0.1.0';

--- a/npm/packages/rudag/src/node.ts
+++ b/npm/packages/rudag/src/node.ts
@@ -4,9 +4,9 @@
  * @security Path traversal prevention via ID validation
  */
 
-export * from './index';
+export * from './index.js';
 
-import { RuDag, MemoryStorage } from './index';
+import { RuDag, MemoryStorage } from './index.js';
 import { promises as fs } from 'fs';
 import { join, normalize, resolve } from 'path';
 


### PR DESCRIPTION
## Problem

When consuming `@ruvector/rudag` from a Node.js ESM project (`"type": "module"`), the bare relative specifiers in the compiled dist files cause resolution failures:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../node_modules/@ruvector/rudag/dist/index'
```

Node.js ESM (per the [ESM specification](https://nodejs.org/api/esm.html#mandatory-file-extensions)) **requires explicit file extensions** in relative imports — bare `./index` is not resolved to `./index.js` automatically.

## Root Cause

Three relative imports in the TypeScript sources were missing `.js` extensions:

| File | Bare specifier | Fixed specifier |
|------|---------------|-----------------|
| `src/index.ts` | `from './dag'` | `from './dag.js'` |
| `src/index.ts` | `from './storage'` | `from './storage.js'` |
| `src/node.ts` | `export * from './index'` | `export * from './index.js'` |
| `src/node.ts` | `import ... from './index'` | `import ... from './index.js'` |

TypeScript with `"moduleResolution": "bundler"` or `"NodeNext"` requires `.js` extensions in source imports that resolve to `.js` in the output. The current `tsconfig.esm.json` emits to `./dist` as ESM but uses the base tsconfig's `"moduleResolution": "node"` which does not enforce this — resulting in broken output for ESM consumers.

## Fix

Added explicit `.js` extensions to all relative imports in the two affected source files. This is consistent with TypeScript's [recommended practice for ESM](https://www.typescriptlang.org/docs/handbook/esm-node.html) and with how `dist/dag.js` and `dist/index.js` already correctly reference `./storage.js` and `./dag.js`.

## Verification

After rebuilding (`npm run build:ts` in `npm/packages/rudag`), the dist files will contain correct ESM specifiers. Consumers can verify with:

```bash
node --input-type=module --eval "import { RuDag } from '@ruvector/rudag/node';"
```

## Context

Discovered via a `patch-package` workaround in a downstream consumer — the patch has been in place since v0.1.1 and covers exactly these three files. This PR eliminates the need for that patch.