### PR TITLE
fix: cognitive cycle spawn_blocking + ruvector-postgres version bump

### DIFF
--- a/crates/mcp-brain-server/src/main.rs
+++ b/crates/mcp-brain-server/src/main.rs
@@ -32,8 +32,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Wait 30s before first cycle (let startup finish, data load)
         tokio::time::sleep(std::time::Duration::from_secs(30)).await;
 
-        // Run an initial enhanced cycle on startup to bootstrap cognitive state (full retrain)
-        let result = routes::run_enhanced_training_cycle(&train_state, true);
+        // Run an initial enhanced cycle on startup to bootstrap cognitive state (full retrain).
+        // spawn_blocking avoids starving HTTP handlers during the CPU-intensive bootstrap.
+        let result = {
+            let state = train_state.clone();
+            tokio::task::spawn_blocking(move || routes::run_enhanced_training_cycle(&state, true))
+                .await
+                .unwrap_or_default()
+        };
         tracing::info!(
             "Initial cognitive bootstrap: props={}, inferences={}, voice={}, curiosity={}, strange_loop={:.4}",
             result.propositions_extracted, result.inferences_derived,
@@ -115,7 +121,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // to benefit from incremental processing; the function auto-forces a full
                 // retrain every 24h.
                 if new_memories > 0 || new_votes > 0 || tick_count % 15 == 0 {
-                    let result = routes::run_enhanced_training_cycle(&train_state, false);
+                    let result = {
+                        let state = train_state.clone();
+                        tokio::task::spawn_blocking(move || {
+                            routes::run_enhanced_training_cycle(&state, false)
+                        })
+                        .await
+                        .unwrap_or_default()
+                    };
                     tracing::info!(
                         "Cognitive cycle #{} ({}): props={}, inferences={}, voice={}, auto_votes={}, \
                          curiosity={}, sona_patterns={}, strange_loop={:.4}, lora_auto={}, processed={}/{}",

--- a/crates/mcp-brain-server/src/routes.rs
+++ b/crates/mcp-brain-server/src/routes.rs
@@ -474,7 +474,7 @@ pub fn run_training_cycle(state: &AppState) -> TrainingCycleResult {
 }
 
 /// Enhanced training result (ADR-110)
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct EnhancedTrainingResult {
     pub sona_message: String,
     pub sona_patterns: usize,

--- a/crates/ruvector-postgres/Cargo.toml
+++ b/crates/ruvector-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruvector-postgres"
-version = "0.3.0"
+version = "2.0.1"
 edition = "2021"
 license = "MIT"
 description = "High-performance PostgreSQL vector database extension v2 - pgvector drop-in replacement with 230+ SQL functions, SIMD acceleration, Flash Attention, GNN layers, hybrid search, multi-tenancy, self-healing, and self-learning capabilities"

--- a/crates/ruvector-postgres/Dockerfile
+++ b/crates/ruvector-postgres/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for ruvector-postgres extension
 # Builds the extension and creates a PostgreSQL image with it installed
-# v0.3.1: Fixes — Cypher self-reference, graph/RDF persistence, SONA dimension panic
+# v2.0.1: Extension version aligned with Docker image tag (fixes #271)
 
 # Build stage
 # Using nightly Rust to support edition2024 crates in the registry


### PR DESCRIPTION
## Summary

- **Closes #305**: `run_enhanced_training_cycle` is CPU-intensive (200 auto-votes, LoRA submissions, SONA pattern extraction, inference). Calling it directly in a `tokio::spawn` async context blocks the executor thread, starving HTTP handlers. Fixed by wrapping both the startup bootstrap call and the recurring cycle call in `tokio::task::spawn_blocking`.
- **Closes #271**: `ruvector-postgres` Cargo.toml had `version = "0.3.0"` while the Docker image was tagged `2.0.1`. Bumped to `2.0.1` so `CREATE EXTENSION ruvector` installs the correct version in new deployments.

## Changes

- `crates/mcp-brain-server/src/main.rs`: wrap both `run_enhanced_training_cycle` calls with `spawn_blocking`
- `crates/mcp-brain-server/src/routes.rs`: add `Default` derive to `EnhancedTrainingResult` for clean error recovery
- `crates/ruvector-postgres/Cargo.toml`: `version = "0.3.0"` → `"2.0.1"`
- `crates/ruvector-postgres/Dockerfile`: update version comment

## Test plan

- [ ] `cargo check -p mcp-brain-server` passes (verified locally)
- [ ] Full CI suite passes (pre-existing failures: Security Audit RUSTSEC, PostgreSQL 17 macos linker)
- [ ] Verify HTTP endpoints remain responsive during cognitive cycles after deploy

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)