### PR TITLE
fix(security): imageproc 0.26 + NaN panic hardening across ruvllm/ruvector-postgres

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,67 @@
+# cargo-audit configuration for the ruvector workspace.
+#
+# Ignored advisories MUST have a justification. Anything fixable should be
+# fixed via a dependency bump rather than ignored here. Re-evaluate the
+# `until` dates periodically.
+
+[advisories]
+ignore = [
+    # ------------------------------------------------------------------
+    # Vulnerabilities (genuinely no upstream fix available)
+    # ------------------------------------------------------------------
+
+    # rsa 0.9.x — Marvin Attack (timing sidechannel on RSA decryption).
+    # No fixed upgrade is available from upstream `rsa`. We do not expose
+    # an RSA decryption oracle: TLS in this workspace runs on rustls with
+    # Ed25519/X25519 suites, and `rsa` is pulled only transitively (e.g.
+    # SQL drivers, JWT verification paths) where we never decrypt
+    # attacker-controlled ciphertexts under a long-lived RSA key.
+    # Re-evaluate when the `rsa` crate ships a constant-time implementation.
+    "RUSTSEC-2023-0071",
+
+    # ------------------------------------------------------------------
+    # "Unmaintained" warnings (informational, not vulnerabilities)
+    # ------------------------------------------------------------------
+    # These are pulled transitively through deps we do not control. They
+    # are not exploitable on their own; they are notices that the upstream
+    # crate is no longer accepting patches. We mute them to keep CI clean
+    # and revisit when the parent dep migrates.
+
+    "RUSTSEC-2021-0140",  # rusttype — transitive via plotters; pure rendering, no untrusted input
+    "RUSTSEC-2022-0054",  # wee_alloc — transitive via wasm-bindgen-cli internals
+    "RUSTSEC-2024-0370",  # proc-macro-error — build-time only (proc-macro), no runtime exposure
+    "RUSTSEC-2024-0380",  # pqcrypto-dilithium — replaced by pqcrypto-mldsa, awaiting parent migration
+    "RUSTSEC-2024-0381",  # pqcrypto-kyber — replaced by pqcrypto-mlkem, awaiting parent migration
+    "RUSTSEC-2024-0384",  # instant — transitive via parking_lot/older time deps
+    "RUSTSEC-2024-0388",  # derivative — transitive proc-macro
+    "RUSTSEC-2024-0436",  # paste — transitive proc-macro, build-time only
+    "RUSTSEC-2025-0119",  # number_prefix — transitive via indicatif rendering
+    "RUSTSEC-2025-0124",  # rand_os — transitive, replaced by getrandom in modern code paths
+    "RUSTSEC-2025-0134",  # rustls-pemfile — transitive; rustls itself is current
+    "RUSTSEC-2025-0141",  # bincode — unmaintained notice; we pin a known-good version
+    "RUSTSEC-2026-0105",  # core2 — transitive, no_std fallback for std::io types
+
+    # ------------------------------------------------------------------
+    # Soundness/unsoundness notices in deps we do not directly control
+    # ------------------------------------------------------------------
+
+    # lru — IterMut Stacked Borrows violation. Used transitively; we do
+    # not call IterMut from the affected crate. Track parent dep upgrade.
+    "RUSTSEC-2024-0408",
+
+    # pprof — unsound `slice::from_raw_parts` usage. Only loaded behind
+    # benchmark/profiling features, never in production binaries.
+    "RUSTSEC-2026-0002",
+
+    # rand — unsoundness when using a custom global logger with rand::rng().
+    # We never install a custom logger in the rand call path. Awaiting
+    # transitive upgrade across the workspace.
+    "RUSTSEC-2026-0097",
+
+    # imageproc 0.25.0 advisories — RESOLVED: bumped to imageproc 0.26.2.
+    # Keeping the IDs commented out for historical reference; remove this
+    # block on next audit.toml cleanup.
+    # "RUSTSEC-2026-0115",  # fixed in 0.26+
+    # "RUSTSEC-2026-0116",  # fixed in 0.26+
+    # "RUSTSEC-2026-0117",  # fixed in 0.26+
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,19 @@
 version = 3
 
 [[package]]
+name = "a2a-swarm"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "reqwest 0.12.28",
+ "rvagent-cli",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "ab_glyph"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,7 +90,6 @@ dependencies = [
  "cfg-if 1.0.4",
  "getrandom 0.3.4",
  "once_cell",
- "serde",
  "version_check",
  "zerocopy",
 ]
@@ -145,16 +157,6 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "rayon",
-]
-
-[[package]]
-name = "annotate-snippets"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
-dependencies = [
- "unicode-width 0.1.11",
- "yansi-term",
 ]
 
 [[package]]
@@ -396,16 +398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "atomic-traits"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29ec3788e96fb4fdb275ccb9d62811f2fa903d76c5eb4dd6fe7d09a7ed5871f"
-dependencies = [
- "cfg-if 1.0.4",
- "rustc_version 0.3.3",
 ]
 
 [[package]]
@@ -749,19 +741,20 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "annotate-snippets",
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.117",
 ]
@@ -838,18 +831,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake3"
 version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,7 +883,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -911,7 +892,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -1011,15 +992,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "candle-core"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,7 +1002,7 @@ dependencies = [
  "candle-metal-kernels",
  "cudarc",
  "gemm 0.17.1",
- "half 2.7.1",
+ "half",
  "memmap2",
  "metal 0.27.0",
  "num-traits",
@@ -1038,7 +1010,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_distr 0.5.1",
  "rayon",
- "safetensors 0.4.5",
+ "safetensors",
  "thiserror 1.0.69",
  "ug",
  "ug-cuda",
@@ -1076,11 +1048,11 @@ checksum = "be1160c3b63f47d40d91110a3e1e1e566ae38edddbbf492a60b40ffc3bc1ff38"
 dependencies = [
  "candle-core",
  "candle-metal-kernels",
- "half 2.7.1",
+ "half",
  "metal 0.27.0",
  "num-traits",
  "rayon",
- "safetensors 0.4.5",
+ "safetensors",
  "serde",
  "thiserror 1.0.69",
 ]
@@ -1109,39 +1081,6 @@ name = "cargo-husky"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver 1.0.28",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cargo_toml"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be"
-dependencies = [
- "serde",
- "toml",
-]
 
 [[package]]
 name = "cassowary"
@@ -1174,16 +1113,6 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
-]
-
-[[package]]
-name = "cee-scape"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d67dfb052149f779f77e9ce089cea126e00657e8f0d11dafc7901fde4291101"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -1268,7 +1197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half 2.7.1",
+ "half",
 ]
 
 [[package]]
