### PR TITLE
feat(ruvector-diskann): persist RaBitQ codes — reloads keep codes-driven traversal

### DIFF
--- a/crates/ruvector-diskann/src/index.rs
+++ b/crates/ruvector-diskann/src/index.rs
@@ -29,6 +29,28 @@ const ORIGINALS_MAGIC: &[u8; 8] = b"DARO0001";
 const ORIGINALS_HEADER_BYTES: usize = 24;
 const ORIGINALS_FILENAME: &str = "originals.bin";
 
+// Sidecar layout for the RaBitQ quantizer state, written next to `pq.bin` /
+// `pq_codes.bin` when the active backend is `QuantizerKind::Rabitq`. Format:
+//   [0..8)   magic "DARQ0001" (DiskAnn RaBitQ Quantizer v1)
+//   [8..12)  version (u32 LE, currently 1)
+//   [12..16) dim     (u32 LE)
+//   [16..24) seed    (u64 LE) — replays the rotation deterministically
+//   [24..28) code_bytes_total (u32 LE) — for cross-checking
+//   [28..32) n_codes (u32 LE) — number of code entries that follow
+//   [32..)   raw codes slab, n_codes * code_bytes_total bytes
+//
+// We persist `(dim, seed)` rather than the rotation matrix because
+// `ruvector_rabitq::RabitqIndex::new(dim, seed)` is documented (ADR-154) to
+// be bit-identical for the same `(dim, seed)` pair. Storing only the seed
+// keeps the sidecar tiny (32 B header) regardless of `D` — the `D×D` Haar
+// matrix at D=128 alone is 64 KiB — and makes the format trivially portable
+// across machines. Codes are written in the same flat layout as `pq_codes.bin`.
+const RABITQ_MAGIC: &[u8; 8] = b"DARQ0001";
+const RABITQ_VERSION: u32 = 1;
+const RABITQ_HEADER_BYTES: usize = 32;
+#[cfg(feature = "rabitq")]
+const RABITQ_FILENAME: &str = "rabitq.bin";
+
 /// Backing store for the original f32 vectors used by the rerank pass.
 ///
 /// Two variants:
