### PR TITLE
feat(mcp-brain-server): add ruvllm-embedder HTTP binary for obsidian-brain

### DIFF
--- a/crates/mcp-brain-server/src/bin/embedder.rs
+++ b/crates/mcp-brain-server/src/bin/embedder.rs
@@ -52,17 +52,16 @@ struct ErrorResponse {
     error: String,
 }
 
-async fn embed(
-    State(state): State<AppState>,
-    Json(req): Json<EmbedRequest>,
-) -> impl IntoResponse {
+async fn embed(State(state): State<AppState>, Json(req): Json<EmbedRequest>) -> impl IntoResponse {
     if req.texts.is_empty() {
         return (
             StatusCode::BAD_REQUEST,
-            Json(serde_json::to_value(ErrorResponse {
-                error: "texts array must not be empty".into(),
-            })
-            .unwrap()),
+            Json(
+                serde_json::to_value(ErrorResponse {
+                    error: "texts array must not be empty".into(),
+                })
+                .unwrap(),
+            ),
         );
     }
 
@@ -73,7 +72,10 @@ async fn embed(
         corpus_size: engine.corpus_size(),
         vectors,
     };
-    (StatusCode::OK, Json(serde_json::to_value(response).unwrap()))
+    (
+        StatusCode::OK,
+        Json(serde_json::to_value(response).unwrap()),
+    )
 }
 
 async fn health(State(state): State<AppState>) -> impl IntoResponse {
@@ -92,8 +94,7 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
 async fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
         .init();
 


### PR DESCRIPTION
## Summary

- Adds `ruvllm-embedder` binary to `mcp-brain-server` that exposes `EmbeddingEngine` over HTTP on port 9877
- Resolves the missing binary that `obsidian-brain` references via `run-dev.sh`
- No new dependencies — uses existing axum + EmbeddingEngine already in the crate

## Endpoints

| Method | Path | Body | Response |
|--------|------|------|----------|
| POST | /embed | `{"texts":["..."]}` | `{"vectors":[[...]], "engine":"...", "corpus_size":N}` |
| GET | /health | — | `{"status":"ok","engine":"...","embed_dim":N,"corpus_size":N,"rlm_active":bool}` |

## Build

```bash
cargo build --release -p mcp-brain-server --bin ruvllm-embedder
./target/release/ruvllm-embedder  # listens on :9877
# or
EMBEDDER_PORT=9999 ./target/release/ruvllm-embedder
```

## Test plan

- [ ] `cargo build -p mcp-brain-server --bin ruvllm-embedder` succeeds
- [ ] `curl -s localhost:9877/health` returns `{"status":"ok",...}`
- [ ] `curl -s -X POST localhost:9877/embed -H 'Content-Type: application/json' -d '{"texts":["hello world"]}' | jq '.vectors[0] | length'` returns 128
- [ ] obsidian-brain's `run-dev.sh` can start without the 16-dim stub fallback

Fixes #455

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)