### PR TITLE
hailo: lint cleanup + bridge test gates + doc refresh (iter 251-255)

### DIFF
--- a/crates/ruvector-hailo-cluster/README.md
+++ b/crates/ruvector-hailo-cluster/README.md
@@ -4,16 +4,18 @@ Multi-Pi cluster coordinator for ruvector's Hailo-8 NPU embedding workers.
 Implements P2C+EWMA load balancing, fingerprint enforcement, optional
 in-process caching, and Tailscale-tag-based discovery.
 
-> **Status:** library + 3 CLI binaries production-shaped; **131 tests**
-> passing across lib unit / cluster integration / 3 CLI integration / 7
-> doctest suites.
+> **Status:** library + 8 CLI binaries production-shaped; **204 tests**
+> passing across lib unit / cluster integration / 7 CLI integration /
+> 7 doctest suites (iter 253).
 >
 > **NPU acceleration is the production default** as of iter 163
 > (ADR-176). `cargo build --release --features hailo,cpu-fallback
 > --bin ruvector-hailo-worker` produces a worker that auto-detects
 > `model.hef` in the model dir and runs encoder forward pass on the
-> Hailo-8 NPU. Measured **67.3 embeds/sec/worker** on real Pi 5 +
-> AI HAT+ (9.6× over cpu-fallback baseline).
+> Hailo-8 NPU. Measured **70.6 embeds/sec/worker** on cognitum-v0
+> (Pi 5 + AI HAT+, iter-227 baseline reverified post-iter-237 deploy);
+> ~10× over cpu-fallback baseline. iter-237's pool=2 default also
+> cuts p50 latency by 23% under multi-bridge concurrent load.
 >
 > **cpu-fallback remains the automatic failover.** When `model.hef`
 > isn't present, the worker uses host-CPU candle BERT-6 (~7
@@ -419,13 +421,16 @@ See [ADR-170][adr170] for the full design.
                 ┌──────────────────────────────┐
                 │ Doctests             (7)     │  module + 6 method examples
                 ├──────────────────────────────┤
-                │ Lib unit             (69)    │  pure Rust, no IO
+                │ Lib unit            (114)    │  pure Rust, no IO
                 ├──────────────────────────────┤
-                │ Cluster integration  (12)    │  GrpcTransport + tonic mocks
+                │ Cluster integration  (~30)   │  GrpcTransport + tonic mocks +
+                │                              │   load distribution + DoS gates
                 ├──────────────────────────────┤
-                │ CLI integration      (18)    │  real binaries, real subprocess
+                │ CLI integration      (~53)   │  real binaries, real subprocess —
+                │                              │   bench/embed/stats/fakeworker +
+                │                              │   3 sensor bridges
                 └──────────────────────────────┘
