### PR TITLE
fix(ruvector): bundle ONNX runtime into dist/ on build (#354)

### DIFF
--- a/npm/packages/ruvector/package.json
+++ b/npm/packages/ruvector/package.json
@@ -8,7 +8,7 @@
     "ruvector": "./bin/cli.js"
   },
   "scripts": {
-    "build": "tsc && cp src/core/onnx/pkg/package.json dist/core/onnx/pkg/",
+    "build": "tsc && node scripts/copy-onnx-assets.js",
     "verify-dist": "node scripts/verify-dist.js",
     "prepublishOnly": "npm run build && npm run verify-dist",
     "test": "node test/integration.js && node test/cli-commands.js"

--- a/npm/packages/ruvector/scripts/copy-onnx-assets.js
+++ b/npm/packages/ruvector/scripts/copy-onnx-assets.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * copy-onnx-assets.js — copy non-TypeScript ONNX runtime files into `dist/`.
+ *
+ * Why: `tsconfig.json` does not set `allowJs`, so `tsc` only emits compiled
+ * `.ts` output. The wasm-bindgen artifacts under `src/core/onnx/pkg/`
+ * (`*.wasm`, `*_bg.js`, `*.d.ts`, `package.json`, `LICENSE`) and the
+ * sibling `src/core/onnx/loader.js` are required at runtime by
+ * `dist/core/onnx-embedder.js` but were not being copied — published
+ * tarballs were missing the WASM payload entirely (#354), making
+ * `OptimizedOnnxEmbedder` unloadable on every clean install.
+ *
+ * Implemented as a Node script (no `cp -r`) so the build runs unchanged
+ * on Windows.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const pkgRoot = path.resolve(__dirname, '..');
+
+function copyRecursive(src, dst) {
+  const stat = fs.statSync(src);
+  if (stat.isDirectory()) {
+    fs.mkdirSync(dst, { recursive: true });
+    for (const entry of fs.readdirSync(src)) {
+      // Skip dotfiles (e.g. transient `.claude-flow/` agent metadata)
+      // and node_modules — neither belongs in the published artifact.
+      if (entry.startsWith('.') || entry === 'node_modules') continue;
+      copyRecursive(path.join(src, entry), path.join(dst, entry));
+    }
+  } else {
+    fs.mkdirSync(path.dirname(dst), { recursive: true });
+    fs.copyFileSync(src, dst);
+  }
+}
+
+// (sourceRel, destinationRel) — both relative to the package root.
+const assets = [
+  ['src/core/onnx/loader.js', 'dist/core/onnx/loader.js'],
+  ['src/core/onnx/pkg', 'dist/core/onnx/pkg'],
+];
+
+let fileCount = 0;
+function countFiles(p) {
+  const stat = fs.statSync(p);
+  if (stat.isDirectory()) {
+    for (const entry of fs.readdirSync(p)) countFiles(path.join(p, entry));
+  } else {
+    fileCount++;
+  }
+}
+
+for (const [srcRel, dstRel] of assets) {
+  const src = path.join(pkgRoot, srcRel);
+  const dst = path.join(pkgRoot, dstRel);
+  if (!fs.existsSync(src)) {
+    console.error(`copy-onnx-assets: missing source ${srcRel}`);
+    process.exit(1);
+  }
+  copyRecursive(src, dst);
+  countFiles(src);
+}
+
+// Sanity check the runtime payload landed where the embedder expects it.
+const required = [
+  'dist/core/onnx/loader.js',
+  'dist/core/onnx/pkg/ruvector_onnx_embeddings_wasm_bg.js',
+  'dist/core/onnx/pkg/ruvector_onnx_embeddings_wasm_bg.wasm',
+  'dist/core/onnx/pkg/ruvector_onnx_embeddings_wasm.js',
+];
+const missing = required.filter((rel) => !fs.existsSync(path.join(pkgRoot, rel)));
+if (missing.length > 0) {
+  console.error('copy-onnx-assets: required files missing after copy:');
+  for (const m of missing) console.error(`  - ${m}`);
+  process.exit(1);
+}
+
+console.log(`copy-onnx-assets: ${fileCount} ONNX runtime file(s) staged under dist/.`);


### PR DESCRIPTION
## Summary

- Closes #354 — the published tarball shipped only a 1-line `dist/core/onnx/pkg/package.json` and **none** of the ONNX WASM runtime files. Every clean install failed at `initOnnxEmbedder()` with `Error: ONNX WASM files not bundled. The onnx/ directory is missing.`
- Same root cause as #417 (part 2). #417 still has CLI-handler bugs to fix on top of this; that work continues in a separate PR.

## Root cause

```
"build": "tsc && cp src/core/onnx/pkg/package.json dist/core/onnx/pkg/"
```

`tsc` only emits compiled `.ts` output (no `allowJs`), so the JS sources under `src/core/onnx/` (the wasm-bindgen `.wasm` payload, `_bg.js`, type defs, LICENSE, sibling `loader.js`) never reach `dist/`. The script copied a single `package.json` and called it a day.

## Fix

- Replace the single-file copy with `scripts/copy-onnx-assets.js`, a Node-portable recursive copy (no `cp -r`, works on Windows).
- Skip dotfiles (e.g. transient `.claude-flow/` agent metadata) and `node_modules/` so they don't leak into the published artifact.
- Sanity-check that the canonical runtime files (`*_bg.{js,wasm}`, `*.js`, `loader.js`) landed where `onnx-embedder.js` looks for them; fail the build loudly if not.

## Proof

On a fresh build of the current 0.2.25 working tree (Node 22.22.2):

```
$ rm -rf dist/core/onnx && npm run build
> tsc && node scripts/copy-onnx-assets.js
copy-onnx-assets: 10 ONNX runtime file(s) staged under dist/.

$ ls dist/core/onnx/pkg/
LICENSE                                  ruvector_onnx_embeddings_wasm_bg.js
loader.js                                ruvector_onnx_embeddings_wasm_bg.wasm
package.json                             ruvector_onnx_embeddings_wasm_bg.wasm.d.ts
ruvector_onnx_embeddings_wasm.d.ts       ruvector_onnx_embeddings_wasm.js

$ npm pack && tar -tzf ruvector-0.2.25.tgz | grep -c 'dist/core/onnx/pkg'
8

# Clean install in /tmp:
$ node -e "const {isOnnxAvailable} = require('ruvector/dist/core/onnx-embedder'); console.log(isOnnxAvailable())"
true
```

Tarball grew from 825 KB → 3.1 MB; that's the 7.4 MB MiniLM WASM payload (uncompressed) compressing to ~2.3 MB on top of the 825 KB baseline — expected since this is the file the consumer was previously missing.

## Test plan

- [x] `npm run build` lands all 10 ONNX runtime files under `dist/core/onnx/`.
- [x] `npm pack` includes them in the tarball (`grep -c onnx/pkg = 8`).
- [x] Clean install of the packed tarball makes `isOnnxAvailable()` return `true` (was `false`/throw before).
- [x] Build does not leak transient `.claude-flow/` dotfiles into the artifact.
- [x] Script doesn't depend on `cp` (portable to Windows).
- [ ] Optional follow-up: extend `verify-dist.js` to assert the ONNX runtime files exist (best done after #433 lands to avoid merge conflicts).

## Scope notes

- This PR only fixes the bundling (#354). It does not touch the CLI handler bugs reported in #417 — those are a separate fix.
- Once this lands, the loader change in #432 (Node 22 LTS .wasm extension fix, #323) can be exercised end-to-end on a clean install.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)