### PR TITLE
security: fix vulnerable transitive npm dependencies

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -28,5 +28,12 @@
   "engines": {
     "node": ">=18.0.0",
     "npm": ">=9.0.0"
+  },
+  "overrides": {
+    "node-forge": ">=1.4.0",
+    "flatted": ">=3.3.3",
+    "picomatch": ">=4.0.3",
+    "lodash": ">=4.17.22",
+    "brace-expansion": ">=2.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- Add npm `overrides` in `npm/package.json` to pin vulnerable transitive dependencies to safe versions
- Fixes: node-forge (CVE-2026-33891–33896), flatted (CVE-2026-32141, CVE-2026-33228), picomatch (CVE-2026-33671–33672), lodash (CVE-2026-4800, CVE-2026-2950), brace-expansion (CVE-2026-33750)

## Context
These were flagged by Dependabot in the downstream consumer `BAS-More/RuView` which uses ruvector as a git submodule.

## Test plan
- [ ] `cd npm && npm install` resolves without errors
- [ ] `npm audit` shows no high/critical vulnerabilities from overridden packages

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)