### PR TITLE
fix(cli): add io-std to workspace tokio features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,7 +247,7 @@ web-sys = { version = "0.3", features = ["Worker", "MessagePort", "console"] }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 
 # Async runtime
-tokio = { version = "1.41", features = ["rt-multi-thread", "sync", "macros"] }
+tokio = { version = "1.41", features = ["rt-multi-thread", "sync", "macros", "io-std"] }
 futures = "0.3"
 
 # Error handling and utilities


### PR DESCRIPTION
## Summary

Adds `io-std` to the workspace `tokio` features in the root `Cargo.toml`. The `ruvector-cli` MCP transport (`crates/ruvector-cli/src/mcp/transport.rs`, lines 30-31) calls `tokio::io::stdin()` and `tokio::io::stdout()`, but the workspace `tokio` dependency omits the `io-std` feature. Because `ruvector-cli` inherits `tokio` via `workspace = true`, the binary cannot be built from a clean workspace:

```
cargo build --release -p ruvector-cli --bin ruvector-mcp
error[E0425]: cannot find function `stdin` in module `tokio::io`
error[E0425]: cannot find function `stdout` in module `tokio::io`
```

## Why workspace-level

Adding `io-std` at the workspace tier resolves the regression for every consumer at once with no per-crate overrides. This is the scope @ruvnet recommended in the review of #406.

## Verification

`cargo build --release -p ruvector-cli --bin ruvector-mcp` now finishes cleanly on macOS aarch64 (release profile).

## Context

This is the standalone `io-std` fix per @ruvnet's request to split #406. The release-workflow rework from that PR will land separately as a follow-up.