@@ -745,11 +767,13 @@ impl DiskAnnIndex {
             .map_err(|e| DiskAnnError::Serialization(e.to_string()))?;
         fs::write(&ids_path, ids_json)?;
 
-        // Save PQ if present. RaBitQ persistence is intentionally a
-        // follow-up: the rotation matrix lives in `ruvector-rabitq` and
-        // doesn't yet expose a stable on-disk format. For now we only
-        // persist PQ-backed indexes; a RaBitQ-backed save returns Ok and
-        // skips the codes — `load()` will rebuild from f32 originals.
+        // Save PQ or RaBitQ quantizer state. PQ uses bincode for the
+        // codebooks plus a flat `pq_codes.bin` for the per-vector codes;
+        // RaBitQ persists `(dim, seed)` plus a flat codes slab in a single
+        // `rabitq.bin` sidecar (rotation matrix is replayed on load via the
+        // ADR-154 determinism contract). The two formats use distinct magic
+        // bytes ("DARQ0001" vs the bincode-PQ stream) so `load()` can
+        // dispatch by file presence alone.
         match &self.quantizer {
             QuantizerBackend::None => {}
             QuantizerBackend::Pq(pq) => {
@@ -767,11 +791,32 @@ impl DiskAnnIndex {
                 f.flush()?;
             }
             #[cfg(feature = "rabitq")]
-            QuantizerBackend::Rabitq(_) => {
-                // Disk format for RaBitQ rotation matrices is a follow-up.
-                // The graph + originals are still saved above so the index
-                // can be reloaded with `quantizer_kind = None` and rebuilt
-                // by the caller if needed.
+            QuantizerBackend::Rabitq(rb) => {
+                // Header + raw codes slab in one sidecar. We don't reuse
+                // `ruvector_rabitq::persist::save_index` here: that helper
+                // takes a `RabitqPlusIndex` and re-persists the *originals*
+                // (so the rebuild path can re-encode them), but DiskANN
+                // already owns the originals via `vectors.bin` /
+                // `originals.bin` and just needs the codes + replay seed.
+                // Reusing it would double-store the f32 payload.
+                let path = dir.join(RABITQ_FILENAME);
+                let mut f = BufWriter::new(File::create(&path)?);
+                f.write_all(RABITQ_MAGIC)?;
+                f.write_all(&RABITQ_VERSION.to_le_bytes())?;
+                f.write_all(&(rb.dim() as u32).to_le_bytes())?;
+                f.write_all(&rb.seed().to_le_bytes())?;
+                let code_bytes_total = rb.code_bytes() as u32;
+                f.write_all(&code_bytes_total.to_le_bytes())?;
+                f.write_all(&(self.codes.len() as u32).to_le_bytes())?;
+                for code in &self.codes {
+                    debug_assert_eq!(
+                        code.len() as u32,
+                        code_bytes_total,
+                        "rabitq code length mismatch"
+                    );
+                    f.write_all(code)?;
+                }
+                f.flush()?;
             }
         }
 
@@ -779,6 +824,16 @@ impl DiskAnnIndex {
         // load() can pick the right originals backing without the caller
         // having to re-specify. `rerank_factor` is persisted for the same
         // reason — it affects search behaviour, not just construction.
+        // `quantizer_kind` is persisted as a string tag so the load path
+        // can fail loudly if the on-disk sidecars don't match the saved
+        // config (e.g. a "Rabitq"-tagged save that's missing rabitq.bin
+        // is a corrupted index, not a silent fallback to f32).
+        let quantizer_tag = match self.quantizer_kind() {
+            QuantizerKind::None => "none",
+            QuantizerKind::Pq => "pq",
+            #[cfg(feature = "rabitq")]
+            QuantizerKind::Rabitq => "rabitq",
+        };
         let config_path = dir.join("config.json");
         let config_json = serde_json::json!({
             "dim": self.config.dim,
@@ -789,6 +844,7 @@ impl DiskAnnIndex {
             "pq_subspaces": self.config.pq_subspaces,
             "rerank_factor": self.config.rerank_factor,
             "keep_originals_in_memory": self.config.keep_originals_in_memory,
+            "quantizer_kind": quantizer_tag,
             "count": n,
             "built": self.built,
         });
@@ -912,29 +968,145 @@ impl DiskAnnIndex {
             alpha,
         };
 
-        // Load PQ if present. RaBitQ persistence is a follow-up — see the
-        // matching note in `save()`.
+        // Load the quantizer backend, dispatching on the saved tag. The
+        // explicit `quantizer_kind` field disambiguates: a "rabitq"-tagged
+        // save that's missing rabitq.bin is a corruption case, not a
+        // silent fallback. v1 PQ saves (which lacked the tag) default to
+        // "pq" via the file-presence heuristic so existing on-disk indexes
+        // keep loading byte-identically.
+        let quantizer_tag = config_json["quantizer_kind"]
+            .as_str()
+            .map(|s| s.to_string());
         let pq_path = dir.join("pq.bin");
-        let (quantizer, codes) = if pq_path.exists() {
-            let pq_bytes = fs::read(&pq_path)?;
-            let (pq, _): (ProductQuantizer, usize) =
-                bincode::decode_from_slice(&pq_bytes, bincode::config::standard())
-                    .map_err(|e| DiskAnnError::Serialization(e.to_string()))?;
+        #[cfg(feature = "rabitq")]
+        let rabitq_path = dir.join(RABITQ_FILENAME);
 
-            let codes_bytes = fs::read(dir.join("pq_codes.bin"))?;
-            let m = pq.m;
-            let mut codes = Vec::with_capacity(n);
-            for i in 0..n {
-                codes.push(codes_bytes[i * m..(i + 1) * m].to_vec());
+        let saved_kind = match quantizer_tag.as_deref() {
+            Some("none") => QuantizerKind::None,
+            Some("pq") => QuantizerKind::Pq,
+            #[cfg(feature = "rabitq")]
+            Some("rabitq") => QuantizerKind::Rabitq,
+            #[cfg(not(feature = "rabitq"))]
+            Some("rabitq") => {
+                return Err(DiskAnnError::InvalidConfig(
+                    "saved index uses RaBitQ quantizer but this build was compiled \
+                     without the `rabitq` feature; rebuild with --features rabitq"
+                        .into(),
+                ));
             }
-            (QuantizerBackend::Pq(pq), codes)
-        } else {
-            (QuantizerBackend::None, Vec::new())
+            // v1 fallback: dispatch on file presence. PQ is the only
+            // quantizer that ever shipped a persisted format pre-this-PR.
+            _ => {
+                if pq_path.exists() {
+                    QuantizerKind::Pq
+                } else {
+                    QuantizerKind::None
+                }
+            }
+        };
+
+        let (quantizer, codes) = match saved_kind {
+            QuantizerKind::None => (QuantizerBackend::None, Vec::new()),
+            QuantizerKind::Pq => {
+                if !pq_path.exists() {
+                    return Err(DiskAnnError::InvalidConfig(format!(
+                        "saved config tags quantizer_kind=pq but {} is missing",
+                        pq_path.display()
+                    )));
+                }
+                let pq_bytes = fs::read(&pq_path)?;
+                let (pq, _): (ProductQuantizer, usize) =
+                    bincode::decode_from_slice(&pq_bytes, bincode::config::standard())
+                        .map_err(|e| DiskAnnError::Serialization(e.to_string()))?;
+
+                let codes_bytes = fs::read(dir.join("pq_codes.bin"))?;
+                let m = pq.m;
+                let mut codes = Vec::with_capacity(n);
+                for i in 0..n {
+                    codes.push(codes_bytes[i * m..(i + 1) * m].to_vec());
+                }
+                (QuantizerBackend::Pq(pq), codes)
+            }
+            #[cfg(feature = "rabitq")]
+            QuantizerKind::Rabitq => {
+                if !rabitq_path.exists() {
+                    return Err(DiskAnnError::InvalidConfig(format!(
+                        "saved config tags quantizer_kind=rabitq but {} is missing — \
+                         the index was likely saved by an older build that didn't \
+                         persist RaBitQ codes; rebuild the index",
+                        rabitq_path.display()
+                    )));
+                }
+                let bytes = fs::read(&rabitq_path)?;
+                if bytes.len() < RABITQ_HEADER_BYTES {
+                    return Err(DiskAnnError::InvalidConfig(format!(
+                        "rabitq sidecar at {} is truncated ({} bytes < header {})",
+                        rabitq_path.display(),
+                        bytes.len(),
+                        RABITQ_HEADER_BYTES
+                    )));
+                }
+                if &bytes[0..8] != RABITQ_MAGIC {
+                    return Err(DiskAnnError::InvalidConfig(format!(
+                        "rabitq sidecar at {} has wrong magic",
+                        rabitq_path.display()
+                    )));
+                }
+                let version = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+                if version != RABITQ_VERSION {
+                    return Err(DiskAnnError::InvalidConfig(format!(
+                        "rabitq sidecar version {} unsupported (expected {})",
+                        version, RABITQ_VERSION
+                    )));
+                }
+                let saved_dim = u32::from_le_bytes(bytes[12..16].try_into().unwrap()) as usize;
+                if saved_dim != dim {
+                    return Err(DiskAnnError::InvalidConfig(format!(
+                        "rabitq sidecar dim {} != index dim {}",
+                        saved_dim, dim
+                    )));
+                }
+                let seed = u64::from_le_bytes(bytes[16..24].try_into().unwrap());
+                let code_bytes_total =
+                    u32::from_le_bytes(bytes[24..28].try_into().unwrap()) as usize;
+                let n_codes = u32::from_le_bytes(bytes[28..32].try_into().unwrap()) as usize;
+                if n_codes != n {
+                    return Err(DiskAnnError::InvalidConfig(format!(
+                        "rabitq sidecar n_codes {} != index count {}",
+                        n_codes, n
+                    )));
+                }
+                let expected = RABITQ_HEADER_BYTES + n_codes * code_bytes_total;
+                if bytes.len() < expected {
+                    return Err(DiskAnnError::InvalidConfig(format!(
+                        "rabitq sidecar truncated: header expects {} bytes, file is {}",
+                        expected,
+                        bytes.len()
+                    )));
+                }
+                let rb = RabitqQuantizer::new_trained(dim, seed);
+                if rb.code_bytes() != code_bytes_total {
+                    return Err(DiskAnnError::InvalidConfig(format!(
+                        "rabitq code_bytes_total mismatch: sidecar={} reconstructed={}",
+                        code_bytes_total,
+                        rb.code_bytes()
+                    )));
+                }
+                let mut codes = Vec::with_capacity(n_codes);
+                for i in 0..n_codes {
+                    let s = RABITQ_HEADER_BYTES + i * code_bytes_total;
+                    codes.push(bytes[s..s + code_bytes_total].to_vec());
+                }
+                (QuantizerBackend::Rabitq(rb), codes)
+            }
         };
 
         // Mirror the saved quantizer into the runtime config. The legacy
         // `pq_subspaces` field is already populated from JSON above; the
         // explicit `quantizer_kind` is set so callers can introspect it.
+        // For RaBitQ we also mirror the seed read from the sidecar so
+        // `config.rabitq_seed` reflects the seed that actually drives the
+        // loaded rotation matrix (rather than the `Default` placeholder).
         let mut config = config;
         config.quantizer_kind = match &quantizer {
             QuantizerBackend::None => QuantizerKind::None,
@@ -942,6 +1114,10 @@ impl DiskAnnIndex {
             #[cfg(feature = "rabitq")]
             QuantizerBackend::Rabitq(_) => QuantizerKind::Rabitq,
         };
+        #[cfg(feature = "rabitq")]
+        if let QuantizerBackend::Rabitq(rb) = &quantizer {
+            config.rabitq_seed = rb.seed();
+        }
 
         Ok(Self {
             config,

--- a/crates/ruvector-diskann/src/quantize/rabitq.rs
+++ b/crates/ruvector-diskann/src/quantize/rabitq.rs
@@ -54,6 +54,12 @@ pub struct RabitqQuery {
 pub struct RabitqQuantizer {
     inner: RabitqIndex,
     dim: usize,
+    /// Seed retained alongside `inner` so persistence (`save`/`load` in
+    /// `index.rs`) can deterministically reconstruct the rotation matrix
+    /// without serialising it: `(dim, seed) → bit-identical rotation` is
+    /// the determinism contract from ADR-154 / `ruvector_rabitq` already
+    /// guarantees, and the persist sidecar simply replays it.
+    seed: u64,
     /// `ceil(D/64)` — the u64-word-length of the bit-packed code.
     n_words: usize,
     /// Total bytes per encoded vector: `n_words * 8` (the code) + `4` (the
@@ -81,10 +87,30 @@ impl RabitqQuantizer {
         Self {
             inner,
             dim,
+            seed,
             n_words,
             code_bytes_total,
             trained: false,
         }
+    }
+
+    /// Constructor used by the load path: same as [`Self::new`] but starts
+    /// in the trained state. Safe because RaBitQ's "training" is purely a
+    /// dim-consistency check — no learned codebooks. The codes that pair
+    /// with this quantizer were already encoded by an equivalent
+    /// `(dim, seed)` quantizer at save time, so they're consistent with
+    /// the rotation we're about to reconstruct.
+    pub(crate) fn new_trained(dim: usize, seed: u64) -> Self {
+        let mut q = Self::new(dim, seed);
+        q.trained = true;
+        q
+    }
+
+    /// Accessor for the seed used to construct this quantizer. Used by the
+    /// DiskANN save path to persist `(dim, seed)` instead of the rotation
+    /// matrix bytes.
+    pub fn seed(&self) -> u64 {
+        self.seed
     }
 
     /// Bytes consumed by the rotation matrix (amortised across all vectors).

--- a/crates/ruvector-diskann/tests/disk_backed_rerank.rs
+++ b/crates/ruvector-diskann/tests/disk_backed_rerank.rs
@@ -370,6 +370,222 @@ fn disk_backed_save_load_round_trip_preserves_results() {
 }
 
 #[test]
+fn disk_backed_save_load_round_trip_preserves_results_rabitq() {
+    // RaBitQ-flavored sibling of the PQ round-trip test above. Closes the
+    // limitation flagged in PR #385: previously a reloaded RaBitQ-built
+    // index dropped its rotation matrix + binary codes and silently fell
+    // back to the f32 traversal path, so a save → drop → load round-trip
+    // changed search results. After this PR the rabitq.bin sidecar
+    // persists `(dim, seed)` plus the codes; load() replays the rotation
+    // deterministically (ADR-154) and search results must be bit-identical.
+    let dim = 64;
+    let n = 300;
+    let k = 5;
+    let vectors = random_unit_vectors(n, dim, 0xABCD);
+
+    let dir = tempdir().unwrap();
+    let storage = dir.path().join("idx");
+
+    let config = DiskAnnConfig {
+        dim,
+        max_degree: 32,
+        build_beam: 64,
+        search_beam: 64,
+        alpha: 1.2,
+        storage_path: Some(storage.clone()),
+        ..Default::default()
+    }
+    .with_rabitq_seed(0xFEED_FACE)
+    .with_quantizer_kind(QuantizerKind::Rabitq)
+    .with_rerank_factor(4)
+    .with_originals_in_memory(false);
+
+    let queries = random_unit_vectors(8, dim, 0x9999);
+    let pre_results: Vec<Vec<(String, u32)>> = {
+        let mut idx = DiskAnnIndex::new(config);
+        let entries: Vec<(String, Vec<f32>)> = vectors
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (format!("v{i}"), v.clone()))
+            .collect();
+        idx.insert_batch(entries).unwrap();
+        idx.build().unwrap();
+        assert_eq!(idx.quantizer_kind(), QuantizerKind::Rabitq);
+        assert!(idx.codes_memory_bytes() > 0, "RaBitQ codes slab is empty");
+        assert!(idx.originals_on_disk());
+        queries
+            .iter()
+            .map(|q| {
+                idx.search(q, k)
+                    .unwrap()
+                    .into_iter()
+                    .map(|r| (r.id, r.distance.to_bits()))
+                    .collect()
+            })
+            .collect()
+        // idx dropped here — proves load() is restoring state from disk
+        // rather than reusing in-memory residuals.
+    };
+
+    // Reload. The rabitq.bin sidecar must be picked up so the loaded
+    // index keeps the codes-driven traversal path (not the f32 fallback
+    // that PR #383/#384/#385 silently reverted to).
+    let loaded = DiskAnnIndex::load(&storage).unwrap();
+    assert_eq!(
+        loaded.quantizer_kind(),
+        QuantizerKind::Rabitq,
+        "loaded index should detect rabitq.bin sidecar"
+    );
+    assert!(loaded.originals_on_disk());
+    assert!(
+        loaded.codes_memory_bytes() > 0,
+        "RaBitQ codes slab not restored on load — search will fall back to f32"
+    );
+    for (q, want) in queries.iter().zip(pre_results.iter()) {
+        let got: Vec<(String, u32)> = loaded
+            .search(q, k)
+            .unwrap()
+            .into_iter()
+            .map(|r| (r.id, r.distance.to_bits()))
+            .collect();
+        assert_eq!(
+            got, *want,
+            "RaBitQ search results changed across save → load round-trip — \
+             rotation matrix + codes are not being persisted"
+        );
+    }
+}
+
+#[test]
+fn v1_pq_index_without_quantizer_kind_tag_still_loads() {
+    // Back-compat guard: v1 indexes (saved by PR #383/#384/#385) don't
+    // have the new `quantizer_kind` JSON tag. The load path must fall
+    // back to the file-presence heuristic ("pq.bin exists → PQ") so
+    // existing on-disk PQ indexes keep loading byte-identically.
+    let dim = 32;
+    let n = 200;
+    let k = 5;
+    let vectors = random_unit_vectors(n, dim, 0xF00D);
+
+    let dir = tempdir().unwrap();
+    let storage = dir.path().join("idx");
+
+    let config = DiskAnnConfig {
+        dim,
+        max_degree: 16,
+        build_beam: 32,
+        search_beam: 32,
+        alpha: 1.2,
+        pq_subspaces: 4,
+        pq_iterations: 5,
+        storage_path: Some(storage.clone()),
+        ..Default::default()
+    };
+
+    let queries = random_unit_vectors(5, dim, 0x1357);
+    let pre_results: Vec<Vec<(String, u32)>> = {
+        let mut idx = DiskAnnIndex::new(config);
+        let entries: Vec<(String, Vec<f32>)> = vectors
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (format!("v{i}"), v.clone()))
+            .collect();
+        idx.insert_batch(entries).unwrap();
+        idx.build().unwrap();
+        queries
+            .iter()
+            .map(|q| {
+                idx.search(q, k)
+                    .unwrap()
+                    .into_iter()
+                    .map(|r| (r.id, r.distance.to_bits()))
+                    .collect()
+            })
+            .collect()
+    };
+
+    // Strip `quantizer_kind` from config.json to simulate a v1 save.
+    let cfg_path = storage.join("config.json");
+    let mut cfg: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&cfg_path).unwrap()).unwrap();
+    cfg.as_object_mut().unwrap().remove("quantizer_kind");
+    std::fs::write(&cfg_path, serde_json::to_string_pretty(&cfg).unwrap()).unwrap();
+
+    // Sanity-check the tag is gone.
+    let cfg_check: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&cfg_path).unwrap()).unwrap();
+    assert!(cfg_check.get("quantizer_kind").is_none());
+
+    // Load and search — must still go through the PQ path because pq.bin
+    // exists, and results must be byte-identical.
+    let loaded = DiskAnnIndex::load(&storage).unwrap();
+    assert_eq!(loaded.quantizer_kind(), QuantizerKind::Pq);
+    for (q, want) in queries.iter().zip(pre_results.iter()) {
+        let got: Vec<(String, u32)> = loaded
+            .search(q, k)
+            .unwrap()
+            .into_iter()
+            .map(|r| (r.id, r.distance.to_bits()))
+            .collect();
+        assert_eq!(got, *want, "v1 PQ index search results changed on load");
+    }
+}
+
+#[test]
+fn rabitq_load_rejects_missing_sidecar() {
+    // If the saved config tags `quantizer_kind = rabitq` but the sidecar
+    // is missing (e.g. a v1 index from before this PR, or a corrupted
+    // index where someone deleted rabitq.bin), load() must surface a
+    // clear `InvalidConfig` error rather than silently falling back to
+    // the f32 path. The brief: "If the saved magic is RaBitQ but the
+    // section is missing, return a clear error (don't silently fall back)."
+    let dim = 32;
+    let n = 100;
+    let vectors = random_unit_vectors(n, dim, 0xFADE);
+
+    let dir = tempdir().unwrap();
+    let storage = dir.path().join("idx");
+
+    let config = DiskAnnConfig {
+        dim,
+        max_degree: 16,
+        build_beam: 32,
+        search_beam: 32,
+        alpha: 1.2,
+        storage_path: Some(storage.clone()),
+        ..Default::default()
+    }
+    .with_rabitq_seed(0xBEEF)
+    .with_quantizer_kind(QuantizerKind::Rabitq)
+    .with_rerank_factor(2);
+
+    let mut idx = DiskAnnIndex::new(config);
+    let entries: Vec<(String, Vec<f32>)> = vectors
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (format!("v{i}"), v.clone()))
+        .collect();
+    idx.insert_batch(entries).unwrap();
+    idx.build().unwrap();
+    drop(idx);
+
+    // Simulate corruption: delete the rabitq sidecar but leave the
+    // config tag claiming RaBitQ.
+    std::fs::remove_file(storage.join("rabitq.bin")).unwrap();
+
+    match DiskAnnIndex::load(&storage) {
+        Ok(_) => panic!("expected load to fail when rabitq sidecar is missing"),
+        Err(DiskAnnError::InvalidConfig(msg)) => {
+            assert!(
+                msg.contains("rabitq"),
+                "expected error mentioning rabitq, got: {msg}"
+            );
+        }
+        Err(other) => panic!("expected InvalidConfig, got {other:?}"),
+    }
+}
+
+#[test]
 fn disk_backed_without_storage_path_rejected() {
     // The whole point of storage_path is "where do I spill the originals".
     // Without it, disk-backed mode has nowhere to write — surface an


### PR DESCRIPTION
## Summary

**Stacked on PR #385.** Closes the RaBitQ persistence limitation that the round-trip test in #385 had to work around with PQ.

After this PR: a saved → dropped → reloaded RaBitQ-built DiskANN index keeps the codes-driven traversal path. Search results are bit-identical (verified via `f32::to_bits()` u32 comparison across 8 queries on a 300-vector D=64 RaBitQ index).

## Sidecar layout

`<storage_path>/rabitq.bin` — sibling to PR #385's `originals.bin` and the existing `pq.bin`. 32-byte header `[magic="DARQ0001"][version=1][dim][seed][code_bytes_total][n_codes]` + raw code bytes.

Dispatch via a new `quantizer_kind` JSON tag in `config.json` (`"none"|"pq"|"rabitq"`), with a v1 fallback that probes `pq.bin` presence.

## Why not reuse `ruvector_rabitq::persist::save_index/load_index`?

Those helpers re-persist the originals to support a rebuild path. DiskANN already owns the originals via `vectors.bin` / `originals.bin` (PR #385). Reusing the helpers would double-store the f32 payload.

The **determinism contract** those helpers rely on (ADR-154's `(dim, seed) → bit-identical rotation`) is reused — that's why the sidecar persists only `(dim, seed)` rather than the dense rotation matrix.

## Surprise finding worth recording

The pre-PR `load()` silently swallowed RaBitQ failures. With `quantizer_kind = Rabitq` set in code but no `rabitq.bin` sidecar on disk, `load()` happily returned a `QuantizerBackend::None` index. Search still worked — just via the f32 fallback path with no warning. The new explicit `InvalidConfig` error converts what was a silent recall regression into a loud configuration error.

## Verification

- [x] `cargo build --workspace` → clean
- [x] `cargo build -p ruvector-diskann --no-default-features` → clean
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings` → clean
- [x] `cargo fmt --all --check` → clean
- [x] `cargo test -p ruvector-diskann --features rabitq` → **38 / 38** (was 35 in PR #385)
- [x] `cargo test -p ruvector-diskann --no-default-features` → **19 / 19**

Three new tests in `tests/disk_backed_rerank.rs`:
- `disk_backed_save_load_round_trip_preserves_results_rabitq` — bit-identical bytes post-reload
- `rabitq_load_rejects_missing_sidecar` — explicit error path
- `v1_pq_index_without_quantizer_kind_tag_still_loads` — back-compat fallback

## DiskANN stack

`base: feature/diskann-disk-backed-rerank` (PR #385)
`base of base: feature/diskann-quantizer-search-path` (PR #384)
`base of base of base: feature/diskann-rabitq-backend` (PR #383)
`base of all: main`

The four PRs (#383 → #384 → #385 → #386) together complete Phase 1 item #1 from the research roadmap *and* close every limitation surfaced along the way:
- Quantizer trait + RaBitQ backend exist (#383)
- Trait is load-bearing in search (#384)
- Disk-backed rerank delivers DRAM compression (#385)
- RaBitQ codes persist across save/load (#386)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)