### PR TITLE
fix(rvf-wasm): publish as ESM-only to resolve #415

### DIFF
--- a/npm/packages/rvf-wasm/package.json
+++ b/npm/packages/rvf-wasm/package.json
@@ -1,22 +1,23 @@
 {
   "name": "@ruvector/rvf-wasm",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "RuVector Format WASM microkernel for browser and edge vector operations",
-  "main": "pkg/rvf_wasm.js",
+  "type": "module",
+  "main": "pkg/rvf_wasm.mjs",
   "types": "pkg/rvf_wasm.d.ts",
   "exports": {
     ".": {
       "types": "./pkg/rvf_wasm.d.ts",
-      "import": "./pkg/rvf_wasm.mjs",
-      "require": "./pkg/rvf_wasm.js",
-      "default": "./pkg/rvf_wasm.js"
+      "default": "./pkg/rvf_wasm.mjs"
     }
   },
   "files": [
     "pkg/"
   ],
   "scripts": {
-    "build": "cargo build --release --target wasm32-unknown-unknown --manifest-path ../../crates/rvf/rvf-wasm/Cargo.toml && wasm-opt -Oz ../../crates/rvf/target/wasm32-unknown-unknown/release/rvf_wasm.wasm -o pkg/rvf_wasm_bg.wasm"
+    "build": "cargo build --release --target wasm32-unknown-unknown --manifest-path ../../crates/rvf/rvf-wasm/Cargo.toml && wasm-opt -Oz ../../crates/rvf/target/wasm32-unknown-unknown/release/rvf_wasm.wasm -o pkg/rvf_wasm_bg.wasm",
+    "test": "node tests/smoke.mjs",
+    "prepublishOnly": "node tests/smoke.mjs"
   },
   "license": "MIT",
   "repository": {

--- a/npm/packages/rvf-wasm/tests/smoke.mjs
+++ b/npm/packages/rvf-wasm/tests/smoke.mjs
@@ -1,0 +1,39 @@
+// Smoke test: regression guard for issue #415.
+// Verifies that @ruvector/rvf-wasm can be loaded as ESM without
+// `SyntaxError: Cannot use 'import.meta' outside a module` and that
+// init() returns a usable WASM exports object.
+
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(__dirname, '..');
+
+let failures = 0;
+function assert(cond, msg) {
+  if (!cond) {
+    console.error('FAIL:', msg);
+    failures++;
+  } else {
+    console.log('  ok:', msg);
+  }
+}
+
+// 1. ESM import via package.json `default` (the published surface).
+const mod = await import(join(pkgRoot, 'pkg/rvf_wasm.mjs'));
+assert(typeof mod.default === 'function', 'mjs default export is a function');
+
+// 2. Initialize and confirm we got real WASM exports back.
+const exports_ = await mod.default();
+assert(exports_ != null && typeof exports_ === 'object', 'init() returned exports object');
+assert(exports_.memory instanceof WebAssembly.Memory, 'exports.memory is WebAssembly.Memory');
+
+// 3. Idempotent re-init returns the cached instance.
+const exports2 = await mod.default();
+assert(exports2 === exports_, 'init() is idempotent');
+
+if (failures > 0) {
+  console.error(`\n${failures} smoke check(s) failed`);
+  process.exit(1);
+}
+console.log('\nrvf-wasm smoke OK');


### PR DESCRIPTION
## Summary

- Fixes #415 — `@ruvector/rvf-wasm@0.1.6` was unloadable because `pkg/rvf_wasm.js` used `import.meta.url` and `export default` while `package.json` had no `"type": "module"`, so Node parsed it as CJS and threw `SyntaxError: Cannot use 'import.meta' outside a module` before any runtime guard could execute.
- This breaks every downstream `agentdb` / `@claude-flow/memory` / `ruflo` operation that touches the RVF backend (`memory init`, `hooks pretrain`, `status`, …).

## Fix

- Add `"type": "module"` and switch `main` → `pkg/rvf_wasm.mjs`.
- Drop the `require`/`default` exports that pointed at the broken CJS-classified `.js`. Node 22.12+ supports `require(ESM)` natively, so a single ESM entry covers both consumers.
- Add `tests/smoke.mjs` regression guard (also wired into `prepublishOnly`) that imports the package, calls `init()`, asserts real WASM memory, and confirms idempotency.
- Bump 0.1.5 → 0.1.7 (skip the broken 0.1.6).

## Proof

End-to-end against a packed tarball installed into `/tmp` on Node 22.22.2:

```
$ npm pack
ruvector-rvf-wasm-0.1.7.tgz

$ node --input-type=module -e "import('@ruvector/rvf-wasm').then(m => m.default()).then(e => console.log('memory bytes:', e.memory.buffer.byteLength))"
memory bytes: 1179648

$ node -e "require('@ruvector/rvf-wasm')"
# succeeds (Node 22.12+ require(ESM))

$ npm test
  ok: mjs default export is a function
  ok: init() returned exports object
  ok: exports.memory is WebAssembly.Memory
  ok: init() is idempotent

rvf-wasm smoke OK
```

## Test plan

- [x] `npm pack` succeeds; tarball contents unchanged (6 files, 21 KB).
- [x] ESM `await import('@ruvector/rvf-wasm')` resolves and `default()` returns real WASM exports.
- [x] CJS `require('@ruvector/rvf-wasm')` works on Node 22.12+ (no `SyntaxError`).
- [x] `npm test` passes (`tests/smoke.mjs`).
- [x] `prepublishOnly` runs the smoke test before any future publish.
- [ ] Manual: re-run `ruflo memory init` against a stack pinning `@ruvector/rvf-wasm@0.1.7` once published.

## Notes

- Local consumers (`@ruvector/rvf` `^0.1.5`, `@ruvector/rvlite` `>=0.1.0`) are unchanged — both already use `await import('@ruvector/rvf-wasm')`, which now works.
- Workaround in the issue (`sed`-patching installed `package.json`) is no longer needed once 0.1.7 is published.
- This PR does NOT publish — version bump is in-tree only; release pipeline owns the actual `npm publish`.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)