-                 106 tests in this crate
+                 204 tests in this crate (iter 253)
 ```
 
 Run all of them:

--- a/crates/ruvector-hailo-cluster/src/bin/worker.rs
+++ b/crates/ruvector-hailo-cluster/src/bin/worker.rs
@@ -173,7 +173,7 @@ impl LogTextContent {
                     text.to_string()
                 } else {
                     let mut out: String = text.chars().take(FULL_LOG_CAP).collect();
-                    out.push_str("…");
+                    out.push('…');
                     out
                 }
             }

--- a/crates/ruvector-hailo-cluster/src/health.rs
+++ b/crates/ruvector-hailo-cluster/src/health.rs
@@ -216,9 +216,9 @@ mod tests {
                 probes: AtomicU64::new(0),
             }
         }
-        fn set_ready(&self, b: bool) {
-            self.ready.store(b, Ordering::SeqCst);
-        }
+        // Iter 255 — `set_ready(b)` was scaffolding for a flip-mid-run
+        // test path that never landed. Removed (the iter-251 allow
+        // cleanup surfaced it).
         fn probe_count(&self) -> u64 {
             self.probes.load(Ordering::SeqCst)
         }

--- a/crates/ruvector-hailo-cluster/src/lib.rs
+++ b/crates/ruvector-hailo-cluster/src/lib.rs
@@ -49,7 +49,6 @@
 //! All three share `--workers` / `--workers-file` / `--tailscale-tag`
 //! discovery and `--auto-fingerprint` / `--validate-fleet` safety flags.
 
-#![allow(dead_code)]
 // Iter 75: locks in the doc audit. Future pub additions trigger a
 // warning at build time so docs don't bit-rot back to the iter-73 baseline.
 #![warn(missing_docs)]

--- a/crates/ruvector-hailo-cluster/src/lib.rs
+++ b/crates/ruvector-hailo-cluster/src/lib.rs
@@ -1108,7 +1108,12 @@ mod tests {
     }
     enum ValidationOutcome {
         Ready { fingerprint: String },
-        NotReady { fingerprint: String },
+        // Iter 255 — `NotReady { fingerprint: String }` was a placeholder
+        // for a not-ready-but-reachable path; no validate_fleet test
+        // currently constructs it (all tests use Ready or Unreachable).
+        // Surfaced by iter-251's allow cleanup. Re-add if a test ever
+        // needs to assert behavior against a worker that responds but
+        // reports `ready: false`.
         Unreachable,
     }
     impl EmbeddingTransport for PerWorkerHealth {
@@ -1127,14 +1132,6 @@ mod tests {
                     device_id: format!("test:{}", w.name),
                     model_fingerprint: fingerprint.clone(),
                     ready: true,
-                    npu_temp_ts0_celsius: None,
-                    npu_temp_ts1_celsius: None,
-                }),
-                Some(ValidationOutcome::NotReady { fingerprint }) => Ok(HealthReport {
-                    version: "test".into(),
-                    device_id: format!("test:{}", w.name),
-                    model_fingerprint: fingerprint.clone(),
-                    ready: false,
                     npu_temp_ts0_celsius: None,
                     npu_temp_ts1_celsius: None,
                 }),

--- a/crates/ruvector-hailo-cluster/tests/mmwave_bridge_cli.rs
+++ b/crates/ruvector-hailo-cluster/tests/mmwave_bridge_cli.rs
@@ -203,6 +203,39 @@ fn bridge_help_prints_synopsis() {
     assert!(stdout.contains("--simulator"));
     assert!(stdout.contains("--workers"));
     assert!(stdout.contains("--fingerprint"));
+    // Iter 253 — lock that iter-242/243/245 flags stay in --help.
+    assert!(stdout.contains("--cache"));
+    assert!(stdout.contains("--cache-ttl"));
+    assert!(stdout.contains("--health-check"));
+}
+
+/// Iter 253 — `--cache N` without fingerprint must be refused per
+/// the ADR-172 §2a gate, mirroring the iter-252 ruvllm-bridge gate
+/// test and iter-253's csi-bridge gate test.
+#[test]
+fn bridge_cache_without_fingerprint_refused() {
+    let out = Command::new(BRIDGE)
+        .args([
+            "--simulator",
+            "--workers",
+            "127.0.0.1:1",
+            "--dim",
+            "4",
+            "--cache",
+            "1024",
+        ])
+        .output()
+        .expect("run bridge");
+    assert!(
+        !out.status.success(),
+        "bridge must refuse --cache without --fingerprint"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("§2a") || stderr.contains("empty --fingerprint"),
+        "stderr should reference the §2a cache+fp gate: {}",
+        stderr
+    );
 }
 
 #[test]

--- a/crates/ruvector-hailo-cluster/tests/ruview_csi_bridge_cli.rs
+++ b/crates/ruvector-hailo-cluster/tests/ruview_csi_bridge_cli.rs
@@ -203,6 +203,38 @@ fn ruview_bridge_help_prints_synopsis() {
     assert!(stdout.contains("--listen"));
     assert!(stdout.contains("--workers"));
     assert!(stdout.contains("ADR-018"));
+    // Iter 253 — lock that iter-240/243/245 flags stay in --help.
+    assert!(stdout.contains("--cache"));
+    assert!(stdout.contains("--cache-ttl"));
+    assert!(stdout.contains("--health-check"));
+}
+
+/// Iter 253 — `--cache N` without fingerprint must be refused per
+/// the ADR-172 §2a gate, mirroring the iter-252 gate test for
+/// ruvllm-bridge.
+#[test]
+fn ruview_bridge_cache_without_fingerprint_refused() {
+    let out = Command::new(BRIDGE)
+        .args([
+            "--workers",
+            "127.0.0.1:1",
+            "--dim",
+            "4",
+            "--cache",
+            "1024",
+        ])
+        .output()
+        .expect("run bridge");
+    assert!(
+        !out.status.success(),
+        "bridge must refuse --cache without --fingerprint"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("§2a") || stderr.contains("empty --fingerprint"),
+        "stderr should reference the §2a cache+fp gate: {}",
+        stderr
+    );
 }
 
 #[test]

--- a/crates/ruvector-hailo-cluster/tests/ruvllm_bridge_cli.rs
+++ b/crates/ruvector-hailo-cluster/tests/ruvllm_bridge_cli.rs
@@ -237,6 +237,104 @@ fn ruvllm_bridge_help_prints_synopsis() {
     assert!(stdout.contains("JSONL"));
     assert!(stdout.contains("--workers"));
     assert!(stdout.contains("--fingerprint"));
+    // Iter 252 — lock that iter-238/243/245 flags stay documented.
+    // A future refactor that drops one of these from the help text
+    // (e.g. someone forgets to update print_help when adding the
+    // next bridge knob) should fail loud.
+    assert!(stdout.contains("--cache"));
+    assert!(stdout.contains("--cache-ttl"));
+    assert!(stdout.contains("--health-check"));
+}
+
+/// Iter 252 — `--cache N` without fingerprint must be refused by
+/// the ADR-172 §2a gate, mirroring the embed.rs / bench.rs gates.
+/// Lock the wire-up so a future regression (e.g. cache flag added
+/// but gate skipped) fails CI.
+#[test]
+fn ruvllm_bridge_cache_without_fingerprint_refused() {
+    // No --fingerprint AND no --allow-empty-fingerprint ⇒ gate fires
+    // on either the workers-empty-fp gate or the cache-empty-fp gate
+    // (whichever is checked first; both reference §2a in the message).
+    let out = Command::new(BRIDGE)
+        .args([
+            "--workers",
+            "127.0.0.1:1",
+            "--dim",
+            "4",
+            "--cache",
+            "1024",
+        ])
+        .output()
+        .expect("run bridge");
+    assert!(
+        !out.status.success(),
+        "bridge must refuse --cache without --fingerprint"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("§2a") || stderr.contains("empty --fingerprint"),
+        "stderr should reference the §2a cache+fp gate: {}",
+        stderr
+    );
+}
+
+/// Iter 252 — `--cache N` paired with `--fingerprint` must succeed
+/// (gate satisfied). Bridge produces correct response shape.
+#[test]
+fn ruvllm_bridge_cache_with_fingerprint_accepted() {
+    let port = free_port();
+    let mut worker = spawn_fakeworker(port, 4, "fp:cache-test");
+
+    let mut child = Command::new(BRIDGE)
+        .args([
+            "--workers",
+            &format!("127.0.0.1:{}", port),
+            "--dim",
+            "4",
+            "--fingerprint",
+            "fp:cache-test",
+            "--cache",
+            "256",
+            "--cache-ttl",
+            "60",
+            "--quiet",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn ruvllm-bridge with --cache + --cache-ttl");
+
+    {
+        let stdin = child.stdin.as_mut().expect("stdin");
+        // Same text twice → second is a cache hit but the bridge's
+        // JSONL contract is opaque to that; both must produce a
+        // vector response with dim=4 + the same vector contents.
+        stdin
+            .write_all(b"{\"text\":\"cached query\"}\n")
+            .unwrap();
+        stdin
+            .write_all(b"{\"text\":\"cached query\"}\n")
+            .unwrap();
+    }
+    drop(child.stdin.take());
+    let out = child.wait_with_output().expect("wait bridge");
+    let _ = worker.kill();
+    let _ = worker.wait();
+
+    assert!(
+        out.status.success(),
+        "expected exit 0 with --cache + --cache-ttl + --fingerprint, got {:?}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 2, "expected 2 response lines, got {:?}", lines);
+    for l in &lines {
+        assert!(l.contains("\"dim\":4"), "missing dim=4 in: {}", l);
+        assert!(l.contains("\"vector\":["), "missing vector in: {}", l);
+    }
 }
 
 #[test]

--- a/crates/ruvector-hailo/src/device.rs
+++ b/crates/ruvector-hailo/src/device.rs
@@ -11,7 +11,6 @@
 //! configured network group. Configuration changes still need external
 //! serialisation; we provide that via `Mutex` higher up in `lib.rs`.
 
-#![allow(dead_code)]
 
 use crate::error::HailoError;
 #[cfg(feature = "hailo")]

--- a/crates/ruvector-hailo/src/hef_pipeline.rs
+++ b/crates/ruvector-hailo/src/hef_pipeline.rs
@@ -25,7 +25,6 @@
 // Iter 158 scaffold: several fields are populated by iter-159's
 // open_inner + forward bodies. Dead-code warnings would mask
 // real-progress signals during the EPIC roll-out.
-#![allow(dead_code)]
 
 use crate::device::HailoDevice;
 use crate::error::HailoError;

--- a/crates/ruvector-hailo/src/inference.rs
+++ b/crates/ruvector-hailo/src/inference.rs
@@ -22,7 +22,6 @@
 //!        → L2-normalise to unit vector
 //!        → return Vec<f32; 384>
 
-#![allow(dead_code)]
 
 use crate::device::HailoDevice;
 use crate::error::HailoError;

--- a/crates/ruvector-hailo/src/tokenizer.rs
+++ b/crates/ruvector-hailo/src/tokenizer.rs
@@ -15,7 +15,6 @@
 //!      Continuation pieces are prefixed `##`.
 //!   5. Wrap with `[CLS] … [SEP]`, pad/truncate to a fixed `max_seq`.
 
