### PR TITLE
fix(gnn): remove broken linux-arm64-musl target from build matrix

### DIFF
--- a/.github/workflows/build-gnn.yml
+++ b/.github/workflows/build-gnn.yml
@@ -40,9 +40,6 @@ jobs:
           - host: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             platform: linux-arm64-gnu
-          - host: ubuntu-22.04
-            target: aarch64-unknown-linux-musl
-            platform: linux-arm64-musl
           - host: macos-14
             target: x86_64-apple-darwin
             platform: darwin-x64
@@ -87,12 +84,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
 
-      - name: Install cross-compilation tools (Linux ARM64 musl)
-        if: matrix.settings.platform == 'linux-arm64-musl'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu musl-tools
-
       - name: Install NAPI-RS CLI
         run: npm install -g @napi-rs/cli
 
@@ -106,7 +97,6 @@ jobs:
           napi build --platform --release --target ${{ matrix.settings.target }} -p ruvector-gnn-node
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
 
       - name: Find built .node files (debug)
         shell: bash
@@ -161,7 +151,7 @@ jobs:
           echo "=== Downloaded artifacts ==="
           find artifacts -name "*.node"
 
-          for platform in linux-x64-gnu linux-x64-musl linux-arm64-gnu linux-arm64-musl darwin-x64 darwin-arm64 win32-x64-msvc; do
+          for platform in linux-x64-gnu linux-x64-musl linux-arm64-gnu darwin-x64 darwin-arm64 win32-x64-msvc; do
             if [ -d "artifacts/gnn-bindings-${platform}" ]; then
               mkdir -p "crates/ruvector-gnn-node/npm/${platform}"
               cp -v artifacts/gnn-bindings-${platform}/*.node "crates/ruvector-gnn-node/npm/${platform}/" || true
@@ -255,10 +245,6 @@ jobs:
               linux-arm64-gnu)
                 OS="linux"; CPU="arm64"; LIBC='"libc": ["glibc"],'
                 NODE_NAME="ruvector-gnn.linux-arm64-gnu.node"
-                ;;
-              linux-arm64-musl)
-                OS="linux"; CPU="arm64"; LIBC='"libc": ["musl"],'
-                NODE_NAME="ruvector-gnn.linux-arm64-musl.node"
                 ;;
               darwin-x64)
                 OS="darwin"; CPU="x64"; LIBC=""

--- a/crates/ruvector-gnn-node/package.json
+++ b/crates/ruvector-gnn-node/package.json
@@ -12,7 +12,6 @@
         "x86_64-unknown-linux-gnu",
         "x86_64-unknown-linux-musl",
         "aarch64-unknown-linux-gnu",
-        "aarch64-unknown-linux-musl",
         "x86_64-apple-darwin",
         "aarch64-apple-darwin",
         "x86_64-pc-windows-msvc"
@@ -56,7 +55,6 @@
     "@ruvector/gnn-linux-x64-gnu": "0.1.25",
     "@ruvector/gnn-linux-x64-musl": "0.1.25",
     "@ruvector/gnn-linux-arm64-gnu": "0.1.25",
-    "@ruvector/gnn-linux-arm64-musl": "0.1.25",
     "@ruvector/gnn-darwin-x64": "0.1.25",
     "@ruvector/gnn-darwin-arm64": "0.1.25",
     "@ruvector/gnn-win32-x64-msvc": "0.1.25"


### PR DESCRIPTION
## Summary

The `linux-arm64-musl` target in `build-gnn.yml` used `aarch64-linux-gnu-gcc` as its linker — the GNU ABI compiler, not a musl cross-compiler. Building for `aarch64-unknown-linux-musl` requires `aarch64-linux-musl-gcc` which is not available as an Ubuntu apt package without significant extra setup.

This caused every ARM64 musl build to fail silently. The binary was never uploaded as an artifact, never committed, and never published to npm — but `@ruvector/gnn-linux-arm64-musl@0.1.25` was declared as an optional dependency, causing npm warnings on every install.

## Changes

- Remove `linux-arm64-musl` from the build matrix in `build-gnn.yml`
- Remove the wrong `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER` env var
- Remove its apt install step
- Remove `@ruvector/gnn-linux-arm64-musl` from `package.json` optionalDependencies
- Remove `aarch64-unknown-linux-musl` from the napi triples list
- Remove `linux-arm64-musl` from the commit-binaries and publish platform loops

## Impact

- The `linux-arm64-gnu` (glibc) target covers the vast majority of ARM64 Linux use cases (GitHub Codespaces, AWS Graviton, Raspberry Pi OS)
- Partial fix for #110 — the `linux-arm64-gnu` binary was always building correctly; this removes the confusion from the missing musl sibling

## Test plan

- [ ] CI passes for all remaining platforms (linux-x64-gnu, linux-x64-musl, linux-arm64-gnu, darwin-x64, darwin-arm64, win32-x64-msvc)
- [ ] `@ruvector/gnn-linux-arm64-gnu` installs successfully on ARM64 Linux

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)