### PR TITLE
fix(ts): remove rootDir+declaration from agentic-synth-examples tsconfig

### DIFF
--- a/npm/packages/agentic-synth-examples/tsconfig.json
+++ b/npm/packages/agentic-synth-examples/tsconfig.json
@@ -10,11 +10,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "declaration": true,
-    "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
     "types": ["node"],
     "paths": {
       "@ruvector/agentic-synth": ["../agentic-synth/src/index.ts"],


### PR DESCRIPTION
## Summary
- Fixes 9 remaining TS6059 errors in `agentic-synth-examples` after previous PR #499

## Root cause
The `paths` alias resolves `@ruvector/agentic-synth` to source files in the sibling package (`../agentic-synth/src/index.ts`). TypeScript TS6059 fires when any resolved file is outside `rootDir`. Since the sibling's source is inherently outside any `rootDir` scoped to this package, removing `rootDir` (TypeScript auto-detects it) and `declaration`/`declarationMap` (not needed for an examples package) eliminates the errors.

## Test plan
- [x] All packages typecheck with 0 errors
- [x] 69/69 CLI integration tests pass
- [x] Workspace build passes

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)