### PR TITLE
docs(adr): ADR-252 HelixDB vs RuVector comparison and improvement opportunities

### DIFF
--- a/crates/ruvector-graph/Cargo.toml
+++ b/crates/ruvector-graph/Cargo.toml
@@ -157,6 +157,10 @@ path = "examples/test_cypher_parser.rs"
 name = "new_capabilities_bench"
 harness = false
 
+[[bench]]
+name = "typed_graph_bench"
+harness = false
+
 [lib]
 crate-type = ["rlib"]
 bench = false

--- a/crates/ruvector-graph/benches/typed_graph_bench.rs
+++ b/crates/ruvector-graph/benches/typed_graph_bench.rs
@@ -1,0 +1,108 @@
+//! Benchmarks for the schema-first typed graph (ADR-252 P1/P2/P4).
+//!
+//! Measures the fused `search_then_traverse` operator at scale, schema
+//! validation overhead, and RRF fusion. Run with:
+//! `cargo bench -p ruvector-graph --bench typed_graph_bench`.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ruvector_graph::schema::{
+    reciprocal_rank_fusion, DistanceMetric, EdgeSchema, GraphSchema, NodeSchema, PropertySchema,
+    PropertyType, VectorSchema,
+};
+use ruvector_graph::types::PropertyValue;
+use ruvector_graph::{Edge, GraphDB, NodeBuilder, TraverseSpec, TypedGraph};
+
+fn make_schema(dims: usize) -> GraphSchema {
+    let mut s = GraphSchema::new();
+    s.add_node(
+        NodeSchema::new("Doc")
+            .property(PropertySchema::new("title", PropertyType::String).required())
+            .property(PropertySchema::new("embedding", PropertyType::Vector)),
+    );
+    s.add_node(NodeSchema::new("Topic").property(PropertySchema::new("name", PropertyType::String)));
+    s.add_edge(EdgeSchema::new("ABOUT", "Doc", "Topic"));
+    s.add_vector(VectorSchema::new("DocEmb", "Doc", "embedding", dims, DistanceMetric::Cosine));
+    s
+}
+
+/// Deterministic pseudo-random embedding so benches are reproducible.
+fn embedding(seed: u64, dims: usize) -> Vec<f32> {
+    let mut x = seed.wrapping_mul(2654435761).wrapping_add(1);
+    (0..dims)
+        .map(|_| {
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            (x as f32 / u64::MAX as f32) - 0.5
+        })
+        .collect()
+}
+
+fn build_graph(n: usize, dims: usize, topics: usize) -> TypedGraph {
+    let tg = TypedGraph::new(GraphDB::new(), make_schema(dims)).unwrap();
+    for t in 0..topics {
+        tg.create_node(
+            NodeBuilder::new().id(format!("t{t}")).label("Topic").property("name", format!("topic{t}")).build(),
+        )
+        .unwrap();
+    }
+    for i in 0..n {
+        tg.create_node(
+            NodeBuilder::new()
+                .id(format!("d{i}"))
+                .label("Doc")
+                .property("title", format!("doc{i}"))
+                .property("embedding", PropertyValue::FloatArray(embedding(i as u64, dims)))
+                .build(),
+        )
+        .unwrap();
+        // Two ABOUT edges per doc so traversal does real work.
+        tg.create_edge(Edge::create(format!("d{i}"), format!("t{}", i % topics), "ABOUT")).unwrap();
+        tg.create_edge(Edge::create(format!("d{i}"), format!("t{}", (i + 1) % topics), "ABOUT")).unwrap();
+    }
+    tg
+}
+
+fn bench_search_then_traverse(c: &mut Criterion) {
+    let dims = 128;
+    let mut group = c.benchmark_group("search_then_traverse");
+    for &n in &[1_000usize, 10_000, 50_000] {
+        let tg = build_graph(n, dims, 64);
+        let query = embedding(424242, dims);
+        let spec = TraverseSpec::out("ABOUT").target_label("Topic");
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                let res = tg
+                    .search_then_traverse(black_box("DocEmb"), black_box(&query), black_box(10), &spec)
+                    .unwrap();
+                black_box(res);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_validation(c: &mut Criterion) {
+    let schema = make_schema(128);
+    let node = NodeBuilder::new()
+        .id("d1")
+        .label("Doc")
+        .property("title", "hello")
+        .property("embedding", PropertyValue::FloatArray(embedding(1, 128)))
+        .build();
+    c.bench_function("validate_node", |b| {
+        b.iter(|| black_box(schema.validate_node(black_box(&node)).unwrap()));
+    });
+}
+
+fn bench_rrf(c: &mut Criterion) {
+    let a: Vec<String> = (0..1000).map(|i| format!("id{i}")).collect();
+    let b_list: Vec<String> = (0..1000).map(|i| format!("id{}", (i * 7) % 1000)).collect();
+    c.bench_function("rrf_2x1000", |b| {
+        b.iter(|| black_box(reciprocal_rank_fusion(black_box(&[a.clone(), b_list.clone()]), 60.0)));
+    });
+}
+
+criterion_group!(benches, bench_search_then_traverse, bench_validation, bench_rrf);
+criterion_main!(benches);

--- a/crates/ruvector-graph/benches/typed_graph_bench.rs
+++ b/crates/ruvector-graph/benches/typed_graph_bench.rs
@@ -83,6 +83,32 @@ fn bench_search_then_traverse(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_indexed_vs_scan(c: &mut Criterion) {
+    let dims = 128;
+    let n = 50_000usize;
+    let query = embedding(424242, dims);
+    let spec = TraverseSpec::out("ABOUT").target_label("Topic");
+
+    // Brute-force scan (no index).
+    let scan = build_graph(n, dims, 64);
+    // Same data, with an HNSW push-down index built.
+    let mut indexed = build_graph(n, dims, 64);
+    indexed.build_vector_index("DocEmb").unwrap();
+
+    let mut group = c.benchmark_group("search_50k_k10");
+    group.bench_function("brute_force_scan", |b| {
+        b.iter(|| {
+            black_box(scan.search_then_traverse(black_box("DocEmb"), black_box(&query), 10, &spec).unwrap());
+        });
+    });
+    group.bench_function("hnsw_pushdown", |b| {
+        b.iter(|| {
+            black_box(indexed.search_then_traverse(black_box("DocEmb"), black_box(&query), 10, &spec).unwrap());
+        });
+    });
+    group.finish();
+}
+
 fn bench_validation(c: &mut Criterion) {
     let schema = make_schema(128);
     let node = NodeBuilder::new()
@@ -104,5 +130,11 @@ fn bench_rrf(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_search_then_traverse, bench_validation, bench_rrf);
+criterion_group!(
+    benches,
+    bench_search_then_traverse,
+    bench_indexed_vs_scan,
+    bench_validation,
+    bench_rrf
+);
 criterion_main!(benches);

--- a/crates/ruvector-graph/benches/typed_graph_bench.rs
+++ b/crates/ruvector-graph/benches/typed_graph_bench.rs
@@ -10,7 +10,8 @@ use ruvector_graph::schema::{
     PropertyType, VectorSchema,
 };
 use ruvector_graph::types::PropertyValue;
-use ruvector_graph::{Edge, GraphDB, NodeBuilder, TraverseSpec, TypedGraph};
+use ruvector_graph::{Edge, Embedder, GraphDB, HashEmbedder, NodeBuilder, TraverseSpec, TypedGraph};
+use std::sync::Arc;
 
 fn make_schema(dims: usize) -> GraphSchema {
     let mut s = GraphSchema::new();
@@ -109,6 +110,67 @@ fn bench_indexed_vs_scan(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_embed_and_hybrid(c: &mut Criterion) {
+    use ruvector_graph::{
+        DistanceMetric, EdgeSchema, GraphSchema, NodeSchema, PropertySchema, PropertyType,
+        VectorSchema,
+    };
+
+    let dims = 256;
+    let embedder = HashEmbedder::new(dims);
+    c.bench_function("hash_embed_256", |b| {
+        b.iter(|| black_box(embedder.embed(black_box("vector database semantic similarity search")).unwrap()));
+    });
+
+    // Build a 10k-doc tri-modal graph: text + inline embeddings + BM25 + ANN.
+    let n = 10_000usize;
+    let words = [
+        "vector", "database", "graph", "search", "embedding", "model", "index",
+        "neural", "semantic", "traversal", "cluster", "ranking", "query", "fusion",
+    ];
+    let text_for = |i: usize| -> String {
+        (0..6).map(|j| words[(i * 7 + j * 13) % words.len()]).collect::<Vec<_>>().join(" ")
+    };
+
+    let mut schema = GraphSchema::new();
+    schema.add_node(
+        NodeSchema::new("Doc")
+            .property(PropertySchema::new("body", PropertyType::String).required())
+            .property(PropertySchema::new("embedding", PropertyType::Vector)),
+    );
+    schema.add_node(NodeSchema::new("Topic"));
+    schema.add_edge(EdgeSchema::new("ABOUT", "Doc", "Topic"));
+    schema.add_vector(VectorSchema::new("DocEmb", "Doc", "embedding", dims, DistanceMetric::Cosine));
+
+    let mut tg = TypedGraph::new(GraphDB::new(), schema)
+        .unwrap()
+        .with_embedder(Arc::new(HashEmbedder::new(dims)));
+    for i in 0..n {
+        let body = text_for(i);
+        let node = NodeBuilder::new().id(format!("d{i}")).label("Doc").property("body", body.clone()).build();
+        tg.create_node_from_text(node, "DocEmb", &body).unwrap();
+    }
+    tg.build_vector_index("DocEmb").unwrap();
+    tg.build_text_index("Doc", "body").unwrap();
+
+    let spec = TraverseSpec::out("ABOUT");
+    c.bench_function("tri_modal_hybrid_10k_k10", |b| {
+        b.iter(|| {
+            black_box(
+                tg.hybrid_search_text(
+                    black_box("DocEmb"),
+                    "body",
+                    black_box("vector semantic search ranking"),
+                    10,
+                    60.0,
+                    &spec,
+                )
+                .unwrap(),
+            );
+        });
+    });
+}
+
 fn bench_validation(c: &mut Criterion) {
     let schema = make_schema(128);
     let node = NodeBuilder::new()
@@ -134,6 +196,7 @@ criterion_group!(
     benches,
     bench_search_then_traverse,
     bench_indexed_vs_scan,
+    bench_embed_and_hybrid,
     bench_validation,
     bench_rrf
 );

--- a/crates/ruvector-graph/src/bm25.rs
+++ b/crates/ruvector-graph/src/bm25.rs
@@ -1,0 +1,166 @@
+//! Compact BM25 keyword index over a node text property (ADR-252 P4).
+//!
+//! Provides the keyword arm of the tri-modal hybrid query (BM25 + ANN vector +
+//! graph traversal). Self-contained — an in-memory inverted index with
+//! Okapi BM25 scoring, no external search engine. Built from `(NodeId, &str)`
+//! pairs and queried for the top-k by keyword relevance.
+
+use crate::types::NodeId;
+use std::collections::HashMap;
+
+/// Okapi BM25 parameters. Defaults `k1=1.2`, `b=0.75` are the standard choices.
+#[derive(Debug, Clone, Copy)]
+pub struct Bm25Params {
+    pub k1: f32,
+    pub b: f32,
+}
+
+impl Default for Bm25Params {
+    fn default() -> Self {
+        Self { k1: 1.2, b: 0.75 }
+    }
+}
+
+/// In-memory BM25 inverted index over a single text field.
+#[derive(Debug, Clone)]
+pub struct Bm25Index {
+    params: Bm25Params,
+    /// term -> postings as (doc index, term frequency).
+    postings: HashMap<String, Vec<(u32, u32)>>,
+    doc_ids: Vec<NodeId>,
+    doc_len: Vec<u32>,
+    avgdl: f32,
+}
+
+impl Bm25Index {
+    /// Lowercase, split on non-alphanumeric. Cheap and dependency-free.
+    pub fn tokenize(text: &str) -> Vec<String> {
+        text.split(|c: char| !c.is_alphanumeric())
+            .filter(|t| !t.is_empty())
+            .map(|t| t.to_ascii_lowercase())
+            .collect()
+    }
+
+    /// Build the index from `(id, text)` pairs.
+    pub fn build<I, S>(docs: I, params: Bm25Params) -> Self
+    where
+        I: IntoIterator<Item = (NodeId, S)>,
+        S: AsRef<str>,
+    {
+        let mut postings: HashMap<String, Vec<(u32, u32)>> = HashMap::new();
+        let mut doc_ids = Vec::new();
+        let mut doc_len = Vec::new();
+        let mut total_len: u64 = 0;
+
+        for (id, text) in docs {
+            let doc_idx = doc_ids.len() as u32;
+            let tokens = Self::tokenize(text.as_ref());
+            doc_len.push(tokens.len() as u32);
+            total_len += tokens.len() as u64;
+
+            // Term frequencies within this doc.
+            let mut tf: HashMap<String, u32> = HashMap::new();
+            for tok in tokens {
+                *tf.entry(tok).or_insert(0) += 1;
+            }
+            for (term, freq) in tf {
+                postings.entry(term).or_default().push((doc_idx, freq));
+            }
+            doc_ids.push(id);
+        }
+
+        let n = doc_ids.len().max(1) as f32;
+        let avgdl = if doc_ids.is_empty() { 0.0 } else { total_len as f32 / n };
+        Self { params, postings, doc_ids, doc_len, avgdl }
+    }
+
+    /// Number of indexed documents.
+    pub fn len(&self) -> usize {
+        self.doc_ids.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.doc_ids.is_empty()
+    }
+
+    /// Top-`k` documents by BM25 score for `query`, descending. Only documents
+    /// with a positive score are returned.
+    pub fn search(&self, query: &str, k: usize) -> Vec<(NodeId, f32)> {
+        if self.doc_ids.is_empty() || k == 0 {
+            return Vec::new();
+        }
+        let n = self.doc_ids.len() as f32;
+        let (k1, b) = (self.params.k1, self.params.b);
+        let mut scores: HashMap<u32, f32> = HashMap::new();
+
+        // Deduplicate query terms; each contributes once via its idf.
+        let mut seen_terms = std::collections::HashSet::new();
+        for term in Self::tokenize(query) {
+            if !seen_terms.insert(term.clone()) {
+                continue;
+            }
+            let Some(postings) = self.postings.get(&term) else {
+                continue;
+            };
+            let df = postings.len() as f32;
+            // Robertson/Spärck-Jones idf with +1 to stay non-negative.
+            let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
+            for &(doc_idx, freq) in postings {
+                let dl = self.doc_len[doc_idx as usize] as f32;
+                let tf = freq as f32;
+                let denom = tf + k1 * (1.0 - b + b * dl / self.avgdl.max(1e-6));
+                let contribution = idf * (tf * (k1 + 1.0)) / denom;
+                *scores.entry(doc_idx).or_insert(0.0) += contribution;
+            }
+        }
+
+        let mut ranked: Vec<(NodeId, f32)> = scores
+            .into_iter()
+            .map(|(idx, s)| (self.doc_ids[idx as usize].clone(), s))
+            .collect();
+        ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        ranked.truncate(k);
+        ranked
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn corpus() -> Vec<(NodeId, &'static str)> {
+        vec![
+            ("d1".into(), "the quick brown fox jumps over the lazy dog"),
+            ("d2".into(), "machine learning models for vector search"),
+            ("d3".into(), "vector databases enable semantic search at scale"),
+            ("d4".into(), "a recipe for italian pasta with tomato sauce"),
+        ]
+    }
+
+    #[test]
+    fn ranks_relevant_docs_first() {
+        let idx = Bm25Index::build(corpus(), Bm25Params::default());
+        assert_eq!(idx.len(), 4);
+        let res = idx.search("vector search", 4);
+        assert!(!res.is_empty());
+        // d2 and d3 both mention "vector" and "search"; pasta doc must not lead.
+        assert!(res[0].0 == "d2" || res[0].0 == "d3");
+        assert!(res.iter().all(|(id, _)| id != "d4") || res.last().unwrap().0 == "d4");
+    }
+
+    #[test]
+    fn idf_downweights_common_terms() {
+        let idx = Bm25Index::build(corpus(), Bm25Params::default());
+        // "the" appears in d1 only here but is short; "pasta" is rare → strong signal.
+        let res = idx.search("pasta", 4);
+        assert_eq!(res[0].0, "d4");
+    }
+
+    #[test]
+    fn empty_query_and_index_safe() {
+        let empty = Bm25Index::build(Vec::<(NodeId, &str)>::new(), Bm25Params::default());
+        assert!(empty.search("anything", 5).is_empty());
+        let idx = Bm25Index::build(corpus(), Bm25Params::default());
+        assert!(idx.search("", 5).is_empty());
+        assert!(idx.search("zzz nonexistent", 5).is_empty());
+    }
+}

--- a/crates/ruvector-graph/src/codegen.rs
+++ b/crates/ruvector-graph/src/codegen.rs
@@ -1,0 +1,259 @@
+//! Schema-driven typed client codegen (HelixDB-inspired, ADR-252 P6).
+//!
+//! HelixDB compiles a schema into typed API endpoints + multi-language SDKs so
+//! callers get compile-time-checked node/edge/vector types. This module does the
+//! same from a [`GraphSchema`]: it emits TypeScript, Python, and Rust type
+//! definitions plus a vector-type manifest. Output is deterministic (schema
+//! elements are sorted) so it can be checked in and diffed.
+//!
+//! These are *type* stubs — the single source of truth is the schema. The
+//! generated code carries the labels, property names/types, edge `from`/`to`
+//! constraints, and vector dimensions/metrics across the language boundary.
+
+use crate::schema::{DistanceMetric, GraphSchema, PropertySchema, PropertyType};
+
+fn metric_name(m: DistanceMetric) -> &'static str {
+    match m {
+        DistanceMetric::Cosine => "Cosine",
+        DistanceMetric::DotProduct => "DotProduct",
+        DistanceMetric::Euclidean => "Euclidean",
+    }
+}
+
+// ---- TypeScript ------------------------------------------------------------
+
+fn ts_type(t: PropertyType) -> &'static str {
+    match t {
+        PropertyType::Boolean => "boolean",
+        PropertyType::Integer | PropertyType::Float => "number",
+        PropertyType::String => "string",
+        PropertyType::Vector => "number[]",
+        PropertyType::Array => "unknown[]",
+        PropertyType::Map => "Record<string, unknown>",
+        PropertyType::Any => "unknown",
+    }
+}
+
+fn ts_property(p: &PropertySchema) -> String {
+    let opt = if p.required { "" } else { "?" };
+    let indexed = if p.indexed { "  /** @indexed */\n" } else { "" };
+    format!("{indexed}  {}{}: {};\n", p.name, opt, ts_type(p.ptype))
+}
+
+/// Generate TypeScript interfaces + a vector-type manifest from the schema.
+pub fn generate_typescript(schema: &GraphSchema) -> String {
+    let mut out = String::new();
+    out.push_str("// Auto-generated from RuVector GraphSchema (ADR-252 P6). Do not edit by hand.\n\n");
+
+    for n in schema.node_schemas_sorted() {
+        out.push_str(&format!("export interface {} {{\n", n.label));
+        for p in &n.properties {
+            out.push_str(&ts_property(p));
+        }
+        out.push_str("}\n\n");
+    }
+
+    for e in schema.edge_schemas_sorted() {
+        out.push_str(&format!(
+            "/** Edge {0}: {1} -> {2} */\nexport interface {0} {{\n  from: string;\n  to: string;\n",
+            e.edge_type, e.from_label, e.to_label
+        ));
+        for p in &e.properties {
+            out.push_str(&ts_property(p));
+        }
+        out.push_str("}\n\n");
+    }
+
+    out.push_str("export const VectorTypes = {\n");
+    for v in schema.vector_schemas_sorted() {
+        out.push_str(&format!(
+            "  {}: {{ label: \"{}\", property: \"{}\", dimensions: {}, metric: \"{}\" }},\n",
+            v.name,
+            v.label,
+            v.property,
+            v.dimensions,
+            metric_name(v.metric)
+        ));
+    }
+    out.push_str("} as const;\n\nexport type VectorTypeName = keyof typeof VectorTypes;\n");
+    out
+}
+
+// ---- Python ----------------------------------------------------------------
+
+fn py_type(t: PropertyType) -> &'static str {
+    match t {
+        PropertyType::Boolean => "bool",
+        PropertyType::Integer => "int",
+        PropertyType::Float => "float",
+        PropertyType::String => "str",
+        PropertyType::Vector => "list[float]",
+        PropertyType::Array => "list",
+        PropertyType::Map => "dict",
+        PropertyType::Any => "Any",
+    }
+}
+
+fn py_property(p: &PropertySchema) -> String {
+    let ty = py_type(p.ptype);
+    if p.required {
+        format!("    {}: {}\n", p.name, ty)
+    } else {
+        format!("    {}: NotRequired[{}]\n", p.name, ty)
+    }
+}
+
+/// Generate Python `TypedDict` classes + a vector-type manifest from the schema.
+pub fn generate_python(schema: &GraphSchema) -> String {
+    let mut out = String::new();
+    out.push_str("# Auto-generated from RuVector GraphSchema (ADR-252 P6). Do not edit by hand.\n");
+    out.push_str("from __future__ import annotations\n");
+    out.push_str("from typing import Any, NotRequired, TypedDict\n\n");
+
+    for n in schema.node_schemas_sorted() {
+        out.push_str(&format!("class {}(TypedDict):\n", n.label));
+        if n.properties.is_empty() {
+            out.push_str("    pass\n\n");
+            continue;
+        }
+        for p in &n.properties {
+            out.push_str(&py_property(p));
+        }
+        out.push('\n');
+    }
+
+    for e in schema.edge_schemas_sorted() {
+        out.push_str(&format!("class {}(TypedDict):\n", e.edge_type));
+        out.push_str(&format!("    # {} -> {}\n", e.from_label, e.to_label));
+        out.push_str("    from_: str\n    to: str\n");
+        for p in &e.properties {
+            out.push_str(&py_property(p));
+        }
+        out.push('\n');
+    }
+
+    out.push_str("VECTOR_TYPES = {\n");
+    for v in schema.vector_schemas_sorted() {
+        out.push_str(&format!(
+            "    \"{}\": {{\"label\": \"{}\", \"property\": \"{}\", \"dimensions\": {}, \"metric\": \"{}\"}},\n",
+            v.name, v.label, v.property, v.dimensions, metric_name(v.metric)
+        ));
+    }
+    out.push_str("}\n");
+    out
+}
+
+// ---- Rust ------------------------------------------------------------------
+
+fn rust_type(t: PropertyType) -> &'static str {
+    match t {
+        PropertyType::Boolean => "bool",
+        PropertyType::Integer => "i64",
+        PropertyType::Float => "f64",
+        PropertyType::String => "String",
+        PropertyType::Vector => "Vec<f32>",
+        PropertyType::Array => "Vec<serde_json::Value>",
+        PropertyType::Map => "std::collections::HashMap<String, serde_json::Value>",
+        PropertyType::Any => "serde_json::Value",
+    }
+}
+
+fn rust_field(p: &PropertySchema) -> String {
+    let ty = rust_type(p.ptype);
+    if p.required {
+        format!("    pub {}: {},\n", p.name, ty)
+    } else {
+        format!("    pub {}: Option<{}>,\n", p.name, ty)
+    }
+}
+
+/// Generate Rust structs from the schema (serde-ready).
+pub fn generate_rust(schema: &GraphSchema) -> String {
+    let mut out = String::new();
+    out.push_str("// Auto-generated from RuVector GraphSchema (ADR-252 P6). Do not edit by hand.\n");
+    out.push_str("use serde::{Deserialize, Serialize};\n\n");
+
+    for n in schema.node_schemas_sorted() {
+        out.push_str("#[derive(Debug, Clone, Serialize, Deserialize)]\n");
+        out.push_str(&format!("pub struct {} {{\n", n.label));
+        for p in &n.properties {
+            out.push_str(&rust_field(p));
+        }
+        out.push_str("}\n\n");
+    }
+
+    for e in schema.edge_schemas_sorted() {
+        out.push_str(&format!("/// Edge {}: {} -> {}\n", e.edge_type, e.from_label, e.to_label));
+        out.push_str("#[derive(Debug, Clone, Serialize, Deserialize)]\n");
+        out.push_str(&format!("pub struct {} {{\n    pub from: String,\n    pub to: String,\n", e.edge_type));
+        for p in &e.properties {
+            out.push_str(&rust_field(p));
+        }
+        out.push_str("}\n\n");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{EdgeSchema, NodeSchema, VectorSchema};
+
+    fn schema() -> GraphSchema {
+        let mut s = GraphSchema::new();
+        s.add_node(
+            NodeSchema::new("Person")
+                .property(PropertySchema::new("name", PropertyType::String).required().indexed())
+                .property(PropertySchema::new("age", PropertyType::Integer))
+                .property(PropertySchema::new("embedding", PropertyType::Vector)),
+        );
+        s.add_node(NodeSchema::new("Company"));
+        s.add_edge(EdgeSchema::new("WORKS_AT", "Person", "Company"));
+        s.add_vector(VectorSchema::new("PersonEmb", "Person", "embedding", 384, DistanceMetric::Cosine));
+        s
+    }
+
+    #[test]
+    fn typescript_has_typed_interfaces_and_manifest() {
+        let ts = generate_typescript(&schema());
+        assert!(ts.contains("export interface Person {"));
+        assert!(ts.contains("name: string;")); // required
+        assert!(ts.contains("age?: number;")); // optional
+        assert!(ts.contains("embedding?: number[];")); // vector
+        assert!(ts.contains("@indexed"));
+        assert!(ts.contains("export interface WORKS_AT {"));
+        assert!(ts.contains("Person -> Company"));
+        assert!(ts.contains("PersonEmb: { label: \"Person\""));
+        assert!(ts.contains("dimensions: 384"));
+        assert!(ts.contains("export type VectorTypeName"));
+    }
+
+    #[test]
+    fn python_has_typeddicts_and_manifest() {
+        let py = generate_python(&schema());
+        assert!(py.contains("class Person(TypedDict):"));
+        assert!(py.contains("    name: str"));
+        assert!(py.contains("    age: NotRequired[int]"));
+        assert!(py.contains("class Company(TypedDict):"));
+        assert!(py.contains("    pass")); // empty node
+        assert!(py.contains("\"PersonEmb\": {\"label\": \"Person\""));
+    }
+
+    #[test]
+    fn rust_has_structs() {
+        let rs = generate_rust(&schema());
+        assert!(rs.contains("pub struct Person {"));
+        assert!(rs.contains("pub name: String,"));
+        assert!(rs.contains("pub age: Option<i64>,"));
+        assert!(rs.contains("pub embedding: Option<Vec<f32>>,"));
+        assert!(rs.contains("pub struct WORKS_AT {"));
+    }
+
+    #[test]
+    fn output_is_deterministic() {
+        let s = schema();
+        assert_eq!(generate_typescript(&s), generate_typescript(&s));
+        assert_eq!(generate_python(&s), generate_python(&s));
+        assert_eq!(generate_rust(&s), generate_rust(&s));
+    }
+}

--- a/crates/ruvector-graph/src/embed.rs
+++ b/crates/ruvector-graph/src/embed.rs
@@ -1,0 +1,134 @@
+//! Pluggable text embedding for inline `embed()`-at-insert/at-query
+//! (HelixDB-inspired, ADR-252 P3).
+//!
+//! HelixQL's built-in `Embed(text)` vectorizes inline so a caller never has to
+//! marshal a separate embedding service into the query. This module gives
+//! `TypedGraph` the same ergonomic via a pluggable [`Embedder`] trait: attach a
+//! model once, then create nodes from text or search by text and the binding's
+//! dimension is validated against the schema's vector type.
+//!
+//! A real model is supplied by implementing [`Embedder`]. A dependency-free
+//! [`HashEmbedder`] is included for offline/dev/test use — it is **not**
+//! semantic (lexical token overlap only) and must be opted into explicitly;
+//! consistent with ADR-194, the typed graph never silently falls back to it.
+
+use crate::error::Result;
+
+/// A text → vector embedding model.
+pub trait Embedder: Send + Sync {
+    /// Output dimension; must match the bound vector type's `dimensions`.
+    fn dimensions(&self) -> usize;
+
+    /// Embed a single text.
+    fn embed(&self, text: &str) -> Result<Vec<f32>>;
+
+    /// Embed a batch. Default loops `embed`; implementors may override with a
+    /// vectorized path.
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        texts.iter().map(|t| self.embed(t)).collect()
+    }
+}
+
+/// Deterministic, dependency-free feature-hashing embedder.
+///
+/// Captures **lexical token overlap only** — it is not a semantic model. It
+/// exists for offline/dev/test use and as an *explicit* opt-in (never a silent
+/// fallback, per ADR-194). Identical text always yields an identical vector, so
+/// it is useful for deterministic tests. For semantic search, supply a real
+/// model via [`Embedder`].
+#[derive(Debug, Clone)]
+pub struct HashEmbedder {
+    dims: usize,
+}
+
+impl HashEmbedder {
+    /// Create a hashing embedder of the given output dimension.
+    pub fn new(dims: usize) -> Self {
+        assert!(dims > 0, "HashEmbedder dimension must be > 0");
+        Self { dims }
+    }
+
+    /// FNV-1a hash of a token.
+    #[inline]
+    fn token_hash(token: &str) -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for b in token.bytes() {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h
+    }
+}
+
+impl Embedder for HashEmbedder {
+    fn dimensions(&self) -> usize {
+        self.dims
+    }
+
+    fn embed(&self, text: &str) -> Result<Vec<f32>> {
+        let mut v = vec![0.0f32; self.dims];
+        for raw in text.split_whitespace() {
+            // Case-fold so "Cat" and "cat" collide.
+            let token = raw.to_ascii_lowercase();
+            let h = Self::token_hash(&token);
+            let idx = (h % self.dims as u64) as usize;
+            // Signed feature hashing reduces collision bias.
+            let sign = if (h >> 32) & 1 == 0 { 1.0 } else { -1.0 };
+            v[idx] += sign;
+        }
+        // L2-normalize so cosine of identical text is exactly 1.0.
+        let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for x in &mut v {
+                *x /= norm;
+            }
+        }
+        Ok(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_and_normalized() {
+        let e = HashEmbedder::new(64);
+        let a = e.embed("the quick brown fox").unwrap();
+        let b = e.embed("the quick brown fox").unwrap();
+        assert_eq!(a, b); // deterministic
+        assert_eq!(a.len(), 64);
+        let norm: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-5); // unit length
+    }
+
+    #[test]
+    fn overlap_scores_higher_than_disjoint() {
+        let e = HashEmbedder::new(256);
+        let cos = |x: &[f32], y: &[f32]| -> f32 { x.iter().zip(y).map(|(a, b)| a * b).sum() };
+        let base = e.embed("machine learning vector database").unwrap();
+        let near = e.embed("machine learning vector search").unwrap();
+        let far = e.embed("unrelated cooking recipe content").unwrap();
+        assert!(cos(&base, &near) > cos(&base, &far));
+    }
+
+    #[test]
+    fn case_insensitive_tokens() {
+        let e = HashEmbedder::new(64);
+        assert_eq!(e.embed("Hello World").unwrap(), e.embed("hello world").unwrap());
+    }
+
+    #[test]
+    fn empty_text_is_zero_vector() {
+        let e = HashEmbedder::new(32);
+        assert_eq!(e.embed("   ").unwrap(), vec![0.0f32; 32]);
+    }
+
+    #[test]
+    fn batch_matches_single() {
+        let e = HashEmbedder::new(48);
+        let batch = e.embed_batch(&["alpha beta", "gamma"]).unwrap();
+        assert_eq!(batch[0], e.embed("alpha beta").unwrap());
+        assert_eq!(batch[1], e.embed("gamma").unwrap());
+    }
+}

--- a/crates/ruvector-graph/src/error.rs
+++ b/crates/ruvector-graph/src/error.rs
@@ -78,6 +78,9 @@ pub enum GraphError {
 
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
+
+    #[error("Schema violation: {0}")]
+    SchemaViolation(String),
 }
 
 impl From<anyhow::Error> for GraphError {

--- a/crates/ruvector-graph/src/graph.rs
+++ b/crates/ruvector-graph/src/graph.rs
@@ -128,6 +128,20 @@ impl GraphDB {
         self.nodes.get(id.as_ref()).map(|entry| entry.clone())
     }
 
+    /// Borrow a node and apply `f` without cloning it.
+    ///
+    /// Hot-path accessor for scans that only need to read a node (e.g. vector
+    /// scoring). Avoids the full `Node` + embedding clone that `get_node`
+    /// incurs. Returns `None` if the node is absent.
+    pub fn with_node<R>(&self, id: &str, f: impl FnOnce(&Node) -> R) -> Option<R> {
+        self.nodes.get(id).map(|entry| f(entry.value()))
+    }
+
+    /// Node ids carrying `label`, straight from the label index (no node clones).
+    pub fn node_ids_by_label(&self, label: &str) -> Vec<NodeId> {
+        self.label_index.get_nodes_by_label(label)
+    }
+
     /// Delete a node
     pub fn delete_node(&self, id: impl AsRef<str>) -> Result<bool> {
         if let Some((_, node)) = self.nodes.remove(id.as_ref()) {

--- a/crates/ruvector-graph/src/lib.rs
+++ b/crates/ruvector-graph/src/lib.rs
@@ -4,6 +4,7 @@
 //! Supports property graphs, hypergraphs, Cypher queries, ACID transactions, and distributed queries.
 
 pub mod bm25;
+pub mod codegen;
 pub mod cypher;
 pub mod edge;
 pub mod embed;

--- a/crates/ruvector-graph/src/lib.rs
+++ b/crates/ruvector-graph/src/lib.rs
@@ -11,8 +11,10 @@ pub mod graph;
 pub mod hyperedge;
 pub mod index;
 pub mod node;
+pub mod schema;
 pub mod storage;
 pub mod transaction;
+pub mod typed_graph;
 pub mod types;
 
 // Performance optimization modules
@@ -31,6 +33,11 @@ pub use error::{GraphError, Result};
 pub use graph::GraphDB;
 pub use hyperedge::{Hyperedge, HyperedgeBuilder, HyperedgeId};
 pub use node::{Node, NodeBuilder};
+pub use schema::{
+    reciprocal_rank_fusion, DistanceMetric, EdgeSchema, GraphSchema, NodeSchema, PropertySchema,
+    PropertyType, VectorSchema,
+};
+pub use typed_graph::{Direction, TraversalResult, TraverseSpec, TypedGraph};
 #[cfg(feature = "storage")]
 pub use storage::GraphStorage;
 pub use transaction::{IsolationLevel, Transaction, TransactionManager};

--- a/crates/ruvector-graph/src/lib.rs
+++ b/crates/ruvector-graph/src/lib.rs
@@ -3,8 +3,10 @@
 //! A high-performance graph database layer built on RuVector with Neo4j compatibility.
 //! Supports property graphs, hypergraphs, Cypher queries, ACID transactions, and distributed queries.
 
+pub mod bm25;
 pub mod cypher;
 pub mod edge;
+pub mod embed;
 pub mod error;
 pub mod executor;
 pub mod graph;
@@ -32,6 +34,8 @@ pub use edge::{Edge, EdgeBuilder};
 pub use error::{GraphError, Result};
 pub use graph::GraphDB;
 pub use hyperedge::{Hyperedge, HyperedgeBuilder, HyperedgeId};
+pub use bm25::{Bm25Index, Bm25Params};
+pub use embed::{Embedder, HashEmbedder};
 pub use node::{Node, NodeBuilder};
 pub use schema::{
     reciprocal_rank_fusion, DistanceMetric, EdgeSchema, GraphSchema, NodeSchema, PropertySchema,

--- a/crates/ruvector-graph/src/schema.rs
+++ b/crates/ruvector-graph/src/schema.rs
@@ -67,23 +67,53 @@ pub enum DistanceMetric {
 }
 
 impl DistanceMetric {
-    /// Higher score == more similar, for any metric.
+    /// Higher score == more similar, for any metric. Convenience wrapper that
+    /// computes the query's norm inline; prefer [`DistanceMetric::query_norm`] +
+    /// [`DistanceMetric::score_pre`] in a scan loop to amortize the query norm.
     pub fn score(&self, a: &[f32], b: &[f32]) -> f32 {
+        self.score_pre(a, b, self.query_norm(a))
+    }
+
+    /// Precompute the query-side norm once per query. Only `Cosine` needs it;
+    /// the others return `1.0`.
+    #[inline]
+    pub fn query_norm(&self, q: &[f32]) -> f32 {
         match self {
-            DistanceMetric::DotProduct => dot(a, b),
+            DistanceMetric::Cosine => dot(q, q).sqrt(),
+            _ => 1.0,
+        }
+    }
+
+    /// Score `candidate` against `query`, reusing a precomputed `query_norm`.
+    /// Hoists the query norm out of the per-candidate hot loop.
+    #[inline]
+    pub fn score_pre(&self, query: &[f32], candidate: &[f32], query_norm: f32) -> f32 {
+        match self {
+            DistanceMetric::DotProduct => dot(query, candidate),
             DistanceMetric::Cosine => {
-                let na = dot(a, a).sqrt();
-                let nb = dot(b, b).sqrt();
-                if na == 0.0 || nb == 0.0 {
+                // Single fused pass: accumulate q·c and c·c together so the
+                // candidate slice is read once (half the memory traffic of two
+                // separate `dot` calls).
+                let n = query.len().min(candidate.len());
+                let mut qc = 0.0f32;
+                let mut cc = 0.0f32;
+                for i in 0..n {
+                    let c = candidate[i];
+                    qc += query[i] * c;
+                    cc += c * c;
+                }
+                let cn = cc.sqrt();
+                if query_norm == 0.0 || cn == 0.0 {
                     0.0
                 } else {
-                    dot(a, b) / (na * nb)
+                    qc / (query_norm * cn)
                 }
             }
             DistanceMetric::Euclidean => {
+                let n = query.len().min(candidate.len());
                 let mut sum = 0.0f32;
-                for i in 0..a.len().min(b.len()) {
-                    let d = a[i] - b[i];
+                for i in 0..n {
+                    let d = query[i] - candidate[i];
                     sum += d * d;
                 }
                 -sum.sqrt()
@@ -92,17 +122,45 @@ impl DistanceMetric {
     }
 }
 
+/// Score a vector-shaped property against a query without allocating in the
+/// common `FloatArray` case (zero-copy slice scoring). Returns `None` if the
+/// property is not vector-shaped or its dimension does not match the query.
+#[inline]
+pub fn score_property(
+    metric: DistanceMetric,
+    query: &[f32],
+    query_norm: f32,
+    value: &PropertyValue,
+) -> Option<f32> {
+    match value {
+        // Fast path: borrow the stored slice directly, no clone.
+        PropertyValue::FloatArray(v) => {
+            if v.len() == query.len() {
+                Some(metric.score_pre(query, v, query_norm))
+            } else {
+                None
+            }
+        }
+        // Slow path: heterogeneous numeric list must be materialized.
+        PropertyValue::Array(_) | PropertyValue::List(_) => {
+            let v = extract_vector(value)?;
+            if v.len() == query.len() {
+                Some(metric.score_pre(query, &v, query_norm))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
 #[inline]
 fn dot(a: &[f32], b: &[f32]) -> f32 {
-    // Plain loop; the optimizer auto-vectorizes this. SIMD via `simsimd`/ruvector-core
-    // is a follow-up (ADR-252 P5) but is deliberately not a hard dependency here so
-    // the schema layer stays WASM- and no-feature-build-safe.
-    let n = a.len().min(b.len());
-    let mut acc = 0.0f32;
-    for i in 0..n {
-        acc += a[i] * b[i];
-    }
-    acc
+    // Iterator form so LLVM auto-vectorizes (SSE/AVX/NEON) without bounds checks.
+    // SIMD via `simsimd`/ruvector-core is a follow-up (ADR-252 P5) but is
+    // deliberately not a hard dependency here so the schema layer stays WASM- and
+    // no-feature-build-safe.
+    a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
 }
 
 /// Coerce a property value into a dense `Vec<f32>` if it is vector-shaped.

--- a/crates/ruvector-graph/src/schema.rs
+++ b/crates/ruvector-graph/src/schema.rs
@@ -1,0 +1,557 @@
+//! Optional, schema-first type layer for the graph (HelixDB-inspired, ADR-252 P1/P2).
+//!
+//! RuVector's graph is schemaless by default and its Cypher engine is interpreted
+//! at runtime. This module adds an **opt-in** schema that catches type errors
+//! *before* execution — declared node labels, typed edges with `from`/`to` label
+//! constraints, indexed properties, and **vector types bound to a node label +
+//! property** (so a vector hit can be traversed back into the graph as a
+//! first-class, validated relationship rather than a runtime string + property
+//! name).
+//!
+//! The module is pure-Rust with no storage/HNSW dependency, so it compiles for
+//! WASM. It coexists with schemaless mode: only declared labels/edges are checked,
+//! and undeclared ones pass through untouched.
+
+use crate::edge::Edge;
+use crate::error::{GraphError, Result};
+use crate::node::Node;
+use crate::types::PropertyValue;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Declared type of a node/edge property.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PropertyType {
+    Boolean,
+    Integer,
+    /// Accepts `Float` and (widening) `Integer`.
+    Float,
+    String,
+    /// Dense embedding (`FloatArray`, or a homogeneous numeric `Array`/`List`).
+    Vector,
+    /// Heterogeneous list.
+    Array,
+    Map,
+    /// Accepts any value (escape hatch).
+    Any,
+}
+
+impl PropertyType {
+    /// Does `value` satisfy this declared type?
+    pub fn accepts(&self, value: &PropertyValue) -> bool {
+        match self {
+            PropertyType::Any => true,
+            PropertyType::Boolean => matches!(value, PropertyValue::Boolean(_)),
+            PropertyType::Integer => matches!(value, PropertyValue::Integer(_)),
+            // Float is permissive: an integer literal is a valid float.
+            PropertyType::Float => {
+                matches!(value, PropertyValue::Float(_) | PropertyValue::Integer(_))
+            }
+            PropertyType::String => matches!(value, PropertyValue::String(_)),
+            PropertyType::Vector => extract_vector(value).is_some(),
+            PropertyType::Array => {
+                matches!(value, PropertyValue::Array(_) | PropertyValue::List(_))
+            }
+            PropertyType::Map => matches!(value, PropertyValue::Map(_)),
+        }
+    }
+}
+
+/// Distance metric for a vector type. Search always ranks by a *higher-is-better*
+/// score, so `Euclidean` is surfaced as the negated distance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DistanceMetric {
+    Cosine,
+    DotProduct,
+    Euclidean,
+}
+
+impl DistanceMetric {
+    /// Higher score == more similar, for any metric.
+    pub fn score(&self, a: &[f32], b: &[f32]) -> f32 {
+        match self {
+            DistanceMetric::DotProduct => dot(a, b),
+            DistanceMetric::Cosine => {
+                let na = dot(a, a).sqrt();
+                let nb = dot(b, b).sqrt();
+                if na == 0.0 || nb == 0.0 {
+                    0.0
+                } else {
+                    dot(a, b) / (na * nb)
+                }
+            }
+            DistanceMetric::Euclidean => {
+                let mut sum = 0.0f32;
+                for i in 0..a.len().min(b.len()) {
+                    let d = a[i] - b[i];
+                    sum += d * d;
+                }
+                -sum.sqrt()
+            }
+        }
+    }
+}
+
+#[inline]
+fn dot(a: &[f32], b: &[f32]) -> f32 {
+    // Plain loop; the optimizer auto-vectorizes this. SIMD via `simsimd`/ruvector-core
+    // is a follow-up (ADR-252 P5) but is deliberately not a hard dependency here so
+    // the schema layer stays WASM- and no-feature-build-safe.
+    let n = a.len().min(b.len());
+    let mut acc = 0.0f32;
+    for i in 0..n {
+        acc += a[i] * b[i];
+    }
+    acc
+}
+
+/// Coerce a property value into a dense `Vec<f32>` if it is vector-shaped.
+pub fn extract_vector(value: &PropertyValue) -> Option<Vec<f32>> {
+    match value {
+        PropertyValue::FloatArray(v) => Some(v.clone()),
+        PropertyValue::Array(items) | PropertyValue::List(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for it in items {
+                match it {
+                    PropertyValue::Float(f) => out.push(*f as f32),
+                    PropertyValue::Integer(i) => out.push(*i as f32),
+                    _ => return None,
+                }
+            }
+            if out.is_empty() {
+                None
+            } else {
+                Some(out)
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Declaration for a single property.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PropertySchema {
+    pub name: String,
+    pub ptype: PropertyType,
+    /// Must be present on every instance.
+    pub required: bool,
+    /// Hint that this property is secondary-indexed (HelixQL `INDEX`).
+    pub indexed: bool,
+}
+
+impl PropertySchema {
+    pub fn new(name: impl Into<String>, ptype: PropertyType) -> Self {
+        Self {
+            name: name.into(),
+            ptype,
+            required: false,
+            indexed: false,
+        }
+    }
+    pub fn required(mut self) -> Self {
+        self.required = true;
+        self
+    }
+    pub fn indexed(mut self) -> Self {
+        self.indexed = true;
+        self
+    }
+}
+
+/// Schema for a node label (`N::` in HelixQL).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeSchema {
+    pub label: String,
+    pub properties: Vec<PropertySchema>,
+    /// If true, properties not declared here are rejected.
+    pub strict: bool,
+}
+
+impl NodeSchema {
+    pub fn new(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            properties: Vec::new(),
+            strict: false,
+        }
+    }
+    pub fn property(mut self, p: PropertySchema) -> Self {
+        self.properties.push(p);
+        self
+    }
+    pub fn strict(mut self) -> Self {
+        self.strict = true;
+        self
+    }
+}
+
+/// Schema for an edge type (`E::` in HelixQL) with `from`/`to` label constraints.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EdgeSchema {
+    pub edge_type: String,
+    pub from_label: String,
+    pub to_label: String,
+    pub properties: Vec<PropertySchema>,
+}
+
+impl EdgeSchema {
+    pub fn new(
+        edge_type: impl Into<String>,
+        from_label: impl Into<String>,
+        to_label: impl Into<String>,
+    ) -> Self {
+        Self {
+            edge_type: edge_type.into(),
+            from_label: from_label.into(),
+            to_label: to_label.into(),
+            properties: Vec::new(),
+        }
+    }
+    pub fn property(mut self, p: PropertySchema) -> Self {
+        self.properties.push(p);
+        self
+    }
+}
+
+/// Schema for a vector type (`V::` in HelixQL), bound to a node label + property.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VectorSchema {
+    /// Vector type name (referenced by `search_then_traverse`).
+    pub name: String,
+    /// Node label whose instances carry this embedding.
+    pub label: String,
+    /// Property holding the embedding.
+    pub property: String,
+    pub dimensions: usize,
+    pub metric: DistanceMetric,
+}
+
+impl VectorSchema {
+    pub fn new(
+        name: impl Into<String>,
+        label: impl Into<String>,
+        property: impl Into<String>,
+        dimensions: usize,
+        metric: DistanceMetric,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            label: label.into(),
+            property: property.into(),
+            dimensions,
+            metric,
+        }
+    }
+}
+
+/// A complete, optional graph schema.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GraphSchema {
+    nodes: HashMap<String, NodeSchema>,
+    edges: HashMap<String, EdgeSchema>,
+    vectors: HashMap<String, VectorSchema>,
+}
+
+impl GraphSchema {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_node(&mut self, schema: NodeSchema) -> &mut Self {
+        self.nodes.insert(schema.label.clone(), schema);
+        self
+    }
+    pub fn add_edge(&mut self, schema: EdgeSchema) -> &mut Self {
+        self.edges.insert(schema.edge_type.clone(), schema);
+        self
+    }
+    pub fn add_vector(&mut self, schema: VectorSchema) -> &mut Self {
+        self.vectors.insert(schema.name.clone(), schema);
+        self
+    }
+
+    pub fn node(&self, label: &str) -> Option<&NodeSchema> {
+        self.nodes.get(label)
+    }
+    pub fn edge(&self, edge_type: &str) -> Option<&EdgeSchema> {
+        self.edges.get(edge_type)
+    }
+    pub fn vector(&self, name: &str) -> Option<&VectorSchema> {
+        self.vectors.get(name)
+    }
+
+    /// Validate the schema's own internal consistency: every edge's `from`/`to`
+    /// label and every vector's bound label must reference a declared node. Run
+    /// this once after building the schema (HelixQL's compile-time check).
+    pub fn validate_self(&self) -> Result<()> {
+        for e in self.edges.values() {
+            if !self.nodes.contains_key(&e.from_label) {
+                return Err(GraphError::SchemaViolation(format!(
+                    "edge '{}' references undeclared from-label '{}'",
+                    e.edge_type, e.from_label
+                )));
+            }
+            if !self.nodes.contains_key(&e.to_label) {
+                return Err(GraphError::SchemaViolation(format!(
+                    "edge '{}' references undeclared to-label '{}'",
+                    e.edge_type, e.to_label
+                )));
+            }
+        }
+        for v in self.vectors.values() {
+            if !self.nodes.contains_key(&v.label) {
+                return Err(GraphError::SchemaViolation(format!(
+                    "vector '{}' bound to undeclared label '{}'",
+                    v.name, v.label
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate a node against any declared schema for its labels. Labels with no
+    /// schema pass through (schemaless coexistence).
+    pub fn validate_node(&self, node: &Node) -> Result<()> {
+        // Collect every property allowed by any matching (declared) label.
+        let mut allowed: Vec<&str> = Vec::new();
+        let mut any_strict = false;
+        let mut matched_any = false;
+
+        for label in &node.labels {
+            let Some(ns) = self.nodes.get(&label.name) else {
+                continue;
+            };
+            matched_any = true;
+            any_strict |= ns.strict;
+            for p in &ns.properties {
+                allowed.push(p.name.as_str());
+                match node.properties.get(&p.name) {
+                    None if p.required => {
+                        return Err(GraphError::SchemaViolation(format!(
+                            "node '{}' (:{}) missing required property '{}'",
+                            node.id, label.name, p.name
+                        )));
+                    }
+                    Some(v) if !p.ptype.accepts(v) => {
+                        return Err(GraphError::SchemaViolation(format!(
+                            "node '{}' (:{}) property '{}' has wrong type (expected {:?})",
+                            node.id, label.name, p.name, p.ptype
+                        )));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        if matched_any && any_strict {
+            for key in node.properties.keys() {
+                if !allowed.iter().any(|a| a == key) {
+                    return Err(GraphError::SchemaViolation(format!(
+                        "node '{}' has undeclared property '{}' (strict schema)",
+                        node.id, key
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate an edge given the labels of its endpoints. Undeclared edge types
+    /// pass through. Pass the actual from/to node labels so direction + endpoint
+    /// types are checked.
+    pub fn validate_edge(&self, edge: &Edge, from_labels: &[String], to_labels: &[String]) -> Result<()> {
+        let Some(es) = self.edges.get(&edge.edge_type) else {
+            return Ok(());
+        };
+        if !from_labels.iter().any(|l| l == &es.from_label) {
+            return Err(GraphError::SchemaViolation(format!(
+                "edge '{}' requires from-label '{}', got {:?}",
+                edge.edge_type, es.from_label, from_labels
+            )));
+        }
+        if !to_labels.iter().any(|l| l == &es.to_label) {
+            return Err(GraphError::SchemaViolation(format!(
+                "edge '{}' requires to-label '{}', got {:?}",
+                edge.edge_type, es.to_label, to_labels
+            )));
+        }
+        for p in &es.properties {
+            match edge.properties.get(&p.name) {
+                None if p.required => {
+                    return Err(GraphError::SchemaViolation(format!(
+                        "edge '{}' missing required property '{}'",
+                        edge.edge_type, p.name
+                    )));
+                }
+                Some(v) if !p.ptype.accepts(v) => {
+                    return Err(GraphError::SchemaViolation(format!(
+                        "edge '{}' property '{}' has wrong type (expected {:?})",
+                        edge.edge_type, p.name, p.ptype
+                    )));
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate that a query vector matches a declared vector type's dimension.
+    pub fn validate_vector_dims(&self, vector_type: &str, query: &[f32]) -> Result<&VectorSchema> {
+        let vs = self.vectors.get(vector_type).ok_or_else(|| {
+            GraphError::SchemaViolation(format!("unknown vector type '{}'", vector_type))
+        })?;
+        if query.len() != vs.dimensions {
+            return Err(GraphError::SchemaViolation(format!(
+                "vector type '{}' expects dimension {}, got {}",
+                vector_type,
+                vs.dimensions,
+                query.len()
+            )));
+        }
+        Ok(vs)
+    }
+}
+
+/// Reciprocal Rank Fusion over several ranked id lists (ADR-252 P4 core).
+///
+/// `score(id) = Σ 1 / (k_const + rank)` with `rank` 1-based per list. The common
+/// default for `k_const` is 60. Returns ids sorted by fused score, descending.
+pub fn reciprocal_rank_fusion(rankings: &[Vec<String>], k_const: f32) -> Vec<(String, f32)> {
+    let mut scores: HashMap<String, f32> = HashMap::new();
+    for ranking in rankings {
+        for (rank, id) in ranking.iter().enumerate() {
+            let contribution = 1.0 / (k_const + (rank as f32 + 1.0));
+            *scores.entry(id.clone()).or_insert(0.0) += contribution;
+        }
+    }
+    let mut fused: Vec<(String, f32)> = scores.into_iter().collect();
+    fused.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    fused
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::NodeBuilder;
+    use crate::types::Label;
+
+    fn person_schema() -> GraphSchema {
+        let mut s = GraphSchema::new();
+        s.add_node(
+            NodeSchema::new("Person")
+                .property(PropertySchema::new("name", PropertyType::String).required().indexed())
+                .property(PropertySchema::new("age", PropertyType::Integer))
+                .property(PropertySchema::new("embedding", PropertyType::Vector)),
+        );
+        s.add_node(NodeSchema::new("Company"));
+        s.add_edge(EdgeSchema::new("WORKS_AT", "Person", "Company"));
+        s.add_vector(VectorSchema::new("PersonEmb", "Person", "embedding", 3, DistanceMetric::Cosine));
+        s
+    }
+
+    #[test]
+    fn self_validation_catches_dangling_refs() {
+        let mut s = GraphSchema::new();
+        s.add_edge(EdgeSchema::new("KNOWS", "Person", "Person"));
+        assert!(s.validate_self().is_err());
+        s.add_node(NodeSchema::new("Person"));
+        assert!(s.validate_self().is_ok());
+    }
+
+    #[test]
+    fn node_validation_required_and_types() {
+        let s = person_schema();
+        // Valid.
+        let ok = NodeBuilder::new().label("Person").property("name", "Alice").property("age", 30i64).build();
+        assert!(s.validate_node(&ok).is_ok());
+        // Missing required `name`.
+        let missing = NodeBuilder::new().label("Person").property("age", 30i64).build();
+        assert!(s.validate_node(&missing).is_err());
+        // Wrong type for `age` (string where integer expected).
+        let wrong = NodeBuilder::new().label("Person").property("name", "Bob").property("age", "old").build();
+        assert!(s.validate_node(&wrong).is_err());
+        // Undeclared label passes through (schemaless coexistence).
+        let other = NodeBuilder::new().label("Alien").property("planet", "Mars").build();
+        assert!(s.validate_node(&other).is_ok());
+    }
+
+    #[test]
+    fn strict_node_rejects_undeclared_props() {
+        let mut s = GraphSchema::new();
+        s.add_node(NodeSchema::new("Tag").property(PropertySchema::new("name", PropertyType::String)).strict());
+        let bad = NodeBuilder::new().label("Tag").property("name", "x").property("extra", 1i64).build();
+        assert!(s.validate_node(&bad).is_err());
+    }
+
+    #[test]
+    fn edge_validation_checks_endpoint_labels() {
+        let s = person_schema();
+        let e = Edge::create("p1".into(), "c1".into(), "WORKS_AT");
+        assert!(s
+            .validate_edge(&e, &["Person".into()], &["Company".into()])
+            .is_ok());
+        // Wrong from-label.
+        assert!(s
+            .validate_edge(&e, &["Company".into()], &["Company".into()])
+            .is_err());
+        // Undeclared edge type passes through.
+        let e2 = Edge::create("p1".into(), "p2".into(), "LIKES");
+        assert!(s.validate_edge(&e2, &["Person".into()], &["Person".into()]).is_ok());
+    }
+
+    #[test]
+    fn vector_dim_validation() {
+        let s = person_schema();
+        assert!(s.validate_vector_dims("PersonEmb", &[1.0, 2.0, 3.0]).is_ok());
+        assert!(s.validate_vector_dims("PersonEmb", &[1.0, 2.0]).is_err());
+        assert!(s.validate_vector_dims("Missing", &[1.0, 2.0, 3.0]).is_err());
+    }
+
+    #[test]
+    fn distance_metrics_rank_higher_is_better() {
+        let q = [1.0f32, 0.0, 0.0];
+        let near = [0.9f32, 0.1, 0.0];
+        let far = [0.0f32, 1.0, 0.0];
+        for m in [DistanceMetric::Cosine, DistanceMetric::DotProduct, DistanceMetric::Euclidean] {
+            assert!(m.score(&q, &near) > m.score(&q, &far), "{:?}", m);
+        }
+    }
+
+    #[test]
+    fn extract_vector_handles_shapes() {
+        assert_eq!(extract_vector(&PropertyValue::FloatArray(vec![1.0, 2.0])), Some(vec![1.0, 2.0]));
+        assert_eq!(
+            extract_vector(&PropertyValue::Array(vec![PropertyValue::Integer(1), PropertyValue::Float(2.0)])),
+            Some(vec![1.0, 2.0])
+        );
+        assert_eq!(extract_vector(&PropertyValue::String("x".into())), None);
+    }
+
+    #[test]
+    fn rrf_fuses_and_ranks() {
+        let a = vec!["x".to_string(), "y".to_string(), "z".to_string()];
+        let b = vec!["y".to_string(), "x".to_string()];
+        let fused = reciprocal_rank_fusion(&[a, b], 60.0);
+        // `y`: 1/62 + 1/61; `x`: 1/61 + 1/62 — tie; `z`: 1/63. x & y lead z.
+        assert_eq!(fused.len(), 3);
+        assert_eq!(fused[2].0, "z");
+    }
+
+    #[test]
+    fn multi_label_node_validation() {
+        let mut s = GraphSchema::new();
+        s.add_node(NodeSchema::new("A").property(PropertySchema::new("a", PropertyType::Integer).required()));
+        s.add_node(NodeSchema::new("B").property(PropertySchema::new("b", PropertyType::String).required()));
+        let n = Node::new(
+            "n1".into(),
+            vec![Label::new("A"), Label::new("B")],
+            [
+                ("a".to_string(), PropertyValue::Integer(1)),
+                ("b".to_string(), PropertyValue::String("x".into())),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        assert!(s.validate_node(&n).is_ok());
+    }
+}

--- a/crates/ruvector-graph/src/schema.rs
+++ b/crates/ruvector-graph/src/schema.rs
@@ -338,6 +338,25 @@ impl GraphSchema {
         self.vectors.get(name)
     }
 
+    /// Node schemas sorted by label (deterministic — for codegen).
+    pub fn node_schemas_sorted(&self) -> Vec<&NodeSchema> {
+        let mut v: Vec<&NodeSchema> = self.nodes.values().collect();
+        v.sort_by(|a, b| a.label.cmp(&b.label));
+        v
+    }
+    /// Edge schemas sorted by edge type (deterministic — for codegen).
+    pub fn edge_schemas_sorted(&self) -> Vec<&EdgeSchema> {
+        let mut v: Vec<&EdgeSchema> = self.edges.values().collect();
+        v.sort_by(|a, b| a.edge_type.cmp(&b.edge_type));
+        v
+    }
+    /// Vector schemas sorted by name (deterministic — for codegen).
+    pub fn vector_schemas_sorted(&self) -> Vec<&VectorSchema> {
+        let mut v: Vec<&VectorSchema> = self.vectors.values().collect();
+        v.sort_by(|a, b| a.name.cmp(&b.name));
+        v
+    }
+
     /// Validate the schema's own internal consistency: every edge's `from`/`to`
     /// label and every vector's bound label must reference a declared node. Run
     /// this once after building the schema (HelixQL's compile-time check).

--- a/crates/ruvector-graph/src/typed_graph.rs
+++ b/crates/ruvector-graph/src/typed_graph.rs
@@ -1,0 +1,306 @@
+//! Schema-validated graph wrapper with a fused vector-search-then-traverse
+//! operator (HelixDB-inspired, ADR-252 P2).
+//!
+//! `TypedGraph` wraps a [`GraphDB`] with an optional [`GraphSchema`]. Mutations
+//! are validated against the schema before they touch storage, and the
+//! [`TypedGraph::search_then_traverse`] method expresses HelixQL's
+//! `SearchV<T>(q, k)::In<Edge>` pattern as a single fused operation: an ANN-style
+//! vector search over a bound node label, immediately traversed into the graph.
+//!
+//! The vector step is a brute-force scan over the bound label's nodes, with an
+//! optimized **bounded top-k heap** (O(n log k) instead of O(n log n) sort).
+//! Wiring this to the HNSW/`HybridIndex` path for large graphs is ADR-252 future
+//! work; the operator's *shape* (typed, single-call, push-down search before
+//! join) is the deliverable here.
+
+use crate::edge::Edge;
+use crate::error::{GraphError, Result};
+use crate::graph::GraphDB;
+use crate::node::Node;
+use crate::schema::{extract_vector, GraphSchema};
+use crate::types::NodeId;
+use ordered_float::OrderedFloat;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+
+/// Traversal direction relative to the matched seed node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    /// Follow edges where the seed is the `from` endpoint (HelixQL `::Out`).
+    Out,
+    /// Follow edges where the seed is the `to` endpoint (HelixQL `::In`).
+    In,
+    /// Both directions.
+    Both,
+}
+
+/// Which edge type to follow, in which direction, optionally filtering targets.
+#[derive(Debug, Clone)]
+pub struct TraverseSpec {
+    pub edge_type: String,
+    pub direction: Direction,
+    /// If set, only keep target nodes carrying this label.
+    pub target_label: Option<String>,
+}
+
+impl TraverseSpec {
+    pub fn out(edge_type: impl Into<String>) -> Self {
+        Self { edge_type: edge_type.into(), direction: Direction::Out, target_label: None }
+    }
+    pub fn incoming(edge_type: impl Into<String>) -> Self {
+        Self { edge_type: edge_type.into(), direction: Direction::In, target_label: None }
+    }
+    pub fn both(edge_type: impl Into<String>) -> Self {
+        Self { edge_type: edge_type.into(), direction: Direction::Both, target_label: None }
+    }
+    pub fn target_label(mut self, label: impl Into<String>) -> Self {
+        self.target_label = Some(label.into());
+        self
+    }
+}
+
+/// A single vector-search hit (seed node) and the nodes reached from it.
+#[derive(Debug, Clone)]
+pub struct TraversalResult {
+    pub seed_id: NodeId,
+    pub score: f32,
+    pub connected: Vec<Node>,
+}
+
+/// A graph wrapped with an optional, validated schema.
+pub struct TypedGraph {
+    graph: GraphDB,
+    schema: GraphSchema,
+}
+
+impl TypedGraph {
+    /// Wrap a graph with a schema. The schema's internal consistency is checked
+    /// up front (the HelixQL compile-time check).
+    pub fn new(graph: GraphDB, schema: GraphSchema) -> Result<Self> {
+        schema.validate_self()?;
+        Ok(Self { graph, schema })
+    }
+
+    pub fn schema(&self) -> &GraphSchema {
+        &self.schema
+    }
+    pub fn graph(&self) -> &GraphDB {
+        &self.graph
+    }
+    /// Escape hatch to the underlying graph for unvalidated/advanced use.
+    pub fn graph_mut(&mut self) -> &mut GraphDB {
+        &mut self.graph
+    }
+
+    /// Validate a node against the schema, then create it.
+    pub fn create_node(&self, node: Node) -> Result<NodeId> {
+        self.schema.validate_node(&node)?;
+        self.graph.create_node(node)
+    }
+
+    /// Validate an edge — including its endpoints' labels — then create it.
+    pub fn create_edge(&self, edge: Edge) -> Result<crate::types::EdgeId> {
+        let from = self.graph.get_node(&edge.from).ok_or_else(|| {
+            GraphError::SchemaViolation(format!("edge from-node '{}' does not exist", edge.from))
+        })?;
+        let to = self.graph.get_node(&edge.to).ok_or_else(|| {
+            GraphError::SchemaViolation(format!("edge to-node '{}' does not exist", edge.to))
+        })?;
+        let from_labels: Vec<String> = from.labels.iter().map(|l| l.name.clone()).collect();
+        let to_labels: Vec<String> = to.labels.iter().map(|l| l.name.clone()).collect();
+        self.schema.validate_edge(&edge, &from_labels, &to_labels)?;
+        self.graph.create_edge(edge)
+    }
+
+    /// Fused vector-search-then-traverse (HelixQL `SearchV<T>(q,k)::In/Out<E>`).
+    ///
+    /// 1. Resolve `vector_type` to its bound label + property + metric (typed —
+    ///    no string/property guessing).
+    /// 2. Validate the query dimension.
+    /// 3. Scan the bound label's nodes, scoring with the declared metric, keeping
+    ///    the top `k` via a bounded heap.
+    /// 4. Traverse from each seed along `traverse` and collect target nodes.
+    pub fn search_then_traverse(
+        &self,
+        vector_type: &str,
+        query: &[f32],
+        k: usize,
+        traverse: &TraverseSpec,
+    ) -> Result<Vec<TraversalResult>> {
+        let vs = self.schema.validate_vector_dims(vector_type, query)?;
+        let metric = vs.metric;
+        let property = vs.property.as_str();
+
+        // Bounded min-heap of size k keyed by score: O(n log k) top-k selection.
+        let mut heap: BinaryHeap<Reverse<(OrderedFloat<f32>, NodeId)>> = BinaryHeap::new();
+        for node in self.graph.get_nodes_by_label(&vs.label) {
+            let Some(prop) = node.properties.get(property) else {
+                continue;
+            };
+            let Some(emb) = extract_vector(prop) else {
+                continue;
+            };
+            if emb.len() != query.len() {
+                continue; // skip malformed embeddings rather than failing the query
+            }
+            let score = metric.score(query, &emb);
+            let entry = Reverse((OrderedFloat(score), node.id.clone()));
+            if heap.len() < k {
+                heap.push(entry);
+            } else if let Some(Reverse((min_score, _))) = heap.peek() {
+                if OrderedFloat(score) > *min_score {
+                    heap.pop();
+                    heap.push(entry);
+                }
+            }
+        }
+
+        // Drain heap into descending-score order.
+        let mut hits: Vec<(f32, NodeId)> =
+            heap.into_iter().map(|Reverse((s, id))| (s.into_inner(), id)).collect();
+        hits.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+        let mut out = Vec::with_capacity(hits.len());
+        for (score, seed_id) in hits {
+            let connected = self.traverse_from(&seed_id, traverse);
+            out.push(TraversalResult { seed_id, score, connected });
+        }
+        Ok(out)
+    }
+
+    /// Collect nodes reachable from `seed` along the traversal spec.
+    fn traverse_from(&self, seed: &NodeId, spec: &TraverseSpec) -> Vec<Node> {
+        let mut targets: Vec<NodeId> = Vec::new();
+        if matches!(spec.direction, Direction::Out | Direction::Both) {
+            for e in self.graph.get_outgoing_edges(seed) {
+                if e.edge_type == spec.edge_type {
+                    targets.push(e.to);
+                }
+            }
+        }
+        if matches!(spec.direction, Direction::In | Direction::Both) {
+            for e in self.graph.get_incoming_edges(seed) {
+                if e.edge_type == spec.edge_type {
+                    targets.push(e.from);
+                }
+            }
+        }
+
+        let mut nodes = Vec::with_capacity(targets.len());
+        let mut seen = std::collections::HashSet::new();
+        for id in targets {
+            if !seen.insert(id.clone()) {
+                continue;
+            }
+            if let Some(node) = self.graph.get_node(&id) {
+                if let Some(label) = &spec.target_label {
+                    if !node.has_label(label) {
+                        continue;
+                    }
+                }
+                nodes.push(node);
+            }
+        }
+        nodes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::NodeBuilder;
+    use crate::schema::{DistanceMetric, EdgeSchema, NodeSchema, PropertySchema, PropertyType, VectorSchema};
+    use crate::types::PropertyValue;
+
+    fn schema() -> GraphSchema {
+        let mut s = GraphSchema::new();
+        s.add_node(
+            NodeSchema::new("Doc")
+                .property(PropertySchema::new("title", PropertyType::String).required())
+                .property(PropertySchema::new("embedding", PropertyType::Vector)),
+        );
+        s.add_node(NodeSchema::new("Topic").property(PropertySchema::new("name", PropertyType::String)));
+        s.add_edge(EdgeSchema::new("ABOUT", "Doc", "Topic"));
+        s.add_vector(VectorSchema::new("DocEmb", "Doc", "embedding", 3, DistanceMetric::Cosine));
+        s
+    }
+
+    fn doc(id: &str, title: &str, emb: Vec<f32>) -> Node {
+        NodeBuilder::new()
+            .id(id)
+            .label("Doc")
+            .property("title", title)
+            .property("embedding", PropertyValue::FloatArray(emb))
+            .build()
+    }
+
+    #[test]
+    fn rejects_invalid_node_and_edge() {
+        let tg = TypedGraph::new(GraphDB::new(), schema()).unwrap();
+        // Missing required `title`.
+        let bad = NodeBuilder::new().id("d0").label("Doc").build();
+        assert!(tg.create_node(bad).is_err());
+
+        tg.create_node(doc("d1", "a", vec![1.0, 0.0, 0.0])).unwrap();
+        let topic = NodeBuilder::new().id("t1").label("Topic").property("name", "ai").build();
+        tg.create_node(topic).unwrap();
+        // Wrong direction: Topic -> Doc on an ABOUT edge declared Doc -> Topic.
+        let bad_edge = Edge::create("t1".into(), "d1".into(), "ABOUT");
+        assert!(tg.create_edge(bad_edge).is_err());
+        // Correct direction.
+        let good_edge = Edge::create("d1".into(), "t1".into(), "ABOUT");
+        assert!(tg.create_edge(good_edge).is_ok());
+    }
+
+    #[test]
+    fn search_then_traverse_ranks_and_expands() {
+        let tg = TypedGraph::new(GraphDB::new(), schema()).unwrap();
+        tg.create_node(doc("d1", "near", vec![1.0, 0.0, 0.0])).unwrap();
+        tg.create_node(doc("d2", "mid", vec![0.7, 0.7, 0.0])).unwrap();
+        tg.create_node(doc("d3", "far", vec![0.0, 0.0, 1.0])).unwrap();
+        for t in ["ai", "ml", "db"] {
+            tg.create_node(NodeBuilder::new().id(t).label("Topic").property("name", t).build()).unwrap();
+        }
+        tg.create_edge(Edge::create("d1".into(), "ai".into(), "ABOUT")).unwrap();
+        tg.create_edge(Edge::create("d1".into(), "ml".into(), "ABOUT")).unwrap();
+        tg.create_edge(Edge::create("d2".into(), "db".into(), "ABOUT")).unwrap();
+
+        let q = [1.0f32, 0.0, 0.0];
+        let res = tg
+            .search_then_traverse("DocEmb", &q, 2, &TraverseSpec::out("ABOUT").target_label("Topic"))
+            .unwrap();
+
+        // Top-k respected and ordered by similarity.
+        assert_eq!(res.len(), 2);
+        assert_eq!(res[0].seed_id, "d1");
+        assert!(res[0].score >= res[1].score);
+        // d1 expands to its two topics.
+        let topics: Vec<&str> = res[0].connected.iter().map(|n| n.id.as_str()).collect();
+        assert_eq!(topics.len(), 2);
+        assert!(topics.contains(&"ai") && topics.contains(&"ml"));
+    }
+
+    #[test]
+    fn search_then_traverse_validates_dimension() {
+        let tg = TypedGraph::new(GraphDB::new(), schema()).unwrap();
+        let err = tg.search_then_traverse("DocEmb", &[1.0, 2.0], 1, &TraverseSpec::out("ABOUT"));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn topk_bounded_heap_returns_exactly_k() {
+        let tg = TypedGraph::new(GraphDB::new(), schema()).unwrap();
+        for i in 0..50 {
+            let v = vec![i as f32 / 50.0, 1.0 - i as f32 / 50.0, 0.0];
+            tg.create_node(doc(&format!("d{i}"), "t", v)).unwrap();
+        }
+        let res = tg
+            .search_then_traverse("DocEmb", &[1.0, 0.0, 0.0], 5, &TraverseSpec::out("ABOUT"))
+            .unwrap();
+        assert_eq!(res.len(), 5);
+        // Strictly non-increasing scores.
+        for w in res.windows(2) {
+            assert!(w[0].score >= w[1].score);
+        }
+    }
+}

--- a/crates/ruvector-graph/src/typed_graph.rs
+++ b/crates/ruvector-graph/src/typed_graph.rs
@@ -19,17 +19,23 @@
 //!   higher-is-better score semantics to the brute-force path while skipping the
 //!   full-label scan.
 
+use crate::bm25::{Bm25Index, Bm25Params};
 use crate::edge::Edge;
+use crate::embed::Embedder;
 use crate::error::{GraphError, Result};
 use crate::graph::GraphDB;
 use crate::hybrid::{EmbeddingConfig, HybridIndex, VectorIndexType};
 use crate::node::Node;
-use crate::schema::{extract_vector, score_property, DistanceMetric, GraphSchema};
-use crate::types::NodeId;
+use crate::schema::{
+    extract_vector, reciprocal_rank_fusion, score_property, DistanceMetric, GraphSchema,
+    VectorSchema,
+};
+use crate::types::{NodeId, PropertyValue};
 use ordered_float::OrderedFloat;
 use rayon::prelude::*;
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap};
+use std::sync::Arc;
 
 /// Below this candidate count the serial scan wins (rayon fork/join overhead
 /// exceeds the work). Above it, the parallel path engages.
@@ -120,6 +126,10 @@ pub struct TypedGraph {
     /// Optional ANN index per vector-type name (HNSW push-down). Each index holds
     /// only the bound label's nodes, so searches are naturally label-scoped.
     indexes: HashMap<String, HybridIndex>,
+    /// Optional BM25 keyword index per `"label::property"` (snapshot-built).
+    text_indexes: HashMap<String, Bm25Index>,
+    /// Optional text embedder for inline `embed()` at insert and query.
+    embedder: Option<Arc<dyn Embedder>>,
 }
 
 impl TypedGraph {
@@ -127,7 +137,70 @@ impl TypedGraph {
     /// up front (the HelixQL compile-time check).
     pub fn new(graph: GraphDB, schema: GraphSchema) -> Result<Self> {
         schema.validate_self()?;
-        Ok(Self { graph, schema, indexes: HashMap::new() })
+        Ok(Self {
+            graph,
+            schema,
+            indexes: HashMap::new(),
+            text_indexes: HashMap::new(),
+            embedder: None,
+        })
+    }
+
+    /// Attach a text embedder, enabling inline `embed()` at insert and query
+    /// (HelixQL `Embed()`). Builder-style.
+    pub fn with_embedder(mut self, embedder: Arc<dyn Embedder>) -> Self {
+        self.embedder = Some(embedder);
+        self
+    }
+
+    /// Embed `text` with the attached embedder. Errors explicitly if none is
+    /// attached — the typed graph never silently falls back (ADR-194).
+    pub fn embed(&self, text: &str) -> Result<Vec<f32>> {
+        let e = self.embedder.as_ref().ok_or_else(|| {
+            GraphError::SchemaViolation("no embedder attached (call with_embedder)".into())
+        })?;
+        e.embed(text)
+    }
+
+    /// Create a node, embedding `text` into the vector type's bound property
+    /// inline (HelixQL `AddN<T>({ embedding: Embed(text) })`). The embedding
+    /// dimension is validated against the vector type before the write.
+    pub fn create_node_from_text(
+        &self,
+        mut node: Node,
+        vector_type: &str,
+        text: &str,
+    ) -> Result<NodeId> {
+        let vs = self
+            .schema
+            .vector(vector_type)
+            .ok_or_else(|| GraphError::SchemaViolation(format!("unknown vector type '{vector_type}'")))?;
+        let property = vs.property.clone();
+        let dims = vs.dimensions;
+        let emb = self.embed(text)?;
+        if emb.len() != dims {
+            return Err(GraphError::SchemaViolation(format!(
+                "embedder produced dimension {} but vector type '{}' expects {}",
+                emb.len(),
+                vector_type,
+                dims
+            )));
+        }
+        node.set_property(property, PropertyValue::FloatArray(emb));
+        self.create_node(node)
+    }
+
+    /// Search by text: embed the query inline, then run the typed
+    /// search-then-traverse (HelixQL `SearchV<T>(Embed(text), k)::...`).
+    pub fn search_text(
+        &self,
+        vector_type: &str,
+        text: &str,
+        k: usize,
+        traverse: &TraverseSpec,
+    ) -> Result<Vec<TraversalResult>> {
+        let query = self.embed(text)?;
+        self.search_then_traverse(vector_type, &query, k, traverse)
     }
 
     pub fn schema(&self) -> &GraphSchema {
@@ -245,22 +318,113 @@ impl TypedGraph {
             return Ok(Vec::new());
         }
         let vs = self.schema.validate_vector_dims(vector_type, query)?;
+        let hits = self.rank_seeds(vs, query, k)?;
+        Ok(self.expand(hits, traverse))
+    }
+
+    /// Rank the top-`k` seeds for a vector type: ANN index if built, else the
+    /// optimized brute-force scan. Returns `(score, id)` descending.
+    fn rank_seeds(&self, vs: &VectorSchema, query: &[f32], k: usize) -> Result<Vec<(f32, NodeId)>> {
         let metric = vs.metric;
         let property = vs.property.as_str();
-        // Hoist the query-side norm out of the per-candidate loop (cosine).
         let query_norm = metric.query_norm(query);
-
-        let hits = match self.indexes.get(vector_type) {
+        Ok(match self.indexes.get(&vs.name) {
             Some(index) => self.rank_via_index(index, property, query, query_norm, metric, k)?,
             None => self.rank_via_scan(&vs.label, property, query, query_norm, metric, k),
-        };
+        })
+    }
 
+    /// Traverse from each ranked seed and assemble results.
+    fn expand(&self, hits: Vec<(f32, NodeId)>, traverse: &TraverseSpec) -> Vec<TraversalResult> {
         let mut out = Vec::with_capacity(hits.len());
         for (score, seed_id) in hits {
             let connected = self.traverse_from(&seed_id, traverse);
             out.push(TraversalResult { seed_id, score, connected });
         }
-        Ok(out)
+        out
+    }
+
+    /// Build (snapshot) a BM25 keyword index over a string property of `label`.
+    /// Rebuild to reflect later writes. Returns the number of documents indexed.
+    pub fn build_text_index(&mut self, label: &str, text_property: &str) -> Result<usize> {
+        let mut docs: Vec<(NodeId, String)> = Vec::new();
+        for id in self.graph.node_ids_by_label(label) {
+            let text = self
+                .graph
+                .with_node(&id, |n| match n.properties.get(text_property) {
+                    Some(PropertyValue::String(s)) => Some(s.clone()),
+                    _ => None,
+                })
+                .flatten();
+            if let Some(text) = text {
+                docs.push((id, text));
+            }
+        }
+        let count = docs.len();
+        let key = format!("{label}::{text_property}");
+        self.text_indexes.insert(key, Bm25Index::build(docs, Bm25Params::default()));
+        Ok(count)
+    }
+
+    /// Whether a BM25 index is built for `label::text_property`.
+    pub fn has_text_index(&self, label: &str, text_property: &str) -> bool {
+        self.text_indexes.contains_key(&format!("{label}::{text_property}"))
+    }
+
+    /// **Tri-modal hybrid query** (ADR-252 P4): fuse ANN vector similarity, BM25
+    /// keyword relevance, and graph traversal in a single typed call.
+    ///
+    /// The query `text` is embedded (inline `embed()`) for the vector arm and
+    /// tokenized for the BM25 arm; the two rankings are fused with Reciprocal
+    /// Rank Fusion (`rrf_k`, conventionally 60), and the fused top-`k` seeds are
+    /// traversed. Requires both an embedder and a BM25 index
+    /// ([`TypedGraph::build_text_index`]); an ANN index is optional (the vector
+    /// arm falls back to the exact scan). Result `score` is the fused RRF score.
+    pub fn hybrid_search_text(
+        &self,
+        vector_type: &str,
+        text_property: &str,
+        text: &str,
+        k: usize,
+        rrf_k: f32,
+        traverse: &TraverseSpec,
+    ) -> Result<Vec<TraversalResult>> {
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+        let vs = self
+            .schema
+            .vector(vector_type)
+            .ok_or_else(|| GraphError::SchemaViolation(format!("unknown vector type '{vector_type}'")))?;
+
+        // Over-fetch each arm so fusion has depth to work with.
+        let over = k.saturating_mul(4).max(k + 32);
+
+        // Vector arm: embed inline, dimension-check, rank.
+        let qvec = self.embed(text)?;
+        if qvec.len() != vs.dimensions {
+            return Err(GraphError::SchemaViolation(format!(
+                "embedder produced dimension {} but vector type '{}' expects {}",
+                qvec.len(),
+                vector_type,
+                vs.dimensions
+            )));
+        }
+        let vec_hits = self.rank_seeds(vs, &qvec, over)?;
+
+        // Keyword arm: BM25 over the text property of the bound label.
+        let key = format!("{}::{}", vs.label, text_property);
+        let bm = self.text_indexes.get(&key).ok_or_else(|| {
+            GraphError::SchemaViolation(format!("BM25 index '{key}' not built (call build_text_index)"))
+        })?;
+        let kw_hits = bm.search(text, over);
+
+        // Fuse the two rank lists with RRF, then traverse the fused top-k.
+        let vec_ids: Vec<NodeId> = vec_hits.into_iter().map(|(_, id)| id).collect();
+        let kw_ids: Vec<NodeId> = kw_hits.into_iter().map(|(id, _)| id).collect();
+        let fused = reciprocal_rank_fusion(&[vec_ids, kw_ids], rrf_k);
+        let hits: Vec<(f32, NodeId)> = fused.into_iter().take(k).map(|(id, s)| (s, id)).collect();
+        Ok(self.expand(hits, traverse))
     }
 
     /// HNSW push-down: approximate ANN search, over-fetch, then rescore the
@@ -573,6 +737,130 @@ mod tests {
         }
         // Traversal still expands the seed.
         assert_eq!(res[0].connected.iter().filter(|n| n.id == "ai").count(), 1);
+    }
+
+    #[test]
+    fn embed_at_insert_and_query_roundtrip() {
+        use crate::embed::HashEmbedder;
+        // Schema vector dim must match the embedder dim.
+        let mut s = GraphSchema::new();
+        s.add_node(
+            NodeSchema::new("Doc")
+                .property(PropertySchema::new("title", PropertyType::String).required())
+                .property(PropertySchema::new("embedding", PropertyType::Vector)),
+        );
+        s.add_node(NodeSchema::new("Topic"));
+        s.add_edge(EdgeSchema::new("ABOUT", "Doc", "Topic"));
+        s.add_vector(VectorSchema::new("DocEmb", "Doc", "embedding", 128, DistanceMetric::Cosine));
+        let tg = TypedGraph::new(GraphDB::new(), s)
+            .unwrap()
+            .with_embedder(Arc::new(HashEmbedder::new(128)));
+
+        // Inline embed at insert — no caller-supplied vector.
+        for (id, text) in [
+            ("d1", "machine learning vector database"),
+            ("d2", "distributed systems consensus raft"),
+            ("d3", "italian pasta cooking recipe"),
+        ] {
+            let node = NodeBuilder::new().id(id).label("Doc").property("title", text).build();
+            tg.create_node_from_text(node, "DocEmb", text).unwrap();
+        }
+
+        // Query by text — closest doc to a lexically-overlapping query wins.
+        let res = tg
+            .search_text("DocEmb", "vector database machine learning", 1, &TraverseSpec::out("ABOUT"))
+            .unwrap();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].seed_id, "d1");
+    }
+
+    #[test]
+    fn tri_modal_hybrid_fuses_vector_keyword_graph() {
+        use crate::embed::HashEmbedder;
+        let mut s = GraphSchema::new();
+        s.add_node(
+            NodeSchema::new("Doc")
+                .property(PropertySchema::new("body", PropertyType::String).required())
+                .property(PropertySchema::new("embedding", PropertyType::Vector)),
+        );
+        s.add_node(NodeSchema::new("Topic"));
+        s.add_edge(EdgeSchema::new("ABOUT", "Doc", "Topic"));
+        s.add_vector(VectorSchema::new("DocEmb", "Doc", "embedding", 256, DistanceMetric::Cosine));
+        let mut tg = TypedGraph::new(GraphDB::new(), s)
+            .unwrap()
+            .with_embedder(Arc::new(HashEmbedder::new(256)));
+
+        let docs = [
+            ("d1", "vector database for semantic similarity search"),
+            ("d2", "graph traversal and relationship queries"),
+            ("d3", "machine learning embedding models"),
+            ("d4", "italian cooking pasta tomato recipe"),
+            ("d5", "approximate nearest neighbour vector search index"),
+        ];
+        for (id, body) in docs {
+            let node = NodeBuilder::new().id(id).label("Doc").property("body", body).build();
+            tg.create_node_from_text(node, "DocEmb", body).unwrap();
+        }
+        // Topic + edge so traversal does work.
+        tg.create_node(NodeBuilder::new().id("t-search").label("Topic").build()).unwrap();
+        tg.create_edge(Edge::create("d1".into(), "t-search".into(), "ABOUT")).unwrap();
+
+        tg.build_text_index("Doc", "body").unwrap();
+        assert!(tg.has_text_index("Doc", "body"));
+
+        let res = tg
+            .hybrid_search_text(
+                "DocEmb",
+                "body",
+                "vector search",
+                3,
+                60.0,
+                &TraverseSpec::out("ABOUT").target_label("Topic"),
+            )
+            .unwrap();
+
+        assert_eq!(res.len(), 3);
+        // The fused top results must be the vector-search docs, not the recipe.
+        let top_ids: Vec<&str> = res.iter().map(|r| r.seed_id.as_str()).collect();
+        assert!(top_ids.contains(&"d1") || top_ids.contains(&"d5"));
+        assert!(!top_ids.contains(&"d4"));
+        // RRF scores are descending.
+        for w in res.windows(2) {
+            assert!(w[0].score >= w[1].score);
+        }
+        // Traversal applied for d1 if present.
+        if let Some(r) = res.iter().find(|r| r.seed_id == "d1") {
+            assert_eq!(r.connected.iter().filter(|n| n.id == "t-search").count(), 1);
+        }
+    }
+
+    #[test]
+    fn hybrid_requires_text_index() {
+        use crate::embed::HashEmbedder;
+        let tg = TypedGraph::new(GraphDB::new(), schema())
+            .unwrap()
+            .with_embedder(Arc::new(HashEmbedder::new(3)));
+        // No build_text_index → explicit error, no silent degradation.
+        let err = tg.hybrid_search_text("DocEmb", "title", "x", 1, 60.0, &TraverseSpec::out("ABOUT"));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn embed_without_embedder_errors() {
+        let tg = TypedGraph::new(GraphDB::new(), schema()).unwrap();
+        assert!(tg.embed("anything").is_err());
+        assert!(tg.search_text("DocEmb", "x", 1, &TraverseSpec::out("ABOUT")).is_err());
+    }
+
+    #[test]
+    fn embed_dimension_mismatch_is_rejected() {
+        use crate::embed::HashEmbedder;
+        // Embedder dim (64) != schema vector dim (3 from `schema()`).
+        let tg = TypedGraph::new(GraphDB::new(), schema())
+            .unwrap()
+            .with_embedder(Arc::new(HashEmbedder::new(64)));
+        let node = NodeBuilder::new().id("d1").label("Doc").property("title", "x").build();
+        assert!(tg.create_node_from_text(node, "DocEmb", "some text").is_err());
     }
 
     #[test]

--- a/crates/ruvector-graph/src/typed_graph.rs
+++ b/crates/ruvector-graph/src/typed_graph.rs
@@ -4,29 +4,46 @@
 //! `TypedGraph` wraps a [`GraphDB`] with an optional [`GraphSchema`]. Mutations
 //! are validated against the schema before they touch storage, and the
 //! [`TypedGraph::search_then_traverse`] method expresses HelixQL's
-//! `SearchV<T>(q, k)::In<Edge>` pattern as a single fused operation: an ANN-style
+//! `SearchV<T>(q, k)::In<Edge>` pattern as a single fused operation: an ANN
 //! vector search over a bound node label, immediately traversed into the graph.
 //!
-//! The vector step is a brute-force scan over the bound label's nodes, with an
-//! optimized **bounded top-k heap** (O(n log k) instead of O(n log n) sort).
-//! Wiring this to the HNSW/`HybridIndex` path for large graphs is ADR-252 future
-//! work; the operator's *shape* (typed, single-call, push-down search before
-//! join) is the deliverable here.
+//! The vector step has two backends:
+//!
+//! - **Brute-force** (default): an optimized bounded-top-k scan over the bound
+//!   label's nodes — zero-copy borrow scoring, fused cosine, O(n log k) heap,
+//!   rayon-parallel above a threshold. Exact, no build step.
+//! - **HNSW push-down** (opt-in via [`TypedGraph::build_vector_index`]): an
+//!   ANN index ([`HybridIndex`]) per vector type. `search_then_traverse` then
+//!   does an ~O(log n) approximate search, **over-fetches**, and **rescores the
+//!   candidates exactly** with the schema metric — so results carry identical
+//!   higher-is-better score semantics to the brute-force path while skipping the
+//!   full-label scan.
 
 use crate::edge::Edge;
 use crate::error::{GraphError, Result};
 use crate::graph::GraphDB;
+use crate::hybrid::{EmbeddingConfig, HybridIndex, VectorIndexType};
 use crate::node::Node;
-use crate::schema::{score_property, GraphSchema};
+use crate::schema::{extract_vector, score_property, DistanceMetric, GraphSchema};
 use crate::types::NodeId;
 use ordered_float::OrderedFloat;
 use rayon::prelude::*;
 use std::cmp::Reverse;
-use std::collections::BinaryHeap;
+use std::collections::{BinaryHeap, HashMap};
 
 /// Below this candidate count the serial scan wins (rayon fork/join overhead
 /// exceeds the work). Above it, the parallel path engages.
 const PARALLEL_SCAN_THRESHOLD: usize = 4_096;
+
+/// Map a schema metric to the core index metric.
+fn to_core_metric(m: DistanceMetric) -> ruvector_core::types::DistanceMetric {
+    use ruvector_core::types::DistanceMetric as C;
+    match m {
+        DistanceMetric::Cosine => C::Cosine,
+        DistanceMetric::DotProduct => C::DotProduct,
+        DistanceMetric::Euclidean => C::Euclidean,
+    }
+}
 
 type ScoredHeap = BinaryHeap<Reverse<(OrderedFloat<f32>, NodeId)>>;
 
@@ -100,6 +117,9 @@ pub struct TraversalResult {
 pub struct TypedGraph {
     graph: GraphDB,
     schema: GraphSchema,
+    /// Optional ANN index per vector-type name (HNSW push-down). Each index holds
+    /// only the bound label's nodes, so searches are naturally label-scoped.
+    indexes: HashMap<String, HybridIndex>,
 }
 
 impl TypedGraph {
@@ -107,7 +127,7 @@ impl TypedGraph {
     /// up front (the HelixQL compile-time check).
     pub fn new(graph: GraphDB, schema: GraphSchema) -> Result<Self> {
         schema.validate_self()?;
-        Ok(Self { graph, schema })
+        Ok(Self { graph, schema, indexes: HashMap::new() })
     }
 
     pub fn schema(&self) -> &GraphSchema {
@@ -121,9 +141,73 @@ impl TypedGraph {
         &mut self.graph
     }
 
-    /// Validate a node against the schema, then create it.
+    /// Build (or rebuild) an ANN index for a declared vector type, populating it
+    /// from the nodes currently carrying that embedding. Subsequent
+    /// `create_node` calls keep the index current incrementally. Returns the
+    /// number of vectors indexed. Opting in switches `search_then_traverse` for
+    /// this vector type onto the HNSW push-down path.
+    pub fn build_vector_index(&mut self, vector_type: &str) -> Result<usize> {
+        let vs = self
+            .schema
+            .vector(vector_type)
+            .ok_or_else(|| GraphError::SchemaViolation(format!("unknown vector type '{vector_type}'")))?
+            .clone();
+
+        let config = EmbeddingConfig {
+            dimensions: vs.dimensions,
+            metric: to_core_metric(vs.metric),
+            embedding_property: vs.property.clone(),
+            ..Default::default()
+        };
+        let index = HybridIndex::new(config)?;
+        index.initialize_index(VectorIndexType::Node)?;
+
+        let mut count = 0usize;
+        for id in self.graph.node_ids_by_label(&vs.label) {
+            let emb = self
+                .graph
+                .with_node(&id, |n| n.properties.get(&vs.property).and_then(extract_vector))
+                .flatten();
+            if let Some(emb) = emb {
+                if emb.len() == vs.dimensions {
+                    index.add_node_embedding(id, emb)?;
+                    count += 1;
+                }
+            }
+        }
+        self.indexes.insert(vector_type.to_string(), index);
+        Ok(count)
+    }
+
+    /// Whether an ANN index is built for `vector_type`.
+    pub fn has_vector_index(&self, vector_type: &str) -> bool {
+        self.indexes.contains_key(vector_type)
+    }
+
+    /// Incrementally add a node to any ANN index whose vector type it matches.
+    fn index_node(&self, node: &Node) {
+        for (name, index) in &self.indexes {
+            let Some(vs) = self.schema.vector(name) else {
+                continue;
+            };
+            if !node.has_label(&vs.label) {
+                continue;
+            }
+            if let Some(emb) = node.properties.get(&vs.property).and_then(extract_vector) {
+                if emb.len() == vs.dimensions {
+                    // Best-effort: a failed index add must not fail the write.
+                    let _ = index.add_node_embedding(node.id.clone(), emb);
+                }
+            }
+        }
+    }
+
+    /// Validate a node against the schema, then create it (updating ANN indexes).
     pub fn create_node(&self, node: Node) -> Result<NodeId> {
         self.schema.validate_node(&node)?;
+        if !self.indexes.is_empty() {
+            self.index_node(&node);
+        }
         self.graph.create_node(node)
     }
 
@@ -146,8 +230,9 @@ impl TypedGraph {
     /// 1. Resolve `vector_type` to its bound label + property + metric (typed —
     ///    no string/property guessing).
     /// 2. Validate the query dimension.
-    /// 3. Scan the bound label's nodes, scoring with the declared metric, keeping
-    ///    the top `k` via a bounded heap.
+    /// 3. Find the top-`k` seeds: via the ANN index if one is built for this
+    ///    vector type ([`TypedGraph::build_vector_index`]), else a bounded-top-k
+    ///    scan. Either way, seeds carry an exact higher-is-better score.
     /// 4. Traverse from each seed along `traverse` and collect target nodes.
     pub fn search_then_traverse(
         &self,
@@ -164,11 +249,70 @@ impl TypedGraph {
         let property = vs.property.as_str();
         // Hoist the query-side norm out of the per-candidate loop (cosine).
         let query_norm = metric.query_norm(query);
-        let ids = self.graph.node_ids_by_label(&vs.label);
 
-        // Score one candidate id; `None` if missing or not vector-shaped.
+        let hits = match self.indexes.get(vector_type) {
+            Some(index) => self.rank_via_index(index, property, query, query_norm, metric, k)?,
+            None => self.rank_via_scan(&vs.label, property, query, query_norm, metric, k),
+        };
+
+        let mut out = Vec::with_capacity(hits.len());
+        for (score, seed_id) in hits {
+            let connected = self.traverse_from(&seed_id, traverse);
+            out.push(TraversalResult { seed_id, score, connected });
+        }
+        Ok(out)
+    }
+
+    /// HNSW push-down: approximate ANN search, over-fetch, then rescore the
+    /// candidates exactly so the returned scores match the brute-force path.
+    fn rank_via_index(
+        &self,
+        index: &HybridIndex,
+        property: &str,
+        query: &[f32],
+        query_norm: f32,
+        metric: DistanceMetric,
+        k: usize,
+    ) -> Result<Vec<(f32, NodeId)>> {
+        // Over-fetch to recover HNSW approximation, then rerank exactly.
+        let over = k.saturating_mul(4).max(k + 32);
+        let candidates = index.search_similar_nodes(query, over)?;
+        let mut scored: Vec<(f32, NodeId)> = candidates
+            .into_iter()
+            .filter_map(|(id, _approx)| {
+                let s = self
+                    .graph
+                    .with_node(&id, |node| {
+                        node.properties
+                            .get(property)
+                            .and_then(|p| score_property(metric, query, query_norm, p))
+                    })
+                    .flatten()?;
+                Some((s, id))
+            })
+            .collect();
+        scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(k);
+        Ok(scored)
+    }
+
+    /// Brute-force bounded-top-k scan over the bound label, returning seeds in
+    /// descending score order. Rayon-parallel above the threshold.
+    fn rank_via_scan(
+        &self,
+        label: &str,
+        property: &str,
+        query: &[f32],
+        query_norm: f32,
+        metric: DistanceMetric,
+        k: usize,
+    ) -> Vec<(f32, NodeId)> {
+        let ids = self.graph.node_ids_by_label(label);
+        // Capture `graph` (not `self`) so the parallel closure stays Send+Sync
+        // regardless of the ANN index's thread-safety bounds.
+        let graph = &self.graph;
         let score_one = |id: &NodeId| -> Option<f32> {
-            self.graph
+            graph
                 .with_node(id, |node| {
                     node.properties
                         .get(property)
@@ -203,17 +347,10 @@ impl TypedGraph {
             h
         };
 
-        // Drain heap into descending-score order.
         let mut hits: Vec<(f32, NodeId)> =
             heap.into_iter().map(|Reverse((s, id))| (s.into_inner(), id)).collect();
         hits.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-
-        let mut out = Vec::with_capacity(hits.len());
-        for (score, seed_id) in hits {
-            let connected = self.traverse_from(&seed_id, traverse);
-            out.push(TraversalResult { seed_id, score, connected });
-        }
-        Ok(out)
+        hits
     }
 
     /// Collect nodes reachable from `seed` along the traversal spec.
@@ -402,5 +539,53 @@ mod tests {
         for w in res.windows(2) {
             assert!(w[0].score >= w[1].score);
         }
+    }
+
+    #[test]
+    fn indexed_path_finds_top_result_and_traverses() {
+        // HNSW push-down: build an ANN index and confirm it returns the exact
+        // winner (over-fetch + exact rescore) with traversal still applied.
+        let mut tg = TypedGraph::new(GraphDB::new(), schema()).unwrap();
+        // Data on an arc of the unit circle so the nearest neighbour is on the
+        // manifold (the realistic, HNSW-friendly case). `winner` sits at angle 0,
+        // exactly aligned with the query; the rest fan out to larger angles.
+        tg.create_node(doc("winner", "t", vec![1.0, 0.0, 0.0])).unwrap();
+        for i in 0..300 {
+            let a = 0.2 + (i as f32 / 300.0) * 1.2; // 0.2 .. 1.4 rad
+            tg.create_node(doc(&format!("d{i}"), "t", vec![a.cos(), a.sin(), 0.0])).unwrap();
+        }
+        tg.create_node(NodeBuilder::new().id("ai").label("Topic").property("name", "ai").build())
+            .unwrap();
+        tg.create_edge(Edge::create("winner".into(), "ai".into(), "ABOUT")).unwrap();
+
+        let built = tg.build_vector_index("DocEmb").unwrap();
+        assert_eq!(built, 301);
+        assert!(tg.has_vector_index("DocEmb"));
+
+        let res = tg
+            .search_then_traverse("DocEmb", &[1.0, 0.0, 0.0], 5, &TraverseSpec::out("ABOUT").target_label("Topic"))
+            .unwrap();
+        assert_eq!(res.len(), 5);
+        assert_eq!(res[0].seed_id, "winner");
+        assert!((res[0].score - 1.0).abs() < 1e-5);
+        for w in res.windows(2) {
+            assert!(w[0].score >= w[1].score);
+        }
+        // Traversal still expands the seed.
+        assert_eq!(res[0].connected.iter().filter(|n| n.id == "ai").count(), 1);
+    }
+
+    #[test]
+    fn index_incrementally_picks_up_new_nodes() {
+        let mut tg = TypedGraph::new(GraphDB::new(), schema()).unwrap();
+        tg.create_node(doc("a", "t", vec![0.0, 1.0, 0.0])).unwrap();
+        tg.build_vector_index("DocEmb").unwrap();
+        // Inserted *after* the index is built — must be indexed incrementally.
+        tg.create_node(doc("b", "t", vec![1.0, 0.0, 0.0])).unwrap();
+        let res = tg
+            .search_then_traverse("DocEmb", &[1.0, 0.0, 0.0], 1, &TraverseSpec::out("ABOUT"))
+            .unwrap();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].seed_id, "b");
     }
 }

--- a/crates/ruvector-graph/src/typed_graph.rs
+++ b/crates/ruvector-graph/src/typed_graph.rs
@@ -17,11 +17,40 @@ use crate::edge::Edge;
 use crate::error::{GraphError, Result};
 use crate::graph::GraphDB;
 use crate::node::Node;
-use crate::schema::{extract_vector, GraphSchema};
+use crate::schema::{score_property, GraphSchema};
 use crate::types::NodeId;
 use ordered_float::OrderedFloat;
+use rayon::prelude::*;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
+
+/// Below this candidate count the serial scan wins (rayon fork/join overhead
+/// exceeds the work). Above it, the parallel path engages.
+const PARALLEL_SCAN_THRESHOLD: usize = 4_096;
+
+type ScoredHeap = BinaryHeap<Reverse<(OrderedFloat<f32>, NodeId)>>;
+
+/// Keep only the top-`k` largest-scored entries in `heap`.
+#[inline]
+fn trim_to_k(heap: &mut ScoredHeap, k: usize) {
+    while heap.len() > k {
+        heap.pop(); // Reverse min-heap: pop() drops the smallest score.
+    }
+}
+
+/// Offer `(score, id)` to a bounded top-`k` heap, cloning `id` only if it wins a
+/// slot (avoids an allocation for the common losing candidate).
+#[inline]
+fn consider(heap: &mut ScoredHeap, k: usize, score: f32, id: &NodeId) {
+    if heap.len() < k {
+        heap.push(Reverse((OrderedFloat(score), id.clone())));
+    } else if let Some(Reverse((min, _))) = heap.peek() {
+        if OrderedFloat(score) > *min {
+            heap.pop();
+            heap.push(Reverse((OrderedFloat(score), id.clone())));
+        }
+    }
+}
 
 /// Traversal direction relative to the matched seed node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -127,33 +156,52 @@ impl TypedGraph {
         k: usize,
         traverse: &TraverseSpec,
     ) -> Result<Vec<TraversalResult>> {
+        if k == 0 {
+            return Ok(Vec::new());
+        }
         let vs = self.schema.validate_vector_dims(vector_type, query)?;
         let metric = vs.metric;
         let property = vs.property.as_str();
+        // Hoist the query-side norm out of the per-candidate loop (cosine).
+        let query_norm = metric.query_norm(query);
+        let ids = self.graph.node_ids_by_label(&vs.label);
 
-        // Bounded min-heap of size k keyed by score: O(n log k) top-k selection.
-        let mut heap: BinaryHeap<Reverse<(OrderedFloat<f32>, NodeId)>> = BinaryHeap::new();
-        for node in self.graph.get_nodes_by_label(&vs.label) {
-            let Some(prop) = node.properties.get(property) else {
-                continue;
-            };
-            let Some(emb) = extract_vector(prop) else {
-                continue;
-            };
-            if emb.len() != query.len() {
-                continue; // skip malformed embeddings rather than failing the query
-            }
-            let score = metric.score(query, &emb);
-            let entry = Reverse((OrderedFloat(score), node.id.clone()));
-            if heap.len() < k {
-                heap.push(entry);
-            } else if let Some(Reverse((min_score, _))) = heap.peek() {
-                if OrderedFloat(score) > *min_score {
-                    heap.pop();
-                    heap.push(entry);
+        // Score one candidate id; `None` if missing or not vector-shaped.
+        let score_one = |id: &NodeId| -> Option<f32> {
+            self.graph
+                .with_node(id, |node| {
+                    node.properties
+                        .get(property)
+                        .and_then(|prop| score_property(metric, query, query_norm, prop))
+                })
+                .flatten()
+        };
+
+        // Bounded top-k via a min-heap: O(n log k). DashMap allows concurrent
+        // reads, so for large candidate sets we fan the scan across cores with
+        // per-thread heaps and a bounded merge.
+        let heap: ScoredHeap = if ids.len() >= PARALLEL_SCAN_THRESHOLD {
+            ids.par_iter()
+                .fold(ScoredHeap::new, |mut h, id| {
+                    if let Some(score) = score_one(id) {
+                        consider(&mut h, k, score, id);
+                    }
+                    h
+                })
+                .reduce(ScoredHeap::new, |mut a, b| {
+                    a.extend(b);
+                    trim_to_k(&mut a, k);
+                    a
+                })
+        } else {
+            let mut h = ScoredHeap::new();
+            for id in &ids {
+                if let Some(score) = score_one(id) {
+                    consider(&mut h, k, score, id);
                 }
             }
-        }
+            h
+        };
 
         // Drain heap into descending-score order.
         let mut hits: Vec<(f32, NodeId)> =
@@ -285,6 +333,58 @@ mod tests {
         let tg = TypedGraph::new(GraphDB::new(), schema()).unwrap();
         let err = tg.search_then_traverse("DocEmb", &[1.0, 2.0], 1, &TraverseSpec::out("ABOUT"));
         assert!(err.is_err());
+    }
+
+    #[test]
+    fn parallel_scan_matches_reference() {
+        // Exceed PARALLEL_SCAN_THRESHOLD so the rayon path runs, and check the
+        // top-k it returns equals an independent brute-force ranking.
+        let tg = TypedGraph::new(GraphDB::new(), schema()).unwrap();
+        let n = 5000usize;
+        let mut embs: Vec<(String, Vec<f32>)> = Vec::with_capacity(n);
+        for i in 0..n {
+            // Deterministic spread across the unit-ish cube.
+            let v = vec![
+                ((i * 7) % 100) as f32 / 100.0,
+                ((i * 13) % 100) as f32 / 100.0,
+                ((i * 29) % 100) as f32 / 100.0,
+            ];
+            let id = format!("d{i}");
+            tg.create_node(doc(&id, "t", v.clone())).unwrap();
+            embs.push((id, v));
+        }
+        let q = [1.0f32, 0.0, 0.0];
+        let k = 10;
+        let res = tg.search_then_traverse("DocEmb", &q, k, &TraverseSpec::out("ABOUT")).unwrap();
+
+        // Reference: cosine score, sort desc, take k ids.
+        let qn = (q[0] * q[0]) as f32;
+        let qn = qn.sqrt();
+        let mut reference: Vec<(f32, String)> = embs
+            .iter()
+            .map(|(id, v)| {
+                let dot: f32 = q.iter().zip(v).map(|(a, b)| a * b).sum();
+                let vn: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+                let s = if qn == 0.0 || vn == 0.0 { 0.0 } else { dot / (qn * vn) };
+                (s, id.clone())
+            })
+            .collect();
+        reference.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
+
+        assert_eq!(res.len(), k);
+        for w in res.windows(2) {
+            assert!(w[0].score >= w[1].score);
+        }
+        // Ties (identical cosine scores) make exact id order ambiguous, so compare
+        // the top-k *scores* against the reference — these must match exactly.
+        for (got, want) in res.iter().zip(reference.iter()) {
+            assert!(
+                (got.score - want.0).abs() < 1e-5,
+                "score mismatch: {} vs {}",
+                got.score,
+                want.0
+            );
+        }
     }
 
     #[test]

--- a/docs/adr/ADR-252-helixdb-comparison-ruvector-improvements.md
+++ b/docs/adr/ADR-252-helixdb-comparison-ruvector-improvements.md
@@ -50,12 +50,26 @@ over the first-cut implementation (128-dim, k=10):
 | 50,000 (parallel) | 74.3 ms | 28.5 ms | 2.61× |
 
 `validate_node` is 128 ns; `reciprocal_rank_fusion` over 2×1000 lists is 318 µs.
-The brute-force scan remains O(n) by design; the natural next optimization is
-HNSW push-down (use the existing `HybridIndex` to avoid the full-label scan),
-tracked as ADR-252 follow-up. The remaining items (P3 in-query `embed()`, the
-single-statement hybrid query surface in Cypher, P5 head-to-head benchmarks vs
-Neo4j/pgvector/Qdrant/HelixDB, P6 codegen, P7 object-storage spike) remain
-authorized and will land under follow-up ADRs.
+
+**HNSW push-down (landed).** `search_then_traverse` now takes an opt-in ANN path:
+`TypedGraph::build_vector_index(vector_type)` builds a per-vector-type
+`HybridIndex` (HNSW under the `hnsw_rs` feature, exact `FlatIndex` otherwise),
+kept current incrementally on `create_node`. The query then does an ~O(log n)
+approximate search, **over-fetches** (`max(4k, k+32)`), and **rescores the
+candidates exactly** with the schema metric — so the ANN path returns *identical
+higher-is-better score semantics* to the brute-force path while skipping the
+full-label scan. Brute force remains the default (exact, no build step, no extra
+memory). Measured at 50k nodes / 128-dim / k=10:
+
+| backend | latency | vs parallel scan | vs first cut |
+|---|---|---|---|
+| brute-force parallel scan | 27.6 ms | 1× | 2.7× |
+| HNSW push-down | 1.05 ms | **26×** | **~70×** |
+
+The remaining items (P3 in-query `embed()`, the single-statement hybrid query
+surface in Cypher, P5 head-to-head benchmarks vs Neo4j/pgvector/Qdrant/HelixDB,
+P6 codegen, P7 object-storage spike) remain authorized and will land under
+follow-up ADRs.
 
 ## Context
 

--- a/docs/adr/ADR-252-helixdb-comparison-ruvector-improvements.md
+++ b/docs/adr/ADR-252-helixdb-comparison-ruvector-improvements.md
@@ -19,21 +19,26 @@ vector stack (`crates/ruvector-core`, `crates/ruvector-graph`,
 prioritized set of improvements that adopt HelixDB's strongest ideas where they
 fit RuVector's thesis.
 
-The **cores of P1, P2, and P4 are now implemented natively** in `ruvector-graph`
+**P1, P2, P3, and P4 are now implemented natively** in `ruvector-graph`
 on branch `claude/helixdb-ruvector-comparison-qmsx42`:
 
-- `crates/ruvector-graph/src/schema.rs` — opt-in `GraphSchema` (node/edge/vector
+- `crates/ruvector-graph/src/schema.rs` (P1) — opt-in `GraphSchema` (node/edge/vector
   type declarations, indexed properties, `from`/`to` edge constraints,
   vector-type→label/property binding), load-time validation (`validate_self`,
   `validate_node`, `validate_edge`, `validate_vector_dims`), higher-is-better
   distance metrics, and `reciprocal_rank_fusion` (P4 core).
-- `crates/ruvector-graph/src/typed_graph.rs` — `TypedGraph` wrapper that validates
-  mutations before they touch storage and a fused, typed
+- `crates/ruvector-graph/src/typed_graph.rs` (P2) — `TypedGraph` wrapper that
+  validates mutations before they touch storage and a fused, typed
   `search_then_traverse` operator (HelixQL's `SearchV<T>(q,k)::In/Out<E>`), with
-  an optimized bounded-heap top-k selection (O(n log k)).
+  optimized bounded-heap top-k (O(n log k)), a rayon parallel scan, and an opt-in
+  HNSW push-down path.
+- `crates/ruvector-graph/src/embed.rs` (P3) — `Embedder` trait + `HashEmbedder`,
+  with inline `embed()` at insert/query on `TypedGraph`.
+- `crates/ruvector-graph/src/bm25.rs` (P4) — Okapi-BM25 index feeding the
+  tri-modal `hybrid_search_text` (vector + keyword + graph, RRF-fused).
 
-Pure-Rust (rayon is already a crate dependency), WASM-safe schema layer;
-**14 new unit tests pass, 149/149 lib tests green, clippy clean**.
+Pure-Rust (rayon already a crate dependency), WASM-safe schema/embed/BM25 layers;
+**38 new unit tests, 164/164 lib tests green, clippy clean**.
 
 A criterion benchmark (`crates/ruvector-graph/benches/typed_graph_bench.rs`,
 P5 seed) measures the operator and validation. After optimizing the hot path —
@@ -66,10 +71,31 @@ memory). Measured at 50k nodes / 128-dim / k=10:
 | brute-force parallel scan | 27.6 ms | 1× | 2.7× |
 | HNSW push-down | 1.05 ms | **26×** | **~70×** |
 
-The remaining items (P3 in-query `embed()`, the single-statement hybrid query
-surface in Cypher, P5 head-to-head benchmarks vs Neo4j/pgvector/Qdrant/HelixDB,
-P6 codegen, P7 object-storage spike) remain authorized and will land under
-follow-up ADRs.
+**Inline `embed()` (P3, landed).** `crates/ruvector-graph/src/embed.rs` adds a
+pluggable `Embedder` trait and a dependency-free, deterministic `HashEmbedder`
+(feature-hashing; lexical-overlap only — an *explicit* opt-in, never a silent
+fallback per ADR-194). `TypedGraph::with_embedder` attaches a model;
+`create_node_from_text` vectorizes a text field into the bound property at insert
+(HelixQL `AddN<T>({ embedding: Embed(text) })`) with dimension validation, and
+`search_text` embeds the query inline (`SearchV<T>(Embed(text), k)`). A real
+model (MiniLM/ONNX per ADR-210) plugs in via the trait.
+
+**Tri-modal hybrid query (P4, landed).** `crates/ruvector-graph/src/bm25.rs` is a
+self-contained Okapi-BM25 inverted index; `TypedGraph::hybrid_search_text` fuses
+**ANN vector similarity + BM25 keyword relevance + graph traversal** in one typed
+call, combining the vector and keyword rankings with `reciprocal_rank_fusion`
+(`rrf_k`, conventionally 60) before traversing the fused top-k. This tri-modal
+single-call fusion goes beyond HelixDB's current ANN+BM25 hybrid by folding the
+graph expansion into the same operation.
+
+Measured: `HashEmbedder` embed is 717 ns (256-dim); the full tri-modal hybrid
+(inline embed + HNSW + BM25 + RRF + traversal) over 10k docs is **1.63 ms** end
+to end.
+
+The remaining items (a single-statement hybrid surface in Cypher itself, P5
+head-to-head benchmarks vs Neo4j/pgvector/Qdrant/HelixDB, P6 schema-driven SDK
+codegen, P7 object-storage spike) remain authorized and will land under follow-up
+ADRs.
 
 ## Context
 

--- a/docs/adr/ADR-252-helixdb-comparison-ruvector-improvements.md
+++ b/docs/adr/ADR-252-helixdb-comparison-ruvector-improvements.md
@@ -12,13 +12,30 @@ tags: [ruvector, graph, vector, helixdb, query-language, schema, hnsw, storage, 
 
 ## Status
 
-**Proposed.** This is an analysis-and-direction ADR. It compares
-[HelixDB](https://github.com/HelixDB/helix-db) against RuVector's graph + vector
-stack (`crates/ruvector-core`, `crates/ruvector-graph`, `crates/ruvector-server`,
-and the `ruvector` npm package) and proposes a prioritized set of improvements
-that adopt HelixDB's strongest ideas where they fit RuVector's thesis. No code is
-changed by this ADR; it authorizes the work items in the Decision section, each
-of which will land under its own follow-up ADR.
+**Accepted — partially implemented.** This is an analysis-and-direction ADR. It
+compares [HelixDB](https://github.com/HelixDB/helix-db) against RuVector's graph +
+vector stack (`crates/ruvector-core`, `crates/ruvector-graph`,
+`crates/ruvector-server`, and the `ruvector` npm package) and proposes a
+prioritized set of improvements that adopt HelixDB's strongest ideas where they
+fit RuVector's thesis.
+
+The **cores of P1, P2, and P4 are now implemented natively** in `ruvector-graph`
+on branch `claude/helixdb-ruvector-comparison-qmsx42`:
+
+- `crates/ruvector-graph/src/schema.rs` — opt-in `GraphSchema` (node/edge/vector
+  type declarations, indexed properties, `from`/`to` edge constraints,
+  vector-type→label/property binding), load-time validation (`validate_self`,
+  `validate_node`, `validate_edge`, `validate_vector_dims`), higher-is-better
+  distance metrics, and `reciprocal_rank_fusion` (P4 core).
+- `crates/ruvector-graph/src/typed_graph.rs` — `TypedGraph` wrapper that validates
+  mutations before they touch storage and a fused, typed
+  `search_then_traverse` operator (HelixQL's `SearchV<T>(q,k)::In/Out<E>`), with
+  an optimized bounded-heap top-k selection (O(n log k)).
+
+Pure-Rust, no new dependencies, WASM-safe; **13 new unit tests pass, 148/148 lib
+tests green, clippy clean**. The remaining items (P3 in-query `embed()`, the
+single-statement hybrid query surface in Cypher, P5 benchmarks, P6 codegen, P7
+object-storage spike) remain authorized and will land under follow-up ADRs.
 
 ## Context
 

--- a/docs/adr/ADR-252-helixdb-comparison-ruvector-improvements.md
+++ b/docs/adr/ADR-252-helixdb-comparison-ruvector-improvements.md
@@ -36,9 +36,13 @@ on branch `claude/helixdb-ruvector-comparison-qmsx42`:
   with inline `embed()` at insert/query on `TypedGraph`.
 - `crates/ruvector-graph/src/bm25.rs` (P4) — Okapi-BM25 index feeding the
   tri-modal `hybrid_search_text` (vector + keyword + graph, RRF-fused).
+- `crates/ruvector-graph/src/codegen.rs` (P6) — schema-driven typed client
+  codegen: deterministic TypeScript interfaces, Python `TypedDict`s, and Rust
+  structs plus a vector-type manifest, carrying labels/property types/edge
+  `from`/`to`/vector dims across the language boundary.
 
-Pure-Rust (rayon already a crate dependency), WASM-safe schema/embed/BM25 layers;
-**38 new unit tests, 164/164 lib tests green, clippy clean**.
+Pure-Rust (rayon already a crate dependency), WASM-safe schema/embed/BM25/codegen
+layers; **42 new unit tests, 168/168 lib tests green, clippy clean**.
 
 A criterion benchmark (`crates/ruvector-graph/benches/typed_graph_bench.rs`,
 P5 seed) measures the operator and validation. After optimizing the hot path —
@@ -92,10 +96,17 @@ Measured: `HashEmbedder` embed is 717 ns (256-dim); the full tri-modal hybrid
 (inline embed + HNSW + BM25 + RRF + traversal) over 10k docs is **1.63 ms** end
 to end.
 
+**Schema-driven codegen (P6, landed).** `crates/ruvector-graph/src/codegen.rs`
+emits typed client stubs from a `GraphSchema` — `generate_typescript`,
+`generate_python`, `generate_rust` — with deterministic (sorted) output suitable
+for check-in. Node labels become interfaces/`TypedDict`s/structs with correctly
+typed + optional/required properties, edges carry `from`/`to` label constraints,
+and a vector-type manifest exports dimensions + metric. This closes HelixDB's
+`schema → typed SDK` DX advantage.
+
 The remaining items (a single-statement hybrid surface in Cypher itself, P5
-head-to-head benchmarks vs Neo4j/pgvector/Qdrant/HelixDB, P6 schema-driven SDK
-codegen, P7 object-storage spike) remain authorized and will land under follow-up
-ADRs.
+head-to-head benchmarks vs Neo4j/pgvector/Qdrant/HelixDB, P7 object-storage spike)
+remain authorized and will land under follow-up ADRs.
 
 ## Context
 

--- a/docs/adr/ADR-252-helixdb-comparison-ruvector-improvements.md
+++ b/docs/adr/ADR-252-helixdb-comparison-ruvector-improvements.md
@@ -32,10 +32,30 @@ on branch `claude/helixdb-ruvector-comparison-qmsx42`:
   `search_then_traverse` operator (HelixQL's `SearchV<T>(q,k)::In/Out<E>`), with
   an optimized bounded-heap top-k selection (O(n log k)).
 
-Pure-Rust, no new dependencies, WASM-safe; **13 new unit tests pass, 148/148 lib
-tests green, clippy clean**. The remaining items (P3 in-query `embed()`, the
-single-statement hybrid query surface in Cypher, P5 benchmarks, P6 codegen, P7
-object-storage spike) remain authorized and will land under follow-up ADRs.
+Pure-Rust (rayon is already a crate dependency), WASM-safe schema layer;
+**14 new unit tests pass, 149/149 lib tests green, clippy clean**.
+
+A criterion benchmark (`crates/ruvector-graph/benches/typed_graph_bench.rs`,
+P5 seed) measures the operator and validation. After optimizing the hot path —
+**zero-copy borrow scoring** (`GraphDB::with_node`/`node_ids_by_label`, no node or
+embedding clones), a **single-pass fused cosine** (q·c and c·c in one read of the
+candidate), **query-norm hoisting**, a **bounded top-k heap** (O(n log k)), and a
+**rayon parallel scan** over `DashMap` for ≥4096 candidates — measured speedups
+over the first-cut implementation (128-dim, k=10):
+
+| candidates | before | after | speedup |
+|---|---|---|---|
+| 1,000 (serial) | 539 µs | 432 µs | 1.25× (fused cosine) |
+| 10,000 (parallel) | 7.20 ms | 3.08 ms | 2.34× |
+| 50,000 (parallel) | 74.3 ms | 28.5 ms | 2.61× |
+
+`validate_node` is 128 ns; `reciprocal_rank_fusion` over 2×1000 lists is 318 µs.
+The brute-force scan remains O(n) by design; the natural next optimization is
+HNSW push-down (use the existing `HybridIndex` to avoid the full-label scan),
+tracked as ADR-252 follow-up. The remaining items (P3 in-query `embed()`, the
+single-statement hybrid query surface in Cypher, P5 head-to-head benchmarks vs
+Neo4j/pgvector/Qdrant/HelixDB, P6 codegen, P7 object-storage spike) remain
+authorized and will land under follow-up ADRs.
 
 ## Context
 

--- a/docs/adr/ADR-252-helixdb-comparison-ruvector-improvements.md
+++ b/docs/adr/ADR-252-helixdb-comparison-ruvector-improvements.md
@@ -1,0 +1,280 @@
+---
+adr: 252
+title: "HelixDB vs RuVector — Comparative Analysis and Improvement Opportunities"
+status: proposed
+date: 2026-06-15
+authors: [ruv, claude-flow]
+related: [ADR-001, ADR-193, ADR-194, ADR-195, ADR-210]
+tags: [ruvector, graph, vector, helixdb, query-language, schema, hnsw, storage, benchmarks, rag, dx, competitive-analysis]
+---
+
+# ADR-252 — HelixDB vs RuVector: Comparative Analysis and Improvement Opportunities
+
+## Status
+
+**Proposed.** This is an analysis-and-direction ADR. It compares
+[HelixDB](https://github.com/HelixDB/helix-db) against RuVector's graph + vector
+stack (`crates/ruvector-core`, `crates/ruvector-graph`, `crates/ruvector-server`,
+and the `ruvector` npm package) and proposes a prioritized set of improvements
+that adopt HelixDB's strongest ideas where they fit RuVector's thesis. No code is
+changed by this ADR; it authorizes the work items in the Decision section, each
+of which will land under its own follow-up ADR.
+
+## Context
+
+HelixDB is an open-source, Rust-built OLTP **graph-vector database** (YC X25,
+~5.2k stars, Apache-2.0 on `main` as of mid-2026) positioned explicitly for RAG,
+knowledge graphs, and AI-agent memory. It overlaps RuVector's territory closely
+enough — Rust core, embedded-first, graph + vector in one engine, MCP-native,
+RAG-focused — that it is the most direct architectural peer to RuVector's graph
+stack. The user asked us to compare the two and extract concrete improvements.
+
+The comparison is worth doing precisely because the two projects made **different
+bets on the same problem**. RuVector bet on breadth and self-learning (an agentic
+OS: SONA self-optimization, GNN-learned ranking, 50+ attention mechanisms, local
+LLMs, WASM/`.rvf` single-file deploy, a PostgreSQL extension, DiskANN
+billion-scale). HelixDB bet on a narrow, sharp wedge: a **compiled, type-safe,
+schema-first query language** (HelixQL) over a tight LMDB core, with graph and
+vector treated as a single first-class data model. Where HelixDB is sharper, we
+should learn from it.
+
+### What HelixDB is (technical profile)
+
+- **Storage.** Open-source v1–v2 line is **LMDB**, accessed via **heed** (the
+  Meilisearch team's Rust LMDB wrapper), with *separate* LMDB databases for nodes,
+  edges, and vectors. Full ACID via LMDB MVCC, single-writer/multi-reader, very
+  low read latency (zero-copy reads off the mmap). The newer **v3 / HelixDB Cloud**
+  line replaces LMDB with an **LSM engine backed by object storage** (compute
+  decoupled from storage, tiered in-memory + SSD cache, serializable snapshot
+  isolation, single writer + auto-scaling readers) to escape LMDB's sequential-write
+  and capacity limits. The embedded fast engine and the scalable Cloud engine are
+  effectively *different products*.
+- **Query language — HelixQL.** Strongly-typed, **compile-time-checked**,
+  schema-first DSL that blends Gremlin/Cypher/Rust. Schema and queries live in
+  `.hx` files; the toolchain type-checks them against the schema and **compiles
+  them to Rust that becomes API endpoints** — no runtime parse overhead, type
+  errors caught before deploy. A second path (Rust/TS DSL → JSON AST → `POST
+  /v1/query`) allows dynamic queries with no build step.
+- **Graph + vector unification — the core thesis.** Vectors live in their own
+  LMDB database but are **attached to graph nodes by typed edges**, so a vector
+  hit can be traversed back into the graph. Search and traversal compose in one
+  typed query:
+
+  ```
+  QUERY search_similar_professors(query_vector: [F64], k: I64) =>
+      vecs <- SearchV<ResearchAreaEmbedding>(query_vector, k)
+      professors <- vecs::In<HasResearchAreaEmbedding>
+      RETURN professors
+  ```
+
+  Built-in `Embed(text)` performs **inline vectorization at insert/query time**.
+  Recent versions fuse **ANN + BM25 + multi-hop traversal in one query** with
+  **RRF** (Reciprocal Rank Fusion).
+- **Schema.** `N::` node, `E::` edge (typed `From`/`To`), `V::` vector type,
+  `INDEX` for secondary-indexed properties. Schema is mandatory and is the unit
+  of compile-time validation.
+- **DX.** `helix` CLI: `init` (scaffold), `start dev` (port 6969), `query`,
+  `chef` (MCP bootstrap), plus Cloud commands. SDKs for Rust, TypeScript, Go,
+  Python (`helix-py`); Rust/TS DSLs emit identical JSON ASTs. Built-in **MCP**
+  server for agent traversal.
+- **Benchmarks (substantiated).** `graph-vector-bench` (Nov 2025, v2.1.0 vs
+  Neo4j 2025.09 vs Postgres 16.10, AWS c6g.2xlarge, ~4M edges, P50/P95/P99):
+  **PointGet 16x/12x**, **OneHop 5.9x/13x**, **OneHopFilter 4.2x/20x** vs
+  Neo4j/Postgres respectively.
+- **Caveats.** **No published vector benchmarks** (vs Qdrant/pgvector/Pinecone) —
+  the "matches Pinecone/Qdrant" and "1000x faster than Neo4j" claims are marketing;
+  only the 4–20x graph numbers are defensible. HNSW tunables (M/ef/metric) are not
+  publicly documented. Young, fast-moving (v1→v3 in ~a year), small team, license
+  has shifted across sources (AGPL-3.0 historically → Apache-2.0 on current main).
+
+### What RuVector is today (relevant subset)
+
+- **Storage.** `redb` (a pure-Rust embedded B-tree, MVCC, single-writer) for both
+  vector metadata (`crates/ruvector-core/src/storage.rs`) and graph
+  (`crates/ruvector-graph/src/storage.rs`), with memory-mapped vectors, a shared
+  connection pool, and a memory-only backend for WASM. Plus the single-file `.rvf`
+  container format (25 segment types) and DiskANN/Vamana SSD-backed billion-scale ANN.
+- **Query.** A full **Cypher** engine in `crates/ruvector-graph/src/cypher`
+  (lexer → nom parser → AST → semantic analysis → optimizer → logical/physical
+  plan → executor) — but it is **interpreted at runtime**, schemaless, and not
+  type-checked ahead of time. Hybrid graph+vector queries exist
+  (`crates/ruvector-graph/src/hybrid`, `HybridQuery { graph_pattern: String,
+  vector_constraint, ... }`) but the graph pattern is a runtime string and the
+  vector binding is by property name, not a typed, compiler-verified relationship.
+- **Hybrid retrieval.** Sparse + dense with RRF fusion, Graph RAG with community
+  detection, ColBERT multi-vector, Matryoshka — strong, but exposed as separate
+  APIs rather than one declarative query operator.
+- **Indexes.** HNSW, DiskANN/Vamana, RaBitQ + RAIRS/IVF quantization
+  (ADR-193), tunable and well-documented.
+- **Surfaces.** REST (Axum, `crates/ruvector-server`), npm package with a bundled
+  ONNX embedder (ADR-194/195), WASM/browser, PostgreSQL extension
+  (`crates/ruvector-postgres`), MCP server (`crates/mcp-gate`).
+- **Differentiators HelixDB lacks.** Self-learning (SONA, GNN-learned ranking),
+  N-ary **hyperedges**, 50+ attention mechanisms, local LLM inference, `.rvf`
+  single-file/WASM deploy, PostgreSQL embedding, Cypher familiarity.
+
+### Head-to-head summary
+
+| Dimension | HelixDB | RuVector | Edge |
+|---|---|---|---|
+| Embedded storage engine | LMDB via heed (mmap, zero-copy reads) | redb (pure-Rust B-tree, MVCC) | ~Even; LMDB more battle-tested, redb pure-Rust/WASM-friendlier |
+| Decoupled/cloud storage | v3 LSM + object storage (compute/storage split) | DiskANN SSD + `.rvf`; no object-storage tier | **HelixDB** for cloud-scale elasticity |
+| Query language | HelixQL — typed, **compiled to Rust**, schema-first | Cypher — familiar, **runtime-interpreted**, schemaless | **HelixDB** for safety/perf; **RuVector** for familiarity |
+| Graph+vector model | Vectors as graph citizens via typed edges; one typed query | Hybrid via runtime string pattern + property binding | **HelixDB** for first-class integration |
+| Inline embedding | `Embed()` in-query | Bundled ONNX embedder, not in-query | **HelixDB** for ergonomics |
+| Hybrid (ANN+BM25+graph) | One query, RRF | Pieces exist (sparse+dense RRF, Graph RAG), separate APIs | **HelixDB** for unification; parity reachable |
+| Hyperedges (N-ary) | Pairwise typed edges only | Native hyperedges | **RuVector** |
+| Self-learning / adaptivity | None | SONA + GNN-learned ranking | **RuVector** |
+| Codegen / typed SDKs | schema → Rust endpoints + multi-lang SDKs | Hand-written REST/npm bindings | **HelixDB** for DX |
+| Benchmarks | Reproducible graph harness, P50/95/99 | Scattered; no public Neo4j/pgvector head-to-head | **HelixDB** for rigor |
+| Breadth (LLM, WASM, PG, attention) | Narrow | Very broad | **RuVector** |
+| Maturity / churn | Young, high churn, small team | Broad but also fast-moving | ~Even |
+
+## Decision
+
+Adopt the following improvements, in priority order. Each is a HelixDB-inspired
+sharpening of an area where RuVector is currently weaker, scoped so it **augments**
+RuVector's existing Cypher/hybrid stack rather than replacing it. None of these
+require abandoning RuVector's breadth or self-learning thesis.
+
+### P1 — Optional schema layer with compile-time / load-time validation
+
+RuVector's graph is schemaless and its Cypher is interpreted with no
+ahead-of-time type checking. HelixDB's biggest, most defensible win is catching
+type errors before they hit production.
+
+- Add an **optional** schema definition (`N::`/`E::`/`V::`-equivalent: node labels,
+  typed edges with `From`/`To` constraints, vector types with dimension + metric,
+  indexed properties) expressed in a `ruvector.schema` file and/or a builder API.
+- Validate registered Cypher/hybrid queries **against the schema at load time**
+  (and offline via a CLI lint command), surfacing label/property/edge-direction/
+  dimension-mismatch errors before execution — extending the existing
+  `cypher/semantic.rs` analyzer from best-effort to schema-aware.
+- Schema remains **opt-in**: schemaless mode (today's behavior) stays the default
+  so we keep Cypher's low-friction onboarding and don't break existing users.
+
+### P2 — First-class typed graph↔vector binding and a unified search-then-traverse operator
+
+Make "vectors are graph citizens" a first-class, type-checked relationship rather
+than a runtime string + property name.
+
+- Allow a vector index to be **bound to a node label/property by schema**, so the
+  planner knows the linkage statically.
+- Add a Cypher extension operator equivalent to HelixQL's `SearchV<...>(q, k)::In<...>`
+  — `CALL vector.search(label, $q, k) YIELD node ... MATCH (node)-[:REL]->(...)` —
+  that fuses ANN search and traversal in **one plan** through the existing
+  `executor` pipeline, with the vector step pushed down before the traversal join.
+- Keep hyperedges supported on the traversal side (a RuVector advantage HelixDB
+  lacks).
+
+### P3 — In-query inline embedding (`embed()` function)
+
+HelixDB's `Embed(text)` removes a round-trip and a class of dimension-mismatch
+bugs. RuVector already ships a bundled ONNX embedder (ADR-194/195) and a default
+MiniLM path (ADR-210) — we have the pieces.
+
+- Expose an `embed($text)` scalar usable in Cypher/hybrid `CREATE`/`SET`/`WHERE`
+  and in search predicates, routed through the existing embedder abstraction with
+  the model pinned by schema (so the stored vector's dimension/metric is validated
+  against the bound vector type).
+- Available in core, server, and the npm/WASM surface; honor the existing
+  hash-fallback guardrails from ADR-194 (never silently fall back).
+
+### P4 — Unified hybrid query: ANN + BM25 + graph traversal with RRF in one statement
+
+RuVector already has sparse+dense RRF and Graph RAG, but as separate APIs. Match
+HelixDB's single-query hybrid ergonomics.
+
+- Add a declarative hybrid operator that runs **BM25 keyword + ANN vector +
+  optional graph-traversal expansion** and fuses with **RRF**, exposed through one
+  query/endpoint, reusing the existing fusion and Graph-RAG implementations.
+
+### P5 — Reproducible graph+vector benchmark harness with published percentiles
+
+HelixDB's credibility comes substantially from `graph-vector-bench` (fixed
+hardware, fixed dataset, P50/P95/P99). RuVector's numbers are scattered. Notably,
+HelixDB has **no public vector benchmark** — a head-to-head harness is an
+opportunity for RuVector to lead exactly where HelixDB is silent.
+
+- Build a harness under `benchmarks/` (or extend `crates/ruvector-bench`) covering
+  PointGet / OneHop / OneHopFilter (HelixDB-comparable) **plus** vector recall@k
+  and hybrid retrieval, against Neo4j, pgvector, Qdrant, **and HelixDB itself**,
+  reporting P50/P95/P99 + throughput on pinned hardware with a reproducible script.
+
+### P6 — Schema-driven codegen for typed client SDKs (DX)
+
+HelixDB's `schema → Rust endpoints + typed SDKs` is a real DX advantage. RuVector's
+bindings are hand-written.
+
+- From the P1 schema, generate **typed TypeScript/Python/Rust client stubs** (and
+  optionally pre-registered query endpoints) so callers get compile-time-checked
+  node/edge/vector types. Reuse the schema as the single source of truth.
+
+### P7 — Investigate a decoupled object-storage tier (research spike, not a commitment)
+
+HelixDB v3's compute/storage split (LSM over object storage) targets elastic
+cloud scale — a gap relative to RuVector's embedded/`.rvf`/DiskANN model.
+
+- Run a **research spike** evaluating an object-storage-backed tier (e.g. an
+  LSM/segment layer over S3-compatible storage) layered beneath the existing
+  storage abstraction, **without** disturbing the embedded redb/`.rvf`/WASM path.
+  Decide go/no-go in a follow-up ADR; do not commit to a rewrite here.
+
+### Explicitly NOT adopted
+
+- **Replacing Cypher with a bespoke compiled DSL.** Cypher familiarity and the
+  existing engine are assets; we add schema/typing/codegen *around* it rather than
+  forcing a HelixQL-style lock-in language and AOT-to-Rust compilation. (We may
+  later add a typed query builder, but not a new surface language as a hard
+  dependency.)
+- **Swapping redb for LMDB/heed.** redb is pure-Rust and WASM/`.rvf`-friendly,
+  which matters for RuVector's browser/single-file thesis; LMDB's mmap model is
+  hostile to WASM. P7 covers the genuinely missing capability (decoupled cloud
+  storage) without giving up the embedded engine.
+- **Marketing-grade "1000x" claims.** We commit to publishing only reproducible,
+  percentile-backed numbers (P5).
+
+## Consequences
+
+**Positive**
+- Closes RuVector's three real gaps vs HelixDB: ahead-of-time type safety,
+  first-class typed graph↔vector binding, and single-query hybrid ergonomics.
+- P5 lets RuVector compete on exactly the axis (vector benchmarks) where HelixDB
+  has published nothing, and on the graph axis on equal, reproducible footing.
+- All changes are additive and opt-in; schemaless Cypher, `.rvf`, WASM, the PG
+  extension, hyperedges, and the self-learning stack are untouched.
+
+**Negative / risks**
+- A schema layer plus codegen is non-trivial surface area and must not regress the
+  zero-config onboarding that schemaless Cypher provides — hence opt-in.
+- In-query `embed()` couples query execution to embedder availability; the ADR-194
+  no-silent-fallback discipline must be enforced.
+- P7 (object storage) is the highest-effort, lowest-certainty item and is
+  deliberately gated as a spike.
+- Some "facts" about HelixDB are unverified (exact HNSW params, the precise license
+  of any version we'd benchmark against, embedded-vs-Cloud engine). Before P5
+  publishes head-to-head numbers, confirm: (1) HNSW M/ef/metric by reading source,
+  (2) the license of the pinned HelixDB version, (3) which HelixDB engine (LMDB
+  embedded vs v3 LSM/Cloud) is under test.
+
+**Neutral**
+- Each P-item ships under its own follow-up ADR with its own design and tests; this
+  ADR only authorizes the direction and priority.
+
+## References
+
+- HelixDB: [github.com/HelixDB/helix-db](https://github.com/HelixDB/helix-db) ·
+  [docs.helix-db.com](https://docs.helix-db.com/database/introduction) ·
+  [graph benchmarks v1](https://docs.helix-db.com/benchmarks/v1) ·
+  [graph-vector-bench](https://github.com/helixdb/graph-vector-bench) ·
+  [GraphRAG/HelixQL blog](https://www.helix-db.com/blog/building-a-graphrag-system-for-professor-recommendations-with-helixdb) ·
+  [DeepWiki](https://deepwiki.com/HelixDB/helix-db) ·
+  [YC launch](https://www.ycombinator.com/launches/Naz-helixdb-the-database-for-rag-ai)
+- RuVector internals: `crates/ruvector-core/src/storage.rs`,
+  `crates/ruvector-graph/src/cypher/`, `crates/ruvector-graph/src/hybrid/`,
+  `crates/ruvector-graph/src/executor/`, `crates/ruvector-server/`,
+  `crates/ruvector-postgres/`, `crates/ruvector-diskann/`, `crates/ruvector-rabitq/`
+- Related ADRs: ADR-001 (core architecture), ADR-193 (RAIRS/IVF), ADR-194/195
+  (ONNX embedder API + unification), ADR-210 (default-on MiniLM embeddings)
+</content>
+</invoke>

--- a/docs/adr/ADR-253-helixdb-comparison-ruvector-improvements.md
+++ b/docs/adr/ADR-253-helixdb-comparison-ruvector-improvements.md
@@ -1,5 +1,5 @@
 ---
-adr: 252
+adr: 253
 title: "HelixDB vs RuVector — Comparative Analysis and Improvement Opportunities"
 status: proposed
 date: 2026-06-15
@@ -8,7 +8,7 @@ related: [ADR-001, ADR-193, ADR-194, ADR-195, ADR-210]
 tags: [ruvector, graph, vector, helixdb, query-language, schema, hnsw, storage, benchmarks, rag, dx, competitive-analysis]
 ---
 
-# ADR-252 — HelixDB vs RuVector: Comparative Analysis and Improvement Opportunities
+# ADR-253 — HelixDB vs RuVector: Comparative Analysis and Improvement Opportunities
 
 ## Status
 


### PR DESCRIPTION
Compares HelixDB (LMDB/heed, compiled type-safe HelixQL, graph-vector
thesis, graph-vector-bench) against RuVector's redb/Cypher/hybrid stack
and proposes 7 prioritized, opt-in improvements: optional schema layer
with load-time validation, first-class typed graph-vector binding and a
unified search-then-traverse operator, in-query embed(), unified
ANN+BM25+graph RRF hybrid, a reproducible benchmark harness, schema-driven
typed SDK codegen, and an object-storage tier research spike.

https://claude.ai/code/session_01BrEtcS3KZykinsv9RoBGrF