### PR TITLE
fix(docs): correct ADR cross-references in ADR-006 Related field

### DIFF
--- a/docs/adr/ADR-006-memory-management.md
+++ b/docs/adr/ADR-006-memory-management.md
@@ -7,7 +7,7 @@
 | **Authors** | Architecture Team |
 | **Reviewers** | Performance Engineering, ML Infrastructure |
 | **Supersedes** | None |
-| **Related** | ADR-003 (KV Cache), ADR-005 (LoRA Adapter Loading) |
+| **Related** | ADR-004 (KV Cache), ADR-005 (WASM Runtime Integration) |
 
 **Note**: The memory pool and paging strategy described here is complemented by ADR-029. The RVF segment model provides memory management through append-only segments with temperature-tiered quantization.
 


### PR DESCRIPTION
## Summary

- `ADR-003 (KV Cache)` was wrong — ADR-003 is **SIMD Optimization Strategy**; KV Cache is **ADR-004**
- `ADR-005 (LoRA Adapter Loading)` was wrong — ADR-005 is **WASM Runtime Integration**; no dedicated LoRA Adapter Loading ADR exists in the repo

The bottom "Related Decisions" section of the same file already correctly referenced ADR-004, making the frontmatter table internally inconsistent.

## Changes

`docs/adr/ADR-006-memory-management.md` — one line in the frontmatter table:

```
- | **Related** | ADR-003 (KV Cache), ADR-005 (LoRA Adapter Loading) |
+ | **Related** | ADR-004 (KV Cache), ADR-005 (WASM Runtime Integration) |
```

## Test plan

- [ ] Verify ADR-003 title: SIMD Optimization Strategy
- [ ] Verify ADR-004 title: KV Cache Management Strategy
- [ ] Verify ADR-005 title: WASM Runtime Integration
- [ ] Confirm no other ADRs reference the old incorrect cross-links

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)