### PR TITLE
fix(mcp-brain-server): native-tls-vendored for aarch64 cross-compile

### DIFF
--- a/crates/mcp-brain-server/Cargo.toml
+++ b/crates/mcp-brain-server/Cargo.toml
@@ -41,8 +41,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # HTTP client (for Firestore/GCS REST APIs + Common Crawl)
-# Using native-tls for compatibility with servers that don't send TLS close_notify
-reqwest = { version = "0.12", features = ["json", "native-tls"], default-features = false }
+# Using native-tls for compatibility with servers that don't send TLS close_notify.
+# native-tls-vendored builds OpenSSL from source so the crate cross-compiles to
+# aarch64 (Pi 5) without target OpenSSL dev headers — same TLS behavior, just
+# statically linked. Without this, openssl-sys fails the aarch64 cross-build.
+reqwest = { version = "0.12", features = ["json", "native-tls-vendored"], default-features = false }
 
 # Crypto
 sha2 = "0.10"


### PR DESCRIPTION
Fixes #572.

`mcp-brain-server` can't cross-compile to aarch64 — `reqwest`'s `native-tls` pulls `openssl-sys`, which needs target OpenSSL dev headers the cross toolchain doesn't have, so the build fails with *"Failed to find OpenSSL development headers"*.

**Change (one line):** `native-tls` → `native-tls-vendored` in `crates/mcp-brain-server/Cargo.toml`. This builds OpenSSL from source for the target — identical TLS behavior (still native-tls, so the close_notify compatibility the comment documents is preserved), just statically linked, no OpenSSL headers required.

**Context:** unblocks building this as `ruview-mcp-brain-mini` (the :9876 vector-memory store) for the Cognitum v0 appliance image (cognitum-one/v0-appliance), where it's a `vendor/ruvector` submodule.

Cargo.lock will pick up `openssl-src` on first build; left out here to keep the PR to the fix only.