### PR TITLE
fix(diskann): seed test RNGs to fix flaky test_diskann_basic

### DIFF
--- a/crates/ruvector-diskann/src/index.rs
+++ b/crates/ruvector-diskann/src/index.rs
@@ -420,7 +420,10 @@ mod tests {
 
     fn random_vectors(n: usize, dim: usize) -> Vec<(String, Vec<f32>)> {
         use rand::prelude::*;
-        let mut rng = rand::thread_rng();
+        // Seeded so tests are deterministic across CI runs — random data made
+        // basic-search assertions (nearest of vec-X is vec-X) flake when the
+        // ANN graph traversal happened to land on an unrelated near-duplicate.
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0xD15CA77);
         (0..n)
             .map(|i| {
                 let v: Vec<f32> = (0..dim).map(|_| rng.gen()).collect();
@@ -512,7 +515,7 @@ mod tests {
     fn test_recall_at_10() {
         // Measure recall@10: what fraction of true top-10 neighbors does DiskANN find?
         use rand::prelude::*;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0xD15CA77);
         let n = 2000;
         let dim = 64;
         let k = 10;
@@ -615,7 +618,7 @@ mod tests {
         // 5000 vectors, 128-dim — should build in under 5 seconds
         use rand::prelude::*;
         use std::time::Instant;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0xD15CA77);
 
         let n = 5000;
         let dim = 128;


### PR DESCRIPTION
## Problem

Workspace-CI on main started failing `Tests (vector-index)` after the
ACORN/RaBitQ-WASM merges (#391, #394) — not due to the new code, but
because `ruvector-diskann::index::tests::test_diskann_basic` is flaky.

The test draws 500 random 32-dim vectors, queries with `vec-42`, and
asserts the nearest neighbour is `vec-42` itself. With
`rand::thread_rng()` (unseeded), CI run [24976593452](https://github.com/ruvnet/RuVector/actions/runs/24976593452) drew an
unlucky distribution where the Vamana graph traversal returned
`vec-364` instead and the assertion failed.

## Fix

Replace `thread_rng()` with `StdRng::seed_from_u64(0xD15CA77)` in the
three test-only RNG sites in `crates/ruvector-diskann/src/index.rs`:

- `random_vectors()` — used by `test_diskann_basic`,
  `test_diskann_with_pq`, `test_diskann_save_load`
- `test_recall_at_10`
- `test_scale_5k`

Now fully deterministic across runs and platforms.

## Verification

- `cargo test -p ruvector-diskann --lib` → **17/17 pass** (49.6s)
- `cargo test -p ruvector-diskann --lib test_diskann_basic` ×3 → all
  pass with identical timings (≈0.1s each)

No production-code changes; this is tests-only.