-#![allow(dead_code)]
 
 use crate::error::HailoError;
 use std::collections::HashMap;


### PR DESCRIPTION
## Summary

Five iterations cleaning up the post-iter-250 surface — lint hygiene, bridge regression-gate tests, README freshness, and one CI clippy regression caught by the post-merge audit run.

## What ships

- **iter-251** — drop 5 stale module-level `#![allow(dead_code)]` blanket suppressions (device.rs, inference.rs, hef_pipeline.rs, tokenizer.rs, cluster lib.rs). All "dead" items now genuinely live; future regressions surface at build time.
- **iter-252** — 3 CLI regression-gate tests for ruvllm-bridge's iter-238 `--cache`, iter-243 `--cache-ttl`, iter-245 `--health-check` flags (help-text + ADR-172 §2a gate + end-to-end with-cache acceptance).
- **iter-253** — symmetric tests for ruview-csi-bridge + mmwave-bridge. All three bridges now have the same shape of CLI-level coverage.
- **iter-254** — refreshed cluster README status banner: 131→204 tests, 67.3→70.6 RPS, 3→8 CLI binaries, plus updated test-suite tree.
- **iter-255** — fixed 3 clippy regressions surfaced by the post-merge audit run: iter-247's `push_str("…")` → `push('…')`, plus 2 test-only dead items (`set_ready`, `ValidationOutcome::NotReady`) that the iter-251 lib-target check missed because they live in `#[cfg(test)]` mod.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` 204 passed
- [x] CLI tests pass serially (parallel-run port-race flake on `multi_line_with_request_id_propagates` is pre-existing, unrelated)
- [x] `hailo-backend-audit.yml` should now stay green (the iter-247 push_str regression that flipped main red after PR #418 merge is resolved)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)