### PR TITLE
fix(simd): remove outdated nightly-only comment; add AVX-512 CI compile check

### DIFF
--- a/.github/workflows/ruvector-postgres-ci.yml
+++ b/.github/workflows/ruvector-postgres-ci.yml
@@ -229,6 +229,10 @@ jobs:
         run: cargo build --features pg17,index-all,quant-all,graph-complete --release
         working-directory: crates/ruvector-postgres
 
+      - name: Build with AVX-512 feature (compile-check on stable Rust)
+        run: cargo build --features pg17,simd-avx512 --release
+        working-directory: crates/ruvector-postgres
+
       - name: Test with all features
         run: cargo pgrx test pg17 --features index-all,quant-all,graph-complete
         working-directory: crates/ruvector-postgres

--- a/crates/ruvector-postgres/src/distance/simd.rs
+++ b/crates/ruvector-postgres/src/distance/simd.rs
@@ -22,9 +22,8 @@ use simsimd::SpatialSimilarity;
 // SIMD Feature Detection
 // ============================================================================
 
-/// Check if AVX-512F is available at runtime
-/// Note: AVX-512 intrinsics require nightly Rust, so this returns false on stable builds
-/// To enable AVX-512, compile with --features simd-avx512 on nightly Rust
+/// Check if AVX-512F is available at runtime.
+/// Requires compiling with `--features simd-avx512` (stable Rust 1.72+).
 #[cfg(target_arch = "x86_64")]
 #[inline]
 pub fn is_avx512_available() -> bool {


### PR DESCRIPTION
## Summary

- Remove misleading `/// Note: AVX-512 intrinsics require nightly Rust` comment — these have been stable since Rust 1.72; we're on 1.95
- Add a compile-check step in `ruvector-postgres-ci.yml` with `--features simd-avx512` so any future regression breaks CI immediately
- Runtime detection was already correct: `is_x86_feature_detected!("avx512f")` returns `false` at runtime on runners without AVX-512 HW, so no false positives

The actual AVX-512 intrinsic implementations (`_mm512_loadu_ps`, `_mm512_fmadd_ps`, `_mm512_reduce_add_ps`, `_mm512_abs_ps`) were already complete and correct. This PR fixes only the misleading nightly comment and adds CI coverage.

## Test plan

- [ ] CI `test-all-features` job should now include `Build with AVX-512 feature` step
- [ ] Locally: `rustc --edition 2021` test of AVX-512 intrinsics compiles cleanly on stable

Closes #47

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)