### PR TITLE
fix(ruvllm): pin optionalDependencies to actually-published 2.0.1 (#411)

### DIFF
--- a/npm/packages/ruvllm/package.json
+++ b/npm/packages/ruvllm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ruvector/ruvllm",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Self-learning LLM runtime — TurboQuant KV-cache (6-8x compression), SONA adaptive learning, FlashAttention, speculative decoding, GGUF inference",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -65,11 +65,11 @@
     "ora": "^5.4.1"
   },
   "optionalDependencies": {
-    "@ruvector/ruvllm-linux-x64-gnu": "2.3.0",
-    "@ruvector/ruvllm-linux-arm64-gnu": "2.3.0",
-    "@ruvector/ruvllm-darwin-x64": "2.3.0",
-    "@ruvector/ruvllm-darwin-arm64": "2.3.0",
-    "@ruvector/ruvllm-win32-x64-msvc": "2.3.0"
+    "@ruvector/ruvllm-linux-x64-gnu": "2.0.1",
+    "@ruvector/ruvllm-linux-arm64-gnu": "2.0.1",
+    "@ruvector/ruvllm-darwin-x64": "2.0.1",
+    "@ruvector/ruvllm-darwin-arm64": "2.0.1",
+    "@ruvector/ruvllm-win32-x64-msvc": "2.0.1"
   },
   "keywords": [
     "ruvllm",


### PR DESCRIPTION
## Summary

- `@ruvector/ruvllm@2.4.0–2.5.4` pinned `optionalDependencies` to `2.3.0` for all 5 native binary packages, but those native versions were never published — latest published is `2.0.1`. Net effect: wrapper installs but no native loader resolves on any platform.
- Repointed to `2.0.1` (the actually-published native version) and bumped wrapper to `2.5.5`.
- Already published as `2.5.5` to npm before this PR — this commits the source state to match. Issue #411 has the full diagnostic + verification trace.

## Test plan
- [x] `npm view @ruvector/ruvllm@2.5.5 optionalDependencies` returns `2.0.1` for all 5 platforms
- [x] Clean `npm install @ruvector/ruvllm@2.5.5` pulls in `@ruvector/ruvllm-linux-x64-gnu@2.0.1` with `ruvllm.linux-x64-gnu.node` binary present
- [x] Clean `npm install @ruvector/ruvllm@2.5.4` (broken baseline) installs only the wrapper, confirming the original bug
- [ ] CI green

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)