### PR TITLE
fix(ruvector): ONNX wasm bundle + brain MCP ESM errors + supply-chain CI

### DIFF
--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -184,7 +184,7 @@ jobs:
           cd /tmp/pkgcopy
           # Detach from the parent workspace.
           rm -f package-lock.json
-          npm install --no-audit --no-fund --legacy-peer-deps --no-workspaces
+          npm install --no-audit --no-fund --legacy-peer-deps --no-workspaces --no-optional
           mkdir -p /tmp/pack
           npm pack --pack-destination /tmp/pack
           tar -tzf /tmp/pack/*.tgz | head -30

--- a/crates/sona/src/training/federated.rs
+++ b/crates/sona/src/training/federated.rs
@@ -232,7 +232,7 @@ impl EphemeralAgent {
 
     /// Get learned patterns from agent
     pub fn get_patterns(&self) -> Vec<LearnedPattern> {
-        self.engine.find_patterns(&[], 0)
+        self.engine.get_all_patterns()
     }
 
     /// Export agent state for federation
@@ -416,10 +416,8 @@ impl FederatedCoordinator {
     ///
     /// Returns learned patterns that new agents can use for warm start.
     pub fn get_initial_patterns(&self, k: usize) -> Vec<LearnedPattern> {
-        // Find patterns similar to a general query (empty or average)
-        // Since we don't have a specific query, get all patterns
         self.master_engine
-            .find_patterns(&[], 0)
+            .get_all_patterns()
             .into_iter()
             .take(k)
             .collect()
@@ -427,7 +425,7 @@ impl FederatedCoordinator {
 
     /// Get all learned patterns
     pub fn get_all_patterns(&self) -> Vec<LearnedPattern> {
-        self.master_engine.find_patterns(&[], 0)
+        self.master_engine.get_all_patterns()
     }
 
     /// Get coordinator statistics

--- a/npm/packages/ruvector/bin/mcp-server.js
+++ b/npm/packages/ruvector/bin/mcp-server.js
@@ -3307,7 +3307,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const results = await client.search(args.query, { limit: args.limit || 10, category: args.category });
           return { content: [{ type: 'text', text: JSON.stringify({ success: true, ...results }, null, 2) }] };
         } catch (e) {
-          if (e.code === 'MODULE_NOT_FOUND') {
+          if (e.code === 'MODULE_NOT_FOUND' || e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
             return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: 'Brain tools require @ruvector/pi-brain', hint: 'npm install @ruvector/pi-brain' }, null, 2) }] };
           }
           return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: e.message }, null, 2) }], isError: true };
@@ -3324,7 +3324,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const result = await client.share({ title: args.title, content: args.content, category: args.category || 'pattern', tags: args.tags });
           return { content: [{ type: 'text', text: JSON.stringify({ success: true, ...result }, null, 2) }] };
         } catch (e) {
-          if (e.code === 'MODULE_NOT_FOUND') {
+          if (e.code === 'MODULE_NOT_FOUND' || e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
             return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: 'Brain tools require @ruvector/pi-brain', hint: 'npm install @ruvector/pi-brain' }, null, 2) }] };
           }
           return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: e.message }, null, 2) }], isError: true };
@@ -3341,7 +3341,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const result = await client.get(args.id);
           return { content: [{ type: 'text', text: JSON.stringify({ success: true, ...result }, null, 2) }] };
         } catch (e) {
-          if (e.code === 'MODULE_NOT_FOUND') {
+          if (e.code === 'MODULE_NOT_FOUND' || e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
             return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: 'Brain tools require @ruvector/pi-brain', hint: 'npm install @ruvector/pi-brain' }, null, 2) }] };
           }
           return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: e.message }, null, 2) }], isError: true };
@@ -3358,7 +3358,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const result = await client.vote(args.id, args.direction);
           return { content: [{ type: 'text', text: JSON.stringify({ success: true, ...result }, null, 2) }] };
         } catch (e) {
-          if (e.code === 'MODULE_NOT_FOUND') {
+          if (e.code === 'MODULE_NOT_FOUND' || e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
             return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: 'Brain tools require @ruvector/pi-brain', hint: 'npm install @ruvector/pi-brain' }, null, 2) }] };
           }
           return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: e.message }, null, 2) }], isError: true };
@@ -3375,7 +3375,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const results = await client.list({ category: args.category, limit: args.limit || 20 });
           return { content: [{ type: 'text', text: JSON.stringify({ success: true, ...results }, null, 2) }] };
         } catch (e) {
-          if (e.code === 'MODULE_NOT_FOUND') {
+          if (e.code === 'MODULE_NOT_FOUND' || e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
             return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: 'Brain tools require @ruvector/pi-brain', hint: 'npm install @ruvector/pi-brain' }, null, 2) }] };
           }
           return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: e.message }, null, 2) }], isError: true };
@@ -3392,7 +3392,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const result = await client.delete(args.id);
           return { content: [{ type: 'text', text: JSON.stringify({ success: true, ...result }, null, 2) }] };
         } catch (e) {
-          if (e.code === 'MODULE_NOT_FOUND') {
+          if (e.code === 'MODULE_NOT_FOUND' || e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
             return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: 'Brain tools require @ruvector/pi-brain', hint: 'npm install @ruvector/pi-brain' }, null, 2) }] };
           }
           return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: e.message }, null, 2) }], isError: true };
@@ -3409,7 +3409,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const result = await client.status();
           return { content: [{ type: 'text', text: JSON.stringify({ success: true, ...result }, null, 2) }] };
         } catch (e) {
-          if (e.code === 'MODULE_NOT_FOUND') {
+          if (e.code === 'MODULE_NOT_FOUND' || e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
             return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: 'Brain tools require @ruvector/pi-brain', hint: 'npm install @ruvector/pi-brain' }, null, 2) }] };
           }
           return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: e.message }, null, 2) }], isError: true };
@@ -3426,7 +3426,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const result = await client.drift({ domain: args.domain });
           return { content: [{ type: 'text', text: JSON.stringify({ success: true, ...result }, null, 2) }] };
         } catch (e) {
-          if (e.code === 'MODULE_NOT_FOUND') {
+          if (e.code === 'MODULE_NOT_FOUND' || e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
             return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: 'Brain tools require @ruvector/pi-brain', hint: 'npm install @ruvector/pi-brain' }, null, 2) }] };
           }
           return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: e.message }, null, 2) }], isError: true };
@@ -3443,7 +3443,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const result = await client.partition({ domain: args.domain, min_cluster_size: args.min_cluster_size || 3 });
           return { content: [{ type: 'text', text: JSON.stringify({ success: true, ...result }, null, 2) }] };
         } catch (e) {
-          if (e.code === 'MODULE_NOT_FOUND') {
+          if (e.code === 'MODULE_NOT_FOUND' || e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
             return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: 'Brain tools require @ruvector/pi-brain', hint: 'npm install @ruvector/pi-brain' }, null, 2) }] };
           }
           return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: e.message }, null, 2) }], isError: true };
@@ -3460,7 +3460,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const result = await client.transfer(args.source, args.target);
           return { content: [{ type: 'text', text: JSON.stringify({ success: true, ...result }, null, 2) }] };
         } catch (e) {
-          if (e.code === 'MODULE_NOT_FOUND') {
+          if (e.code === 'MODULE_NOT_FOUND' || e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
             return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: 'Brain tools require @ruvector/pi-brain', hint: 'npm install @ruvector/pi-brain' }, null, 2) }] };
           }
           return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: e.message }, null, 2) }], isError: true };
@@ -3477,7 +3477,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const result = await client.sync({ direction: args.direction || 'both' });
           return { content: [{ type: 'text', text: JSON.stringify({ success: true, ...result }, null, 2) }] };
         } catch (e) {
-          if (e.code === 'MODULE_NOT_FOUND') {
+          if (e.code === 'MODULE_NOT_FOUND' || e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
             return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: 'Brain tools require @ruvector/pi-brain', hint: 'npm install @ruvector/pi-brain' }, null, 2) }] };
           }
           return { content: [{ type: 'text', text: JSON.stringify({ success: false, error: e.message }, null, 2) }], isError: true };

--- a/npm/packages/ruvector/package.json
+++ b/npm/packages/ruvector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvector",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "Self-learning vector database for Node.js — hybrid search, Graph RAG, FlashAttention-3, HNSW, 50+ attention mechanisms",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -8,7 +8,7 @@
     "ruvector": "./bin/cli.js"
   },
   "scripts": {
-    "build": "tsc && mkdir -p dist/core/onnx/pkg && cp src/core/onnx/pkg/package.json dist/core/onnx/pkg/",
+    "build": "tsc && mkdir -p dist/core/onnx/pkg && cp -r src/core/onnx/pkg/. dist/core/onnx/pkg/",
     "verify-dist": "node scripts/verify-dist.js",
     "prepack": "npm run build && npm run verify-dist",
     "prepublishOnly": "npm run build && npm run verify-dist",

--- a/npm/packages/ruvector/src/core/intelligence-engine.ts
+++ b/npm/packages/ruvector/src/core/intelligence-engine.ts
@@ -272,23 +272,12 @@ export class IntelligenceEngine {
   // =========================================================================
 
   /**
-   * Generate embedding using ONNX, attention, or hash (in order of preference)
+   * Generate embedding using attention or hash (sync). Use embedAsync() for ONNX.
    */
   embed(text: string): number[] {
     const dim = this.config.embeddingDim;
 
-    // Try ONNX semantic embeddings first (best quality)
-    if (this.onnxReady && this.onnxEmbedder) {
-      try {
-        // Note: This is sync wrapper for async ONNX
-        // For full async, use embedAsync
-        return this.hashEmbed(text, dim); // Fallback for sync context
-      } catch {
-        // Fall through
-      }
-    }
-
-    // Try to use attention-based embedding
+    // Try to use attention-based embedding (best sync quality)
     if (this.attention?.DotProductAttention) {
       try {
         return this.attentionEmbed(text, dim);

--- a/npm/packages/ruvector/src/core/onnx-embedder.ts
+++ b/npm/packages/ruvector/src/core/onnx-embedder.ts
@@ -177,26 +177,29 @@ export async function initOnnxEmbedder(config: OnnxEmbedderConfig = {}): Promise
   loadPromise = (async () => {
     try {
       // Paths to bundled ONNX files
-      const pkgPath = path.join(__dirname, 'onnx', 'pkg', 'ruvector_onnx_embeddings_wasm.js');
+      const bgJsPath = path.join(__dirname, 'onnx', 'pkg', 'ruvector_onnx_embeddings_wasm_bg.js');
+      const wasmPath = path.join(__dirname, 'onnx', 'pkg', 'ruvector_onnx_embeddings_wasm_bg.wasm');
       const loaderPath = path.join(__dirname, 'onnx', 'loader.js');
 
-      if (!fs.existsSync(pkgPath)) {
+      if (!fs.existsSync(bgJsPath) || !fs.existsSync(wasmPath)) {
         throw new Error('ONNX WASM files not bundled. The onnx/ directory is missing.');
       }
 
-      // Convert paths to file:// URLs for cross-platform ESM compatibility (Windows fix)
-      const pkgUrl = pathToFileURL(pkgPath).href;
+      // Load the bg.js module directly (avoids the ESM `import * as wasm from "*.wasm"`
+      // in the main .js shim which requires --experimental-wasm-modules on Node 18-24).
+      const bgUrl = pathToFileURL(bgJsPath).href;
       const loaderUrl = pathToFileURL(loaderPath).href;
+      wasmModule = await dynamicImport(bgUrl);
 
-      // Dynamic import of bundled modules using file:// URLs
-      wasmModule = await dynamicImport(pkgUrl);
-
-      // Initialize WASM module (loads the .wasm file)
-      const wasmPath = path.join(__dirname, 'onnx', 'pkg', 'ruvector_onnx_embeddings_wasm_bg.wasm');
-      if (wasmModule.default && typeof wasmModule.default === 'function') {
-        // For bundler-style initialization, pass the wasm buffer
-        const wasmBytes = fs.readFileSync(wasmPath);
-        await wasmModule.default(wasmBytes);
+      // Instantiate the .wasm bytes via WebAssembly API (no --experimental-wasm-modules needed).
+      const wasmBytes = fs.readFileSync(wasmPath);
+      const wasmResult = await WebAssembly.instantiate(wasmBytes, { './ruvector_onnx_embeddings_wasm_bg.js': wasmModule });
+      const wasmExports = wasmResult.instance.exports;
+      if (typeof wasmModule.__wbg_set_wasm === 'function') {
+        wasmModule.__wbg_set_wasm(wasmExports);
+      }
+      if (typeof (wasmExports as any).__wbindgen_start === 'function') {
+        (wasmExports as any).__wbindgen_start();
       }
 
       const loaderModule = await dynamicImport(loaderUrl);

--- a/npm/packages/ruvector/tsconfig.json
+++ b/npm/packages/ruvector/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "WebWorker"],
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
## Summary

- **#354** — `ruvector@0.2.26`: build script now copies all `src/core/onnx/pkg/*` into `dist/` (was only copying `package.json`), resolving missing WASM runtime assets on clean installs
- **#372** — MCP `brain_*` tools: extend the 11 pi-brain error guards to catch `ERR_REQUIRE_ESM` and `ERR_PACKAGE_PATH_NOT_EXPORTED` in addition to `MODULE_NOT_FOUND`, so they fail gracefully when `@ruvector/pi-brain` is ESM-only or its CJS export path is absent
- **CI** — `regression-guard.yml` npm-publish-pipeline: add `--no-optional` to `npm install` to prevent `EBADPLATFORM` failures for platform-specific router binaries on linux/x64 runners
- **#430** — HNSW insert beam uses `ef_construction` (not clamped), distance-based pruning keeps closest neighbours, storage rebuild on reopen
- **Supply-chain** — 5-layer supply-chain CI guard (`supply-chain.yml`), Dependabot config, `deny.toml`

## Test plan

- [x] `node test/integration.js` → all structure tests pass
- [x] `node test/cli-commands.js` → 56/69 pass (13 pre-existing failures unrelated to this PR)
- [x] `cargo clippy -p ruvllm_sparse_attention` → clean
- [x] `cargo audit` → 3 allowed warnings only (imageproc, pre-existing)
- [x] `cargo deny check` → warnings only, no errors
- [x] `dist/core/onnx/pkg/` now contains all WASM assets after build
- [x] mcp-server.js brain error guards verified at 11 sites

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)