@@ -1300,17 +1229,6 @@ checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
-]
-
-[[package]]
-name = "clap-cargo"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2ea69cefa96b848b73ad516ad1d59a195cdf9263087d977f648a818c8b43e"
-dependencies = [
- "anstyle",
- "cargo_metadata",
- "clap",
 ]
 
 [[package]]
@@ -1388,7 +1306,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -1423,7 +1341,7 @@ dependencies = [
  "criterion 0.5.1",
  "libm",
  "proptest",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -1540,21 +1458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compact_str"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
-dependencies = [
- "castaway",
- "cfg-if 1.0.4",
- "itoa",
- "rustversion",
- "ryu",
- "serde",
- "static_assertions",
-]
-
-[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,30 +1481,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "connectome-fly"
-version = "0.1.0"
-dependencies = [
- "bincode 1.3.3",
- "bytemuck",
- "criterion 0.5.1",
- "csv",
- "cudarc",
- "flate2",
- "rand 0.8.5",
- "rand_distr 0.4.3",
- "rand_xoshiro",
- "ruvector-attention",
- "ruvector-mincut 2.2.0",
- "ruvector-sparsifier",
- "serde",
- "serde_json",
- "smallvec 1.15.1",
- "tempfile",
- "thiserror 1.0.69",
- "wide",
 ]
 
 [[package]]
@@ -1804,7 +1683,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
- "rustc_version 0.4.1",
+ "rustc_version",
 ]
 
 [[package]]
@@ -2064,7 +1943,7 @@ version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486c221362668c63a1636cfa51463b09574433b39029326cff40864b3ba12b6e"
 dependencies = [
- "half 2.7.1",
+ "half",
  "libloading 0.8.9",
 ]
 
@@ -2079,7 +1958,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "rustc_version 0.4.1",
+ "rustc_version",
  "subtle",
  "zeroize",
 ]
