### PR TITLE
fix(ruvector-cli): bundle ONNX runtime assets in dist/ + extend verify-dist gate

### DIFF
--- a/npm/packages/ruvector/package.json
+++ b/npm/packages/ruvector/package.json
@@ -8,7 +8,7 @@
     "ruvector": "./bin/cli.js"
   },
   "scripts": {
-    "build": "tsc && cp src/core/onnx/pkg/package.json dist/core/onnx/pkg/",
+    "build": "tsc && node scripts/copy-onnx-assets.js",
     "verify-dist": "node scripts/verify-dist.js",
     "prepublishOnly": "npm run build && npm run verify-dist",
     "test": "node test/integration.js && node test/cli-commands.js"

--- a/npm/packages/ruvector/scripts/copy-onnx-assets.js
+++ b/npm/packages/ruvector/scripts/copy-onnx-assets.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * copy-onnx-assets.js — copy the bundled ONNX runtime files from src/core/onnx
+ * into dist/core/onnx after `tsc`.
+ *
+ * Why: tsc only emits .js for .ts inputs. The ONNX subsystem ships a JS
+ * loader, a wasm-bindgen JS bridge, and the .wasm binary itself — none of
+ * which are TypeScript and so all of which are skipped by tsc. The previous
+ * build script copied only `pkg/package.json`, which left embed text and
+ * the embed-stream pipeline broken with:
+ *   "Failed to initialize ONNX embedder: ONNX WASM files not bundled.
+ *    The onnx/ directory is missing."
+ *
+ * This script does an explicit, cross-platform copy of every runtime asset
+ * the embedder reads via `path.join(__dirname, 'onnx', ...)` in
+ * src/core/onnx-embedder.ts. It is intentionally explicit (not a recursive
+ * dir copy) so a new file gets noticed and its inclusion is a deliberate
+ * decision, not an accident.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const pkgRoot = path.resolve(__dirname, '..');
+const srcDir = path.join(pkgRoot, 'src', 'core', 'onnx');
+const dstDir = path.join(pkgRoot, 'dist', 'core', 'onnx');
+
+const ASSETS = [
+  // Outer loader (model fetch / cache layer)
+  'loader.js',
+  // wasm-bindgen generated bridge
+  'pkg/ruvector_onnx_embeddings_wasm.js',
+  'pkg/ruvector_onnx_embeddings_wasm.d.ts',
+  'pkg/ruvector_onnx_embeddings_wasm_bg.js',
+  'pkg/ruvector_onnx_embeddings_wasm_bg.wasm',
+  'pkg/ruvector_onnx_embeddings_wasm_bg.wasm.d.ts',
+  // Already-shipped metadata + license (kept for completeness)
+  'pkg/package.json',
+  'pkg/LICENSE',
+];
+
+let copied = 0;
+let missing = 0;
+for (const rel of ASSETS) {
+  const src = path.join(srcDir, rel);
+  const dst = path.join(dstDir, rel);
+  if (!fs.existsSync(src)) {
+    console.warn(`copy-onnx-assets: WARN source missing: ${rel}`);
+    missing++;
+    continue;
+  }
+  fs.mkdirSync(path.dirname(dst), { recursive: true });
+  fs.copyFileSync(src, dst);
+  copied++;
+}
+
+if (missing > 0) {
+  console.error(
+    `copy-onnx-assets: ${missing} expected source asset(s) missing — ONNX subsystem may not work at runtime.`,
+  );
+  process.exit(1);
+}
+
+console.log(`copy-onnx-assets: ${copied} asset(s) copied to dist/core/onnx/.`);

--- a/npm/packages/ruvector/scripts/verify-dist.js
+++ b/npm/packages/ruvector/scripts/verify-dist.js
@@ -1,51 +1,87 @@
 #!/usr/bin/env node
 /**
  * verify-dist.js — pre-publish gate that fails the build if any file
- * `bin/cli.js` requires from `../dist/...` is missing.
+ * `bin/cli.js` requires from `../dist/...` is missing, OR if any of the
+ * runtime asset paths read at startup by dist/core/onnx-embedder.js are
+ * missing.
  *
  * Why: 0.2.23 was published without a `dist/` directory at all (issue #399),
- * which silently broke `ruvector doctor`, the entire `embed` subsystem, and
- * `rvf` commands. tsc was supposed to run via `prepublishOnly`, but the
- * hook didn't fire (or the build failed silently). This script makes the
- * publish itself fail loudly when the artifact is incomplete.
+ * and 0.2.24/0.2.25 still shipped without the ONNX runtime assets (the
+ * embedder reads them via `path.join(__dirname, 'onnx', ...)` rather than
+ * `require()`, so the original CLI-only scan didn't notice them).
+ *
+ * This script makes the publish itself fail loudly when either category of
+ * artifact is incomplete.
  */
 
 const fs = require('fs');
 const path = require('path');
 
 const pkgRoot = path.resolve(__dirname, '..');
-const cliPath = path.join(pkgRoot, 'bin', 'cli.js');
 
-if (!fs.existsSync(cliPath)) {
-  console.error('verify-dist: bin/cli.js not found — package layout is broken.');
+function fail(msg) {
+  console.error(msg);
   process.exit(1);
 }
 
-const cliSource = fs.readFileSync(cliPath, 'utf8');
+// ────────────────────────────────────────────────────────────────────────
+// 1. CLI `require('../dist/...js')` scan (original behavior)
+// ────────────────────────────────────────────────────────────────────────
+const cliPath = path.join(pkgRoot, 'bin', 'cli.js');
+if (!fs.existsSync(cliPath)) {
+  fail('verify-dist: bin/cli.js not found — package layout is broken.');
+}
 
-// Collect every `require('../dist/...')` referenced by the CLI.
+const cliSource = fs.readFileSync(cliPath, 'utf8');
 const distRequires = Array.from(
   cliSource.matchAll(/require\(['"]\.\.\/(dist\/[^'"]+\.js)['"]\)/g),
   (m) => m[1],
 );
-const unique = Array.from(new Set(distRequires)).sort();
-
-const missing = unique.filter(
+const cliUnique = Array.from(new Set(distRequires)).sort();
+const cliMissing = cliUnique.filter(
   (rel) => !fs.existsSync(path.join(pkgRoot, rel)),
 );
 
-if (missing.length > 0) {
+if (cliMissing.length > 0) {
   console.error(
-    `verify-dist: ${missing.length} dist file(s) referenced by bin/cli.js are missing:`,
+    `verify-dist: ${cliMissing.length} dist file(s) referenced by bin/cli.js are missing:`,
   );
-  for (const rel of missing) {
-    console.error(`  - ${rel}`);
-  }
+  for (const rel of cliMissing) console.error(`  - ${rel}`);
   console.error(
     "\nRun `npm run build` and confirm tsc emitted under dist/. If a path was renamed,",
   );
-  console.error('update bin/cli.js to match.');
-  process.exit(1);
+  fail('update bin/cli.js to match.');
 }
 
-console.log(`verify-dist: ${unique.length} dist path(s) present.`);
+// ────────────────────────────────────────────────────────────────────────
+// 2. Runtime asset gate — ONNX subsystem reads non-JS files via
+//    path.join(__dirname, 'onnx', ...). tsc never touches them, so a
+//    missing build-script copy is invisible to the CLI-only scan above.
+//    Each path here corresponds to a `path.join(__dirname, 'onnx', ...)`
+//    site in dist/core/onnx-embedder.js.
+// ────────────────────────────────────────────────────────────────────────
+const RUNTIME_ASSETS = [
+  'dist/core/onnx/loader.js',
+  'dist/core/onnx/pkg/ruvector_onnx_embeddings_wasm.js',
+  'dist/core/onnx/pkg/ruvector_onnx_embeddings_wasm_bg.js',
+  'dist/core/onnx/pkg/ruvector_onnx_embeddings_wasm_bg.wasm',
+];
+
+const runtimeMissing = RUNTIME_ASSETS.filter(
+  (rel) => !fs.existsSync(path.join(pkgRoot, rel)),
+);
+
+if (runtimeMissing.length > 0) {
+  console.error(
+    `verify-dist: ${runtimeMissing.length} ONNX runtime asset(s) missing — embed text and embed-stream pipelines will fail at startup:`,
+  );
+  for (const rel of runtimeMissing) console.error(`  - ${rel}`);
+  console.error(
+    "\nThese live under src/core/onnx/ in source. Make sure `npm run build` runs the",
+  );
+  fail('copy-onnx-assets step (see scripts/copy-onnx-assets.js).');
+}
+
+console.log(
+  `verify-dist: ${cliUnique.length} dist require path(s) + ${RUNTIME_ASSETS.length} runtime asset(s) present.`,
+);


### PR DESCRIPTION
## Summary

`0.2.23` → `0.2.25` ship `dist/core/onnx/pkg/` containing only `package.json`. No `loader.js`, no wasm-bindgen JS bridge, no `.wasm` binary. The embedder reads those at startup via `path.join(__dirname, 'onnx', ...)`, so on a clean install of any of those versions:

```
$ npx ruvector embed text "hello"
Embedding failed: Failed to initialize ONNX embedder:
  ONNX WASM files not bundled. The onnx/ directory is missing.
```

This PR makes the build/publish actually ship what it claims to ship.

## Root cause

Old build script:
```json
"build": "tsc && cp src/core/onnx/pkg/package.json dist/core/onnx/pkg/"
```

`tsc` only emits `.js` for `.ts` inputs. The JS loader, the wasm-bindgen bridge, and the `.wasm` binary itself are all non-TS, so all three were silently skipped. Only the single-file `cp` ran.

The `verify-dist` gate added in #403 caught the original `dist/` regression but didn't catch this one because it only scans `bin/cli.js` for `require('../dist/...js')`. These assets are read via `path.join` + `fs.readFileSync` + `dynamicImport`, not `require()`, so the original gate is structurally blind to them.

## Changes

### 1. `scripts/copy-onnx-assets.js` (new)

Explicit, cross-platform Node script that copies the 8 runtime assets the embedder needs. Listed explicitly (not a recursive `cp`) so adding a new asset is a deliberate choice, not an accident. Fails the build with a non-zero exit if any source asset is missing.

### 2. `package.json`

```diff
- "build": "tsc && cp src/core/onnx/pkg/package.json dist/core/onnx/pkg/"
+ "build": "tsc && node scripts/copy-onnx-assets.js"
```

### 3. `scripts/verify-dist.js`

Adds a second pass that asserts the four runtime asset paths read by `dist/core/onnx-embedder.js` actually exist. Same publish-gate semantics as the existing `bin/cli.js` scan, just covering the path-join'd asset reads as well.

## Verification

```
$ rm -rf dist && npm run build
copy-onnx-assets: 8 asset(s) copied to dist/core/onnx/.

$ npm run verify-dist
verify-dist: 13 dist require path(s) + 4 runtime asset(s) present.

$ ls dist/core/onnx/pkg/
LICENSE
package.json
ruvector_onnx_embeddings_wasm.d.ts
ruvector_onnx_embeddings_wasm.js
ruvector_onnx_embeddings_wasm_bg.js
ruvector_onnx_embeddings_wasm_bg.wasm
ruvector_onnx_embeddings_wasm_bg.wasm.d.ts
```

The "ONNX WASM files not bundled" error no longer fires — the `existsSync` check at `dist/core/onnx-embedder.js:184` passes because the files exist.

## Out of scope (followup needed)

With all assets present, Node still fails the next step:

```
Failed to initialize ONNX embedder: Unknown file extension ".wasm"
for .../dist/core/onnx/pkg/ruvector_onnx_embeddings_wasm_bg.wasm
```

The shipped `ruvector_onnx_embeddings_wasm.js` is the wasm-bindgen **bundler** target (`import * as wasm from "./xxx.wasm"`). Node ESM rejects bare `.wasm` imports without `--experimental-wasm-modules`. The embedder code expects the **web/no-modules** target (with `wasmModule.default(wasmBytes)` for deferred init), but it never gets that branch because the bundler-target import fails before the embedder's branch logic runs.

The clean fix is to rebuild `ruvector-onnx-embeddings-wasm` with `--target nodejs` (or `web` with deferred init) so the entry exposes a `default(bytes)` initializer and doesn't try to `import` the `.wasm` directly. That's a Rust/wasm-bindgen build-config change, not a JS one — out of scope for this PR.

This PR is the necessary precondition for that work: the assets actually need to ship before any wasm-target fix can possibly run end-to-end.

## Related

- #399 — `dist/` missing entirely on 0.2.23. Fixed in #403.
- #402 §C — additional `dist/` paths (`onnx-embedder.js`, `rvf-wrapper.js`) missing. Fixed in #403.
- This PR — the **non-`.js`** assets that `dist/core/onnx-embedder.js` reads at runtime were never copied by the build, even after #403's `dist/` rescue. Same release-hygiene class.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)