### PR TITLE
chore: import shaal/VectorVroom as submodule under examples/

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples/vectorvroom"]
+	path = examples/vectorvroom
+	url = https://github.com/shaal/VectorVroom.git


### PR DESCRIPTION
## Summary

Imports [shaal/VectorVroom](https://github.com/shaal/VectorVroom) as a git submodule under `examples/vectorvroom`. VectorVroom is a browser-based genetic-algorithm car racer that uses RuVector's WASM build for a "cross-track vector-memory bridge" — effectively a downstream demo of the ecosystem running entirely in the browser with no build step.

- **Repo:** https://github.com/shaal/VectorVroom
- **Homepage:** https://vectorvroom.shaal.dev
- **Size:** 3.4 MiB  **Language:** JavaScript  **Stars:** 8
- **Pinned SHA:** \`4c2527b4526ccb8960cd13e3d9e1802d958dca60\` (upstream "fix(ab-mode): sync baseline worker…")

## What lands in this PR

- \`.gitmodules\` — new file, declares the submodule
- \`examples/vectorvroom\` — new gitlink entry (mode 160000) pointing at the pinned SHA

## Consumer notes

Fresh clones get an empty \`examples/vectorvroom/\` directory unless they run:

\`\`\`bash
git submodule update --init examples/vectorvroom
\`\`\`

That's the standard submodule idiom — nothing new for contributors already familiar with it. The rest of the workspace is unaffected: \`examples/*\` is already excluded from the root \`[workspace] members\` list, so \`cargo check\` / \`cargo test\` / \`cargo build\` at the root don't touch the submodule.

To update the submodule to upstream \`main\` later:

\`\`\`bash
git submodule update --remote examples/vectorvroom
git commit -am \"chore(vectorvroom): bump to upstream main\"
\`\`\`

## Licensing note

shaal/VectorVroom currently declares **no license** (GitHub's API returns \`license: null\`). This matters if we ever embed or redistribute its code in a RuVector release artifact. As a pure submodule pointer we're only vendoring a clone URL + commit SHA — no VectorVroom source enters the ruvector tree itself, so this import is fine as-is. Worth revisiting if:

- We ship a bundled release that includes VectorVroom assets
- We want to link to VectorVroom from ruvector docs as "officially part of the ecosystem"

Either of those would need a license clarification with the upstream author first.

## Test plan

- [ ] \`git submodule update --init examples/vectorvroom\` succeeds from a fresh clone
- [ ] \`cargo check\` at the root remains unaffected
- [ ] No CI workflows inadvertently try to build inside \`examples/vectorvroom/\`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)