@@ -2162,15 +2041,6 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "dary_heap"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2548,7 +2418,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -2632,26 +2502,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "enum-map"
-version = "2.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
-dependencies = [
- "enum-map-derive",
-]
-
-[[package]]
-name = "enum-map-derive"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2767,22 +2617,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
 dependencies = [
  "bit_field",
- "half 2.7.1",
+ "half",
  "lebe",
  "miniz_oxide",
  "rayon-core",
  "smallvec 1.15.1",
  "zune-inflate",
-]
-
-[[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
 ]
 
 [[package]]
@@ -2815,27 +2655,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastembed"
-version = "5.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac43f4d16a7b3ad7bf6805f66939a1fadacba46df3610198ca93c0d488759035"
-dependencies = [
- "anyhow",
- "hf-hub 0.4.3",
- "image 0.25.10",
- "ndarray 0.16.1",
- "ort",
- "safetensors 0.7.0",
- "serde",
- "serde_json",
- "tokenizers 0.22.2",
-]
-
-[[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
@@ -3063,7 +2886,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -3092,12 +2915,6 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusion-blossom"
@@ -3340,7 +3157,7 @@ checksum = "a2e7ea062c987abcd8db95db917b4ffb4ecdfd0668471d8dc54734fdff2354e8"
 dependencies = [
  "bytemuck",
  "dyn-stack 0.10.0",
- "half 2.7.1",
+ "half",
  "num-complex 0.4.6",
  "num-traits",
  "once_cell",
@@ -3360,7 +3177,7 @@ checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
 dependencies = [
  "bytemuck",
  "dyn-stack 0.13.2",
- "half 2.7.1",
+ "half",
  "libm",
  "num-complex 0.4.6",
  "num-traits",
@@ -3382,7 +3199,7 @@ dependencies = [
  "dyn-stack 0.10.0",
  "gemm-common 0.17.1",
  "gemm-f32 0.17.1",
- "half 2.7.1",
+ "half",
  "num-complex 0.4.6",
  "num-traits",
  "paste",
@@ -3400,7 +3217,7 @@ dependencies = [
  "dyn-stack 0.13.2",
  "gemm-common 0.18.2",
  "gemm-f32 0.18.2",
- "half 2.7.1",
+ "half",
  "num-complex 0.4.6",
  "num-traits",
  "paste",
@@ -3732,6 +3549,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0746aa765db78b521451ef74221663b57ba595bf83f75d0ce23cc09447c8139f"
+dependencies = [
+ "cfg-if 1.0.4",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot 0.12.5",
+ "portable-atomic",
+ "quanta",
+ "smallvec 1.15.1",
+ "spinning_top",
+]
+
+[[package]]
 name = "gpu-alloc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3867,10 +3703,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+name = "hailort-sys"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+]
 
 [[package]]
 name = "half"
@@ -3884,17 +3721,7 @@ dependencies = [
  "num-traits",
  "rand 0.9.2",
  "rand_distr 0.5.1",
- "serde",
  "zerocopy",
-]
-
-[[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -3932,9 +3759,13 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -4030,17 +3861,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
-]
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -4078,42 +3899,24 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hf-hub"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b780635574b3d92f036890d8373433d6f9fc7abb320ee42a5c25897fc8ed732"
-dependencies = [
- "dirs 5.0.1",
- "futures",
- "indicatif",
- "log",
- "native-tls",
- "num_cpus",
- "rand 0.8.5",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "ureq 2.12.1",
-]
-
-[[package]]
-name = "hf-hub"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
  "dirs 6.0.0",
+ "futures",
  "http 1.4.0",
  "indicatif",
  "libc",
  "log",
  "native-tls",
+ "num_cpus",
  "rand 0.9.2",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "ureq 2.12.1",
  "windows-sys 0.60.2",
 ]
@@ -4307,20 +4110,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
@@ -4328,10 +4117,10 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.6",
 ]
@@ -4524,16 +4313,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
@@ -4603,20 +4382,21 @@ dependencies = [
 
 [[package]]
 name = "imageproc"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2393fb7808960751a52e8a154f67e7dd3f8a2ef9bd80d1553078a7b4e8ed3f0d"
+checksum = "645329c490783f3ea465d2b6c7c08286fece97f15e714fd533b6c70a3ead2252"
 dependencies = [
  "ab_glyph",
  "approx",
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "image 0.25.10",
- "itertools 0.12.1",
- "nalgebra 0.32.6",
+ "itertools 0.14.0",
+ "nalgebra 0.34.2",
  "num 0.4.3",
- "rand 0.8.5",
- "rand_distr 0.4.3",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
  "rayon",
+ "rustdct",
 ]
 
 [[package]]
@@ -4624,12 +4404,6 @@ name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
-
-[[package]]
-name = "indenter"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
@@ -4699,7 +4473,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -4770,12 +4544,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "is_ci"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -5202,7 +4970,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -5286,12 +5054,12 @@ dependencies = [
  "ruvector-consciousness",
  "ruvector-delta-core",
  "ruvector-domain-expansion",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
  "ruvector-nervous-system",
  "ruvector-solver",
  "ruvector-sona 0.2.0",
  "ruvector-sparsifier",
- "ruvllm 2.2.0",
+ "ruvllm 2.2.3",
  "rvf-crypto",
  "rvf-federation",
  "rvf-runtime",
@@ -5612,6 +5380,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "munge"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5637,7 +5411,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -5811,7 +5585,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "semver 1.0.28",
+ "semver",
  "syn 2.0.117",
 ]
 
@@ -6624,7 +6398,7 @@ dependencies = [
  "ruqu-algorithms",
  "ruvector-attention",
  "ruvector-cluster",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "ruvector-delta-core",
  "ruvector-filter",
  "ruvector-gnn",
@@ -6663,16 +6437,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owo-colors"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
-dependencies = [
- "supports-color 2.1.0",
- "supports-color 3.0.2",
-]
-
-[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6688,7 +6452,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -6784,17 +6548,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
 dependencies = [
- "rustc_version 0.4.1",
-]
-
-[[package]]
-name = "pathsearch"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da983bc5e582ab17179c190b4b66c7d76c5943a69c6d34df2a2b6bf8a2977b05"
-dependencies = [
- "anyhow",
- "libc",
+ "rustc_version",
 ]
 
 [[package]]
@@ -6806,6 +6560,16 @@ dependencies = [
  "crossbeam-channel",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -6883,133 +6647,6 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap 2.12.1",
-]
-
-[[package]]
-name = "pgrx"
-version = "0.12.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227bf7e162ce710994306a97bc56bb3fe305f21120ab6692e2151c48416f5c0d"
-dependencies = [
- "atomic-traits",
- "bitflags 2.11.0",
- "bitvec",
- "enum-map",
- "heapless",
- "libc",
- "once_cell",
- "pgrx-macros",
- "pgrx-pg-sys",
- "pgrx-sql-entity-graph",
- "seahash",
- "serde",
- "serde_cbor",
- "serde_json",
- "thiserror 1.0.69",
- "uuid",
-]
-
-[[package]]
-name = "pgrx-bindgen"
-version = "0.12.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cbcd956c2da35baaf0a116e6f6a49a6c2fbc8f6b332f66d6fd060bfd00615f"
-dependencies = [
- "bindgen",
- "cc",
- "clang-sys",
- "eyre",
- "pgrx-pg-config",
- "proc-macro2",
- "quote",
- "shlex",
- "syn 2.0.117",
- "walkdir",
-]
-
-[[package]]
-name = "pgrx-macros"
-version = "0.12.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f4291450d65e4deb770ce57ea93e22353d97950566222429cd166ebdf6f938"
-dependencies = [
- "pgrx-sql-entity-graph",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pgrx-pg-config"
-version = "0.12.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a64a4c6e4e43e73cf8d3379d9533df98ded45c920e1ba8131c979633d74132"
-dependencies = [
- "cargo_toml",
- "eyre",
- "home",
- "owo-colors",
- "pathsearch",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "toml",
- "url",
-]
-
-[[package]]
-name = "pgrx-pg-sys"
-version = "0.12.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a5dc64f2a8226434118aa2c4700450fa42b04f29488ad98268848b21c1a4ec"
-dependencies = [
- "cee-scape",
- "libc",
- "pgrx-bindgen",
- "pgrx-macros",
- "pgrx-sql-entity-graph",
- "serde",
- "sptr",
-]
-
-[[package]]
-name = "pgrx-sql-entity-graph"
-version = "0.12.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81cc2e851c7e36b2f47c03e22d64d56c1d0e762fbde0039ba2cd490cfef3615"
-dependencies = [
- "convert_case",
- "eyre",
- "petgraph",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "thiserror 1.0.69",
- "unescape",
-]
-
-[[package]]
-name = "pgrx-tests"
-version = "0.12.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2dd5d674cb7d92024709543da06d26723a2f7450c02083116b232587160929"
-dependencies = [
- "clap-cargo",
- "eyre",
- "libc",
- "owo-colors",
- "paste",
- "pgrx",
- "pgrx-macros",
- "pgrx-pg-config",
- "postgres",
- "proptest",
- "rand 0.8.5",
- "regex",
- "serde",
- "serde_json",
- "sysinfo 0.30.13",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7202,20 +6839,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "postgres"
-version = "0.19.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacf632d0554ff75f58183694f41dc8999c8a3a43a386994d0ec2d034f1dfbe1"
-dependencies = [
- "bytes",
- "fallible-iterator 0.2.0",
- "futures-util",
- "log",
- "tokio",
- "tokio-postgres",
-]
-
-[[package]]
 name = "postgres-protocol"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7405,6 +7028,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "prime-radiant"
 version = "0.1.0"
 dependencies = [
@@ -7438,11 +7070,11 @@ dependencies = [
  "rkyv",
  "roaring",
  "ruvector-attention",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "ruvector-gnn",
  "ruvector-graph",
  "ruvector-hyperbolic-hnsw",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
  "ruvector-nervous-system",
  "ruvector-raft",
  "ruvector-sona 0.2.0",
@@ -7512,6 +7144,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7587,6 +7241,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7597,6 +7271,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -7618,6 +7301,70 @@ checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "ptr_meta"
@@ -7772,7 +7519,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.2",
- "rustls 0.23.37",
+ "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -7792,7 +7539,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.2",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -7835,12 +7582,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_trie"
@@ -8104,7 +7845,7 @@ checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags 2.11.0",
  "cassowary",
- "compact_str 0.8.1",
+ "compact_str",
  "crossterm 0.28.1",
  "indoc",
  "instability",
@@ -8220,17 +7961,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon-cond"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
-dependencies = [
- "either",
- "itertools 0.14.0",
- "rayon",
-]
-
-[[package]]
 name = "rayon-core"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8239,6 +7969,19 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "wasm_sync",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -8256,7 +7999,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -8343,7 +8086,7 @@ dependencies = [
  "ndarray 0.16.1",
  "rand 0.8.5",
  "rand_distr 0.4.3",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -8418,7 +8161,6 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -8428,8 +8170,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -8437,13 +8178,11 @@ dependencies = [
  "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -8464,7 +8203,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
@@ -8475,7 +8214,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -8483,7 +8222,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.8",
@@ -8530,13 +8269,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.12.1",
  "munge",
  "ptr_meta",
@@ -8549,9 +8288,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8591,7 +8330,7 @@ dependencies = [
 
 [[package]]
 name = "ruqu"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "blake3",
  "cognitum-gate-tilezero 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8718,20 +8457,34 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.28",
+ "semver",
+]
+
+[[package]]
+name = "rustdct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b61555105d6a9bf98797c063c362a1d24ed8ab0431655e38f1cf51e52089551"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex 0.4.6",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
 ]
 
 [[package]]
@@ -8762,18 +8515,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -8782,7 +8523,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -8797,6 +8538,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8808,19 +8558,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -8878,8 +8618,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruvector-acorn"
+version = "2.2.3"
+dependencies = [
+ "criterion 0.5.1",
+ "rand 0.8.5",
+ "rand_distr 0.4.3",
+ "rayon",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ruvector-acorn-wasm"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "getrandom 0.2.17",
+ "js-sys",
+ "ruvector-acorn",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "ruvector-attention"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "approx",
  "criterion 0.5.1",
@@ -8894,7 +8657,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-attention-node"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "napi",
  "napi-build",
@@ -8926,7 +8689,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-attention-wasm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -8941,7 +8704,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-attn-mincut"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -8950,7 +8713,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-bench"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -8971,12 +8734,12 @@ dependencies = [
  "rayon",
  "ruvector-cognitive-container",
  "ruvector-coherence",
- "ruvector-core 2.2.0",
- "ruvector-mincut 2.2.0",
+ "ruvector-core 2.2.3",
+ "ruvector-mincut 2.2.3",
  "serde",
  "serde_json",
  "statistical",
- "sysinfo 0.31.4",
+ "sysinfo",
  "tabled",
  "tempfile",
  "thiserror 2.0.18",
@@ -9000,8 +8763,8 @@ dependencies = [
  "rand 0.8.5",
  "rand_distr 0.4.3",
  "rayon",
- "reqwest 0.11.27",
- "ruvector-core 2.2.0",
+ "reqwest 0.12.28",
+ "ruvector-core 2.2.3",
  "rvf-crypto",
  "rvf-types",
  "rvf-wire",
@@ -9018,7 +8781,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-cli"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9043,7 +8806,7 @@ dependencies = [
  "predicates",
  "prettytable-rs",
  "rand 0.8.5",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "ruvector-gnn",
  "ruvector-graph",
  "serde",
@@ -9076,12 +8839,12 @@ dependencies = [
  "rand_distr 0.4.3",
  "rayon",
  "ruvector-attention",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "ruvector-gnn",
  "ruvector-graph",
  "serde",
  "serde_json",
- "sysinfo 0.31.4",
+ "sysinfo",
  "thiserror 2.0.18",
  "tokio",
  "tower 0.4.13",
@@ -9092,7 +8855,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-cluster"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
@@ -9101,7 +8864,7 @@ dependencies = [
  "futures",
  "parking_lot 0.12.5",
  "rand 0.8.5",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -9112,7 +8875,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-cnn"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "criterion 0.5.1",
  "fastrand",
@@ -9140,7 +8903,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-cognitive-container"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "proptest",
  "serde",
@@ -9150,7 +8913,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-coherence"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -9158,14 +8921,14 @@ dependencies = [
 
 [[package]]
 name = "ruvector-collections"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "bincode 2.0.1",
  "chrono",
  "criterion 0.5.1",
  "dashmap 6.1.0",
  "parking_lot 0.12.5",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -9174,7 +8937,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-consciousness"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "approx",
  "criterion 0.5.1",
@@ -9186,7 +8949,7 @@ dependencies = [
  "ruvector-cognitive-container",
  "ruvector-coherence",
  "ruvector-math",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
  "ruvector-solver",
  "ruvector-sparsifier",
  "serde",
@@ -9196,7 +8959,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-consciousness-wasm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "getrandom 0.2.17",
  "js-sys",
@@ -9262,7 +9025,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-core"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -9270,7 +9033,7 @@ dependencies = [
  "criterion 0.5.1",
  "crossbeam",
  "dashmap 6.1.0",
- "hf-hub 0.3.2",
+ "hf-hub",
  "hnsw_rs",
  "memmap2",
  "mockall",
@@ -9283,14 +9046,14 @@ dependencies = [
  "rand_distr 0.4.3",
  "rayon",
  "redb",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "rkyv",
  "serde",
  "serde_json",
  "simsimd",
  "tempfile",
  "thiserror 2.0.18",
- "tokenizers 0.20.4",
+ "tokenizers",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -9303,7 +9066,7 @@ dependencies = [
  "approx",
  "ruvector-attention",
  "ruvector-gnn",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -9311,7 +9074,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-dag"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "criterion 0.5.1",
  "crossbeam",
@@ -9323,7 +9086,7 @@ dependencies = [
  "pqcrypto-kyber",
  "proptest",
  "rand 0.8.5",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -9348,7 +9111,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-decompiler"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "criterion 0.5.1",
  "memchr",
@@ -9357,7 +9120,7 @@ dependencies = [
  "ort",
  "rayon",
  "regex",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
  "serde",
  "serde_json",
  "sha3",
@@ -9366,7 +9129,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-decompiler-wasm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -9470,7 +9233,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-diskann"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "bincode 2.0.1",
  "bytemuck",
@@ -9487,7 +9250,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-diskann-node"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "napi",
  "napi-build",
@@ -9508,7 +9271,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-domain-expansion"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "criterion 0.5.1",
  "proptest",
@@ -9551,7 +9314,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-exotic-wasm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -9567,12 +9330,12 @@ dependencies = [
 
 [[package]]
 name = "ruvector-filter"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "chrono",
  "dashmap 6.1.0",
  "ordered-float",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -9618,7 +9381,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-gnn"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "criterion 0.5.1",
@@ -9634,7 +9397,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_distr 0.4.3",
  "rayon",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "serde",
  "serde_json",
  "tempfile",
@@ -9643,7 +9406,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-gnn-node"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "napi",
  "napi-build",
@@ -9654,7 +9417,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-gnn-wasm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -9669,7 +9432,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-graph"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -9709,7 +9472,7 @@ dependencies = [
  "rkyv",
  "roaring",
  "ruvector-cluster",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "ruvector-raft",
  "ruvector-replication",
  "serde",
@@ -9730,14 +9493,14 @@ dependencies = [
 
 [[package]]
 name = "ruvector-graph-node"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "futures",
  "napi",
  "napi-build",
  "napi-derive",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "ruvector-graph",
  "serde",
  "serde_json",
@@ -9749,14 +9512,14 @@ dependencies = [
 
 [[package]]
 name = "ruvector-graph-transformer"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "proptest",
  "rand 0.8.5",
  "ruvector-attention",
  "ruvector-coherence",
  "ruvector-gnn",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
  "ruvector-solver",
  "ruvector-verified",
  "serde",
@@ -9765,7 +9528,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-graph-transformer-node"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "napi",
  "napi-build",
@@ -9777,7 +9540,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-graph-transformer-wasm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "js-sys",
  "serde",
@@ -9789,7 +9552,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-graph-wasm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -9798,7 +9561,7 @@ dependencies = [
  "js-sys",
  "parking_lot 0.12.5",
  "regex",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "ruvector-graph",
  "serde",
  "serde-wasm-bindgen",
@@ -9810,6 +9573,53 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+]
+
+[[package]]
+name = "ruvector-hailo"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "candle-core",
+ "candle-nn",
+ "candle-transformers",
+ "criterion 0.5.1",
+ "hailort-sys",
+ "proptest",
+ "ruvector-core 2.2.3",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokenizers",
+]
+
+[[package]]
+name = "ruvector-hailo-cluster"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "criterion 0.5.1",
+ "dashmap 6.1.0",
+ "ed25519-dalek",
+ "futures-core",
+ "governor 0.7.0",
+ "prost",
+ "protoc-bin-vendored",
+ "rcgen",
+ "ruvector-core 2.2.3",
+ "ruvector-hailo",
+ "ruvector-mmwave",
+ "ruvllm 2.2.3",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -9864,7 +9674,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-math"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "approx",
  "criterion 0.5.1",
@@ -9879,7 +9689,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-math-wasm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -9897,7 +9707,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-metrics"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "chrono",
  "lazy_static",
@@ -9952,7 +9762,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-mincut"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "criterion 0.5.1",
@@ -9966,7 +9776,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "roaring",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "ruvector-graph",
  "serde",
  "serde_json",
@@ -10011,24 +9821,24 @@ dependencies = [
 
 [[package]]
 name = "ruvector-mincut-node"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "ruvector-mincut-wasm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
  "js-sys",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -10037,8 +9847,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruvector-mmwave"
+version = "0.0.1"
+
+[[package]]
 name = "ruvector-nervous-system"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "approx",
@@ -10072,14 +9886,14 @@ dependencies = [
 
 [[package]]
 name = "ruvector-node"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "napi",
  "napi-build",
  "napi-derive",
  "ruvector-collections",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "ruvector-filter",
  "ruvector-metrics",
  "serde",
@@ -10090,58 +9904,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruvector-postgres"
-version = "0.3.0"
+name = "ruvector-profiler"
+version = "2.2.3"
 dependencies = [
- "approx",
- "bincode 1.3.3",
- "bitvec",
- "chrono",
- "criterion 0.5.1",
- "crossbeam",
- "dashmap 6.1.0",
- "fastembed",
- "half 2.7.1",
- "home",
- "lazy_static",
- "memmap2",
- "once_cell",
- "ordered-float",
- "parking_lot 0.12.5",
- "pgrx",
- "pgrx-tests",
- "priority-queue 2.7.0",
- "proptest",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rayon",
- "rkyv",
- "ruvector-attention",
- "ruvector-domain-expansion",
- "ruvector-math",
- "ruvector-mincut-gated-transformer 0.1.0",
- "ruvector-solver",
- "ruvector-sona 0.2.0",
  "serde",
  "serde_json",
- "simsimd",
  "tempfile",
- "thiserror 1.0.69",
- "tracing",
 ]
 
 [[package]]
-name = "ruvector-profiler"
-version = "2.2.0"
+name = "ruvector-rabitq"
+version = "2.2.3"
 dependencies = [
+ "criterion 0.5.1",
+ "rand 0.8.5",
+ "rand_distr 0.4.3",
+ "rayon",
  "serde",
  "serde_json",
- "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ruvector-rabitq-wasm"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "getrandom 0.2.17",
+ "js-sys",
+ "ruvector-rabitq",
+ "serde",
+ "serde-wasm-bindgen",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
 name = "ruvector-raft"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "bincode 2.0.1",
  "chrono",
@@ -10149,7 +9949,7 @@ dependencies = [
  "futures",
  "parking_lot 0.12.5",
  "rand 0.8.5",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -10159,8 +9959,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruvector-rairs"
+version = "0.1.0"
+dependencies = [
+ "criterion 0.5.1",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
 name = "ruvector-replication"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "bincode 2.0.1",
  "chrono",
@@ -10168,7 +9977,7 @@ dependencies = [
  "futures",
  "parking_lot 0.12.5",
  "rand 0.8.5",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -10203,7 +10012,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-router-cli"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10218,7 +10027,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-router-core"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -10245,7 +10054,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-router-ffi"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10260,7 +10069,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-router-wasm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "js-sys",
  "ruvector-router-core",
@@ -10273,8 +10082,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruvector-rulake"
+version = "2.2.3"
+dependencies = [
+ "hex",
+ "rand 0.8.5",
+ "rand_distr 0.4.3",
+ "rayon",
+ "ruvector-rabitq",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ruvector-scipix"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -10301,7 +10125,7 @@ dependencies = [
  "futures",
  "getrandom 0.3.4",
  "glob",
- "governor",
+ "governor 0.6.3",
  "hmac 0.12.1",
  "hyper 1.9.0",
  "image 0.25.10",
@@ -10347,12 +10171,12 @@ dependencies = [
 
 [[package]]
 name = "ruvector-server"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "axum 0.7.9",
  "dashmap 6.1.0",
  "parking_lot 0.12.5",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -10365,13 +10189,13 @@ dependencies = [
 
 [[package]]
 name = "ruvector-snapshot"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
  "chrono",
  "flate2",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -10382,7 +10206,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-solver"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "approx",
  "criterion 0.5.1",
@@ -10401,7 +10225,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-solver-node"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "napi",
  "napi-build",
@@ -10414,7 +10238,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-solver-wasm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "getrandom 0.2.17",
  "js-sys",
@@ -10464,12 +10288,12 @@ dependencies = [
 
 [[package]]
 name = "ruvector-sparse-inference"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "byteorder",
  "criterion 0.5.1",
- "half 2.7.1",
+ "half",
  "memmap2",
  "mockall",
  "ndarray 0.16.1",
@@ -10487,7 +10311,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-sparsifier"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "approx",
  "criterion 0.5.1",
@@ -10505,7 +10329,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-sparsifier-wasm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -10520,11 +10344,11 @@ dependencies = [
 
 [[package]]
 name = "ruvector-temporal-tensor"
-version = "2.2.0"
+version = "2.2.3"
 
 [[package]]
 name = "ruvector-tiny-dancer-core"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -10554,7 +10378,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-tiny-dancer-node"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10571,7 +10395,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-tiny-dancer-wasm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "js-sys",
  "ruvector-tiny-dancer-core",
@@ -10592,7 +10416,7 @@ dependencies = [
  "proptest",
  "ruvector-cognitive-container",
  "ruvector-coherence",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -10614,7 +10438,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-wasm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -10627,7 +10451,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "rand 0.8.5",
  "ruvector-collections",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "ruvector-filter",
  "serde",
  "serde-wasm-bindgen",
@@ -10672,7 +10496,7 @@ dependencies = [
  "ruvix-types",
  "serde",
  "serde_json",
- "sysinfo 0.31.4",
+ "sysinfo",
  "tabled",
 ]
 
@@ -10837,7 +10661,7 @@ dependencies = [
  "dashmap 6.1.0",
  "dirs 5.0.1",
  "futures-core",
- "half 2.7.1",
+ "half",
  "md5",
  "ndarray 0.16.1",
  "once_cell",
@@ -10859,7 +10683,7 @@ dependencies = [
 
 [[package]]
 name = "ruvllm"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10873,8 +10697,8 @@ dependencies = [
  "dashmap 6.1.0",
  "dirs 5.0.1",
  "futures-core",
- "half 2.7.1",
- "hf-hub 0.3.2",
+ "half",
+ "hf-hub",
  "md5",
  "memmap2",
  "metal 0.29.0",
@@ -10889,7 +10713,7 @@ dependencies = [
  "rayon",
  "regex",
  "ruvector-attention",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "ruvector-gnn",
  "ruvector-graph",
  "ruvector-sona 0.2.0",
@@ -10899,7 +10723,7 @@ dependencies = [
  "smallvec 1.15.1",
  "tempfile",
  "thiserror 2.0.18",
- "tokenizers 0.20.4",
+ "tokenizers",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -10909,7 +10733,7 @@ dependencies = [
 
 [[package]]
 name = "ruvllm-cli"
-version = "2.2.0"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -10924,12 +10748,12 @@ dependencies = [
  "dialoguer",
  "dirs 5.0.1",
  "futures",
- "hf-hub 0.3.2",
+ "hf-hub",
  "indicatif",
  "predicates",
  "prettytable-rs",
  "rustyline",
- "ruvllm 2.2.0",
+ "ruvllm 2.2.3",
  "serde",
  "serde_json",
  "tempfile",
@@ -10955,6 +10779,64 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+]
+
+[[package]]
+name = "ruvllm_retrieval_diffusion"
+version = "0.1.0"
+dependencies = [
+ "ruvllm_sparse_attention",
+]
+
+[[package]]
+name = "ruvllm_sparse_attention"
+version = "0.1.1"
+dependencies = [
+ "criterion 0.5.1",
+ "half",
+ "libm",
+ "rand 0.8.5",
+ "rayon",
+]
+
+[[package]]
+name = "rvagent-a2a"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum 0.8.8",
+ "axum-test 16.4.1",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "criterion 0.5.1",
+ "ed25519-dalek",
+ "futures",
+ "hex",
+ "hmac 0.12.1",
+ "parking_lot 0.12.5",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rayon",
+ "reqwest 0.12.28",
+ "rvagent-core",
+ "rvagent-middleware",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sha3",
+ "subtle",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-test",
+ "toml",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -11024,16 +10906,22 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "async-trait",
+ "axum 0.8.8",
  "chrono",
  "clap",
  "console",
  "crossterm 0.28.1",
  "dirs 5.0.1",
  "dotenvy",
+ "ed25519-dalek",
+ "hex",
  "indicatif",
  "predicates",
  "rand 0.8.5",
+ "rand_core 0.6.4",
  "ratatui",
+ "reqwest 0.12.28",
+ "rvagent-a2a",
  "rvagent-backends",
  "rvagent-core",
  "rvagent-middleware",
@@ -11198,7 +11086,7 @@ dependencies = [
  "rand_distr 0.4.3",
  "ruvector-attention",
  "ruvector-collections",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "ruvector-dag",
  "ruvector-filter",
  "ruvector-gnn",
@@ -11312,7 +11200,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "parking_lot 0.12.5",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "rvf-runtime",
  "rvf-types",
  "serde",
@@ -11351,17 +11239,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "safetensors"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
-dependencies = [
- "hashbrown 0.16.1",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11384,22 +11261,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -11430,7 +11291,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -11439,16 +11300,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
-]
-
-[[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -11456,19 +11308,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "seq-macro"
@@ -11505,16 +11344,6 @@ checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
 dependencies = [
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half 1.8.3",
- "serde",
 ]
 
 [[package]]
@@ -11610,7 +11439,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -11619,7 +11448,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -11915,12 +11744,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
-
-[[package]]
 name = "sqlx"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12174,6 +11997,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12243,7 +12072,7 @@ name = "subpolynomial-time-mincut-demo"
 version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -12251,25 +12080,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "supports-color"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
-dependencies = [
- "is-terminal",
- "is_ci",
-]
-
-[[package]]
-name = "supports-color"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
-dependencies = [
- "is_ci",
-]
 
 [[package]]
 name = "symbolic-common"
@@ -12372,21 +12182,6 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
-dependencies = [
- "cfg-if 1.0.4",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "windows 0.52.0",
-]
-
-[[package]]
-name = "sysinfo"
 version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
@@ -12471,12 +12266,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tar"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12506,7 +12295,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -12663,7 +12452,7 @@ checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
 dependencies = [
  "fax",
  "flate2",
- "half 2.7.1",
+ "half",
  "quick-error 2.0.1",
  "weezl",
  "zune-jpeg",
@@ -12754,46 +12543,13 @@ dependencies = [
  "paste",
  "rand 0.8.5",
  "rayon",
- "rayon-cond 0.3.0",
+ "rayon-cond",
  "regex",
  "regex-syntax",
  "serde",
  "serde_json",
  "spm_precompiled",
  "thiserror 1.0.69",
- "unicode-normalization-alignments",
- "unicode-segmentation",
- "unicode_categories",
-]
-
-[[package]]
-name = "tokenizers"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
-dependencies = [
- "ahash",
- "aho-corasick",
- "compact_str 0.9.0",
- "dary_heap",
- "derive_builder",
- "esaxx-rs",
- "getrandom 0.3.4",
- "itertools 0.14.0",
- "log",
- "macro_rules_attribute",
- "monostate",
- "onig",
- "paste",
- "rand 0.9.2",
- "rayon",
- "rayon-cond 0.4.0",
- "regex",
- "regex-syntax",
- "serde",
- "serde_json",
- "spm_precompiled",
- "thiserror 2.0.18",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -12865,21 +12621,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -12913,10 +12659,10 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.26.11",
 ]
@@ -13026,13 +12772,29 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-pemfile 2.2.0",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13226,12 +12988,22 @@ name = "train-discoveries"
 version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
- "ruvector-core 2.2.0",
+ "ruvector-core 2.2.3",
  "ruvector-solver",
  "serde",
  "serde_json",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]
@@ -13271,7 +13043,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
@@ -13303,14 +13075,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03719c61a91b51541f076dfdba45caacf750b230cefaa4b32d6f5411c3f7f437"
 dependencies = [
  "gemm 0.18.2",
- "half 2.7.1",
+ "half",
  "libloading 0.8.9",
  "memmap2",
  "num 0.4.3",
  "num-traits",
  "num_cpus",
  "rayon",
- "safetensors 0.4.5",
+ "safetensors",
  "serde",
  "thiserror 1.0.69",
  "tracing",
@@ -13324,7 +13096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50758486d7941f8b0a636ba7e29455c07071f41590beac1fd307ec893e8db69a"
 dependencies = [
  "cudarc",
- "half 2.7.1",
+ "half",
  "serde",
  "thiserror 1.0.69",
  "ug",
@@ -13336,7 +13108,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a02ddc17bf32f7dcaaf016b6735f7198082b82f122df7b3ca15d8ead5911ccef"
 dependencies = [
- "half 2.7.1",
+ "half",
  "metal 0.29.0",
  "objc",
  "serde",
@@ -13349,12 +13121,6 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "unescape"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
 
 [[package]]
 name = "unicase"
@@ -13478,7 +13244,7 @@ dependencies = [
  "log",
  "native-tls",
  "once_cell",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -13524,9 +13290,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
- "idna 1.1.0",
+ "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -13584,11 +13351,11 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.18.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db79c75af171630a3148bd3e6d7c4f42b6a9a014c2945bc5ed0020cbb8d9478e"
+checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
 dependencies = [
- "idna 0.5.0",
+ "idna",
  "once_cell",
  "regex",
  "serde",
@@ -13600,13 +13367,13 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.18.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0bcf92720c40105ac4b2dda2a4ea3aa717d4d6a862cc217da653a4bd5c6b10"
+checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
 dependencies = [
  "darling 0.20.11",
  "once_cell",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13651,7 +13418,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -13902,7 +13669,7 @@ dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap 2.12.1",
- "semver 1.0.28",
+ "semver",
 ]
 
 [[package]]
@@ -13917,7 +13684,7 @@ version = "0.1.0"
 dependencies = [
  "rand 0.8.5",
  "ruvector-coherence",
- "ruvector-mincut 2.2.0",
+ "ruvector-mincut 2.2.3",
 ]
 
 [[package]]
@@ -13948,12 +13715,6 @@ checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
@@ -14179,16 +13940,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
@@ -14204,15 +13955,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -14741,7 +14483,7 @@ dependencies = [
  "id-arena",
  "indexmap 2.12.1",
  "log",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -14754,15 +14496,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "xattr"
@@ -14799,12 +14532,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
-name = "yansi-term"
-version = "0.1.2"
+name = "yasna"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "winapi",
+ "time",
 ]
 
 [[package]]

--- a/crates/ruvector-postgres/src/healing/strategies.rs
+++ b/crates/ruvector-postgres/src/healing/strategies.rs
@@ -1004,7 +1004,7 @@ impl StrategyRegistry {
             .max_by(|a, b| {
                 let weight_a = weights.get(a.name()).unwrap_or(&1.0);
                 let weight_b = weights.get(b.name()).unwrap_or(&1.0);
-                weight_a.partial_cmp(weight_b).unwrap()
+                weight_a.total_cmp(weight_b)
             })
             .cloned()
     }

--- a/crates/ruvector-postgres/src/learning/patterns.rs
+++ b/crates/ruvector-postgres/src/learning/patterns.rs
@@ -135,7 +135,7 @@ impl PatternExtractor {
                 let min_dist = centroids
                     .iter()
                     .map(|c| self.euclidean_distance(&traj.query_vector, c))
-                    .min_by(|a, b| a.partial_cmp(b).unwrap())
+                    .min_by(|a, b| a.total_cmp(b))
                     .unwrap_or(0.0);
                 distances.push(min_dist);
             }
@@ -144,7 +144,7 @@ impl PatternExtractor {
             let idx = distances
                 .iter()
                 .enumerate()
-                .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+                .max_by(|(_, a), (_, b)| a.total_cmp(b))
                 .map(|(i, _)| i)
                 .unwrap_or(0);
 
@@ -160,7 +160,7 @@ impl PatternExtractor {
             .iter()
             .enumerate()
             .map(|(i, c)| (i, self.euclidean_distance(point, c)))
-            .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+            .min_by(|(_, a), (_, b)| a.total_cmp(b))
             .map(|(i, _)| i)
             .unwrap_or(0)
     }

--- a/crates/ruvector-postgres/src/learning/reasoning_bank.rs
+++ b/crates/ruvector-postgres/src/learning/reasoning_bank.rs
@@ -61,7 +61,7 @@ impl ReasoningBank {
         similarities.sort_by(|a, b| {
             let score_a = a.2 * a.1.confidence;
             let score_b = b.2 * b.1.confidence;
-            score_b.partial_cmp(&score_a).unwrap()
+            score_b.total_cmp(&score_a)
         });
 
         // Take top k

--- a/crates/ruvector-postgres/src/math/operators.rs
+++ b/crates/ruvector-postgres/src/math/operators.rs
@@ -53,8 +53,8 @@ pub fn ruvector_wasserstein_distance(a: Vec<f32>, b: Vec<f32>, p: default!(i32, 
     // 1D Wasserstein: sort and compute L_p distance of CDFs
     let mut a_sorted: Vec<f64> = a.iter().map(|&x| x as f64).collect();
     let mut b_sorted: Vec<f64> = b.iter().map(|&x| x as f64).collect();
-    a_sorted.sort_by(|x, y| x.partial_cmp(y).unwrap());
-    b_sorted.sort_by(|x, y| x.partial_cmp(y).unwrap());
+    a_sorted.sort_by(|x, y| x.total_cmp(y));
+    b_sorted.sort_by(|x, y| x.total_cmp(y));
 
     let p_f64 = p.max(1) as f64;
     let sum: f64 = a_sorted

--- a/crates/ruvector-postgres/src/quantization/binary.rs
+++ b/crates/ruvector-postgres/src/quantization/binary.rs
@@ -290,7 +290,7 @@ impl BinarySearcher {
             })
             .collect();
 
-        reranked.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        reranked.sort_by(|a, b| a.1.total_cmp(&b.1));
         reranked.truncate(k);
         reranked
     }

--- a/crates/ruvector-postgres/src/sparse/types.rs
+++ b/crates/ruvector-postgres/src/sparse/types.rs
@@ -156,7 +156,7 @@ impl SparseVec {
             .collect();
 
         // Sort by absolute value (descending)
-        indexed.sort_by(|(_, a), (_, b)| b.abs().partial_cmp(&a.abs()).unwrap());
+        indexed.sort_by(|(_, a), (_, b)| b.abs().total_cmp(&a.abs()));
         indexed.truncate(k);
 
         // Re-sort by index

--- a/crates/ruvector-solver/src/forward_push.rs
+++ b/crates/ruvector-solver/src/forward_push.rs
@@ -679,7 +679,7 @@ mod tests {
             .solution
             .iter()
             .enumerate()
-            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+            .max_by(|(_, a), (_, b)| a.total_cmp(b))
             .unwrap()
             .0;
         assert_eq!(max_idx, 1);

--- a/crates/ruvllm/src/claude_flow/agent_router.rs
+++ b/crates/ruvllm/src/claude_flow/agent_router.rs
@@ -134,7 +134,7 @@ impl AgentRouter {
         // Find best match
         let (primary_agent, primary_score) = scores
             .iter()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .max_by(|a, b| a.1.total_cmp(b.1))
             .map(|(a, s)| (*a, *s))
             .unwrap_or((AgentType::Coder, 0.0));
 
@@ -152,7 +152,7 @@ impl AgentRouter {
             .filter(|(a, _)| *a != primary_agent)
             .map(|(a, s)| (a, s / total_matches.max(1.0)))
             .collect();
-        alternatives.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        alternatives.sort_by(|a, b| b.1.total_cmp(&a.1));
         alternatives.truncate(3);
 
         // Determine task type

--- a/crates/ruvllm/src/claude_flow/task_classifier.rs
+++ b/crates/ruvllm/src/claude_flow/task_classifier.rs
@@ -170,7 +170,7 @@ impl TaskClassifier {
             (TaskType::Performance, self.score_performance(lower)),
         ];
 
-        scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        scores.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         let primary = scores[0];
         let secondary: Vec<(TaskType, f32)> = scores[1..4]

--- a/crates/ruvllm/src/evaluation/economics.rs
+++ b/crates/ruvllm/src/evaluation/economics.rs
@@ -93,7 +93,7 @@ impl LatencyStats {
             return 0.0;
         }
         let mut sorted = self.samples.clone();
-        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        sorted.sort_by(|a, b| a.total_cmp(b));
         let idx = ((p / 100.0) * (sorted.len() - 1) as f64).round() as usize;
         sorted[idx.min(sorted.len() - 1)]
     }

--- a/crates/ruvllm/src/metal/operations.rs
+++ b/crates/ruvllm/src/metal/operations.rs
@@ -309,14 +309,14 @@ pub fn verify_speculative_tokens(
         let draft_token = draft_logits[draft_start..draft_start + vocab_size]
             .iter()
             .enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .max_by(|a, b| a.1.total_cmp(b.1))
             .map(|(idx, _)| idx)
             .unwrap_or(0);
 
         let target_token = target_logits[target_start..target_start + vocab_size]
             .iter()
             .enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .max_by(|a, b| a.1.total_cmp(b.1))
             .map(|(idx, _)| idx)
             .unwrap_or(0);
 

--- a/crates/ruvllm/src/qat/calibration.rs
+++ b/crates/ruvllm/src/qat/calibration.rs
@@ -188,7 +188,7 @@ impl LayerStats {
         if self.values.is_empty() {
             return 0.0;
         }
-        self.values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        self.values.sort_by(|a, b| a.total_cmp(b));
         let idx = ((p / 100.0) * (self.values.len() - 1) as f32) as usize;
         self.values[idx.min(self.values.len() - 1)]
     }

--- a/crates/ruvllm/src/training/grpo.rs
+++ b/crates/ruvllm/src/training/grpo.rs
@@ -697,13 +697,13 @@ mod tests {
         let max_reward_idx = rewards
             .iter()
             .enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .max_by(|a, b| a.1.total_cmp(b.1))
             .map(|(i, _)| i)
             .unwrap();
         let max_advantage_idx = advantages
             .iter()
             .enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .max_by(|a, b| a.1.total_cmp(b.1))
             .map(|(i, _)| i)
             .unwrap();
         assert_eq!(max_reward_idx, max_advantage_idx);

--- a/examples/scipix/Cargo.toml
+++ b/examples/scipix/Cargo.toml
@@ -87,7 +87,7 @@ axum-streams = { version = "0.15", features = ["json"] }
 
 # Image processing (for future OCR integration)
 image = "0.25"
-imageproc = { version = "0.25", optional = true }
+imageproc = { version = "0.26", optional = true }
 rayon = { version = "1.10", optional = true }
 nalgebra = { version = "0.33", optional = true }
 ndarray = { version = "0.16", optional = true }


### PR DESCRIPTION
## Summary

Security hardening for the Connectome-OS / RuVector workspace, targeting the \`research/connectome-ruvector\` branch (which backs the [Connectome-OS](https://github.com/ruvnet/Connectome-OS) project).

### RUSTSEC Advisory Fixes

| Advisory | Crate | Fix |
|---|---|---|
| RUSTSEC-2026-0115 | imageproc 0.25.0 — improper bounds check | Bumped to 0.26.2 in `examples/scipix/Cargo.toml` |
| RUSTSEC-2026-0116 | imageproc 0.25.0 — fragile bounds check | Same bump |
| RUSTSEC-2026-0117 | imageproc 0.25.0 — fragile sampling | Same bump |
| RUSTSEC-2024-0421 | idna 0.5.0 via validator 0.18 | validator → 0.20 (already on base branch) |
| RUSTSEC-2026-0098/0099/0104 | rustls-webpki 0.101.7/0.103.10 | reqwest → 0.12, webpki pinned to 0.103.13 (already on base) |

Stale ignore entries for the three imageproc advisories removed from `.cargo/audit.toml` (now actually fixed rather than suppressed).

### NaN Panic Hardening (partial_cmp → total_cmp)

Replaced all remaining bare `.partial_cmp(...).unwrap()` calls — which panic if NaN enters a float slice — with `.total_cmp(...)` (stable Rust 1.62+, total order, no panic) in **production source** files:

- `crates/ruvllm/src/claude_flow/agent_router.rs` — score max/sort
- `crates/ruvllm/src/claude_flow/task_classifier.rs` — task score sort
- `crates/ruvllm/src/evaluation/economics.rs` — percentile computation
- `crates/ruvllm/src/metal/operations.rs` — argmax over logit arrays
- `crates/ruvllm/src/qat/calibration.rs` — quantization percentile
- `crates/ruvllm/src/training/grpo.rs` — reward/advantage max lookup
- `crates/ruvector-postgres/src/healing/strategies.rs` — strategy weight max
- `crates/ruvector-postgres/src/learning/patterns.rs` — k-means++ distance
- `crates/ruvector-postgres/src/learning/reasoning_bank.rs` — similarity sort
- `crates/ruvector-postgres/src/math/operators.rs` — Wasserstein CDF sort
- `crates/ruvector-postgres/src/quantization/binary.rs` — rerank sort
- `crates/ruvector-postgres/src/sparse/types.rs` — top-k sparse abs sort
- `crates/ruvector-solver/src/forward_push.rs` — argmax in test assertion

## Test plan

- [ ] `cargo audit --no-fetch` reports zero vulnerabilities
- [ ] `cargo check -p connectome-fly` compiles with no errors
- [ ] `cargo check -p ruvllm` compiles with no errors
- [ ] CI passes

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)