### PR TITLE
fix(hooks): use $CLAUDE_PROJECT_DIR instead of hardcoded devcontainer path

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node /workspaces/ruvector/.claude/helpers/hook-handler.cjs pre-bash",
+            "command": "node $CLAUDE_PROJECT_DIR/.claude/helpers/hook-handler.cjs pre-bash",
             "timeout": 5000
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node /workspaces/ruvector/.claude/helpers/hook-handler.cjs post-edit",
+            "command": "node $CLAUDE_PROJECT_DIR/.claude/helpers/hook-handler.cjs post-edit",
             "timeout": 10000
           }
         ]
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node /workspaces/ruvector/.claude/helpers/hook-handler.cjs route",
+            "command": "node $CLAUDE_PROJECT_DIR/.claude/helpers/hook-handler.cjs route",
             "timeout": 10000
           }
         ]
@@ -41,13 +41,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node /workspaces/ruvector/.claude/helpers/hook-handler.cjs session-restore",
+            "command": "node $CLAUDE_PROJECT_DIR/.claude/helpers/hook-handler.cjs session-restore",
             "timeout": 15000,
             "continueOnError": true
           },
           {
             "type": "command",
-            "command": "node /workspaces/ruvector/.claude/helpers/auto-memory-hook.mjs import",
+            "command": "node $CLAUDE_PROJECT_DIR/.claude/helpers/auto-memory-hook.mjs import",
             "timeout": 8000,
             "continueOnError": true
           }
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node /workspaces/ruvector/.claude/helpers/hook-handler.cjs session-end",
+            "command": "node $CLAUDE_PROJECT_DIR/.claude/helpers/hook-handler.cjs session-end",
             "timeout": 10000,
             "continueOnError": true
           }
@@ -71,7 +71,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node /workspaces/ruvector/.claude/helpers/auto-memory-hook.mjs sync",
+            "command": "node $CLAUDE_PROJECT_DIR/.claude/helpers/auto-memory-hook.mjs sync",
             "timeout": 10000,
             "continueOnError": true
           }
@@ -83,7 +83,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node /workspaces/ruvector/.claude/helpers/hook-handler.cjs status",
+            "command": "node $CLAUDE_PROJECT_DIR/.claude/helpers/hook-handler.cjs status",
             "timeout": 3000,
             "continueOnError": true
           }
@@ -93,7 +93,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "node /workspaces/ruvector/.claude/helpers/statusline.cjs",
+    "command": "node $CLAUDE_PROJECT_DIR/.claude/helpers/statusline.cjs",
     "refreshMs": 5000,
     "enabled": true
   },


### PR DESCRIPTION
## Summary

- Replace hardcoded `/workspaces/ruvector/` with `$CLAUDE_PROJECT_DIR` in all 9 hook commands and the `statusLine` command in `.claude/settings.json`.
- `$CLAUDE_PROJECT_DIR` is set automatically by Claude Code to the project root at hook-firing time, so it works identically in Codespaces, devcontainers, and local clones.

## Why

The hardcoded path only resolves inside this project's Codespaces/devcontainer. On any normal local clone, every hook fails on startup with `MODULE_NOT_FOUND`, silently disabling the entire claude-flow V3 coordination layer (`UserPromptSubmit` routing, `SessionStart`/`SessionEnd` restore, `PostToolUse` learning, `auto-memory` sync, statusline — 9 hooks total).

This means every non-Codespaces contributor:
1. Sees noisy `MODULE_NOT_FOUND` stack traces on every turn.
2. Runs with the project's advertised coordination layer silently broken.
3. Gets a poor first impression of the very hooks-automation system RuVector ships.

Fixes #359

## Test plan

- [x] `echo '{}' | CLAUDE_PROJECT_DIR=$(pwd) node .claude/helpers/hook-handler.cjs session-end` → exits 0
- [x] Same manual check run for all 5 `hook-handler.cjs` subcommands (`pre-bash`, `post-edit`, `route`, `session-restore`, `session-end`, `status`) → all exit 0
- [x] `auto-memory-hook.mjs import` and `sync` → exit 0
- [x] `statusline.cjs` → renders status line correctly
- [x] Verified in a live Claude Code session on a local clone at `~/code/utilities/ruvector` — the previously-failing `SessionEnd` and `UserPromptSubmit` hooks now fire cleanly
- [ ] Maintainer verifies hooks still fire correctly inside Codespaces/devcontainer (should be a no-op since `$CLAUDE_PROJECT_DIR` resolves to `/workspaces/ruvector` there)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)