### PR TITLE
fix(security): SECURITY.md disclosure policy (#320) + CORS allowlist for conceptmapping.org (#560)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take the security of RuVector and the π collective (`pi.ruv.io`) seriously and
+appreciate responsible disclosure.
+
+**Please do not open a public issue for security vulnerabilities.** Public issues
+disclose the flaw before a fix is available and put users at risk.
+
+Instead, report privately through either channel:
+
+1. **GitHub Private Vulnerability Reporting (preferred).**
+   Use the **"Report a vulnerability"** button under the repository's
+   [Security tab](https://github.com/ruvnet/ruvector/security/advisories/new).
+   This opens a private advisory visible only to you and the maintainers.
+
+2. **Email.** Send details to **ruv@ruv.net**. Encrypt with the maintainer's
+   public key on request. Use a subject line beginning with `[SECURITY]`.
+
+### What to include
+
+A useful report contains:
+
+- The affected component and version/commit (e.g. a crate under `crates/`, an
+  npm package under `npm/packages/`, or a `pi.ruv.io` endpoint).
+- A clear description of the impact (what an attacker can do).
+- A minimal, reproducible proof-of-concept, or precise steps to reproduce.
+- Any relevant logs, payloads, or configuration.
+
+The more concrete and reproducible the report, the faster we can verify and fix it.
+
+### Our commitment
+
+- We aim to **acknowledge** your report within **3 business days**.
+- We will provide an initial **assessment** within **10 business days**.
+- We will keep you informed of remediation progress and coordinate a disclosure
+  timeline with you. We are happy to credit reporters who wish to be named.
+
+## Scope
+
+In scope:
+
+- The RuVector Rust crates (`crates/`) and published npm packages
+  (`npm/packages/`).
+- The `pi.ruv.io` / mcp-brain-server API and its data-handling
+  (provenance, differential privacy, witness chains).
+- Cryptographic, memory-safety, authentication, authorization, injection,
+  data-poisoning, and denial-of-service issues.
+
+Out of scope:
+
+- Reports without a demonstrable security impact or a reproducible
+  proof-of-concept.
+- Findings in third-party dependencies — please report those upstream (we will
+  still help coordinate if RuVector is affected).
+- Social engineering, physical attacks, and volumetric DDoS.
+
+## Supported versions
+
+Security fixes are applied to the latest released version of each package and
+crate. We do not backport fixes to older majors unless a fix is trivial and the
+older line is still in wide use.
+
+Thank you for helping keep RuVector and its users safe.

--- a/crates/mcp-brain-server/src/routes.rs
+++ b/crates/mcp-brain-server/src/routes.rs
@@ -413,9 +413,12 @@ pub async fn create_router() -> (Router, AppState) {
         .route("/v1/consciousness/status", get(consciousness_status))
         .layer({
             // CORS origins: configurable via CORS_ORIGINS env var (comma-separated).
-            // Falls back to safe defaults if unset.
+            // Falls back to safe defaults if unset. Explicit per-origin allowlist
+            // (not `*`) — callers authenticate with Bearer tokens, so credentials
+            // are not cookie-based, but an allowlist keeps the surface tight.
+            // conceptmapping.org origins added per issue #560.
             let origins: Vec<axum::http::HeaderValue> = std::env::var("CORS_ORIGINS")
-                .unwrap_or_else(|_| "https://brain.ruv.io,https://pi.ruv.io,http://localhost:8080,http://127.0.0.1:8080".to_string())
+                .unwrap_or_else(|_| "https://brain.ruv.io,https://pi.ruv.io,https://app.conceptmapping.org,https://conceptmapping.org,http://localhost:8080,http://127.0.0.1:8080".to_string())
                 .split(',')
                 .filter_map(|s| s.trim().parse::<axum::http::HeaderValue>().ok())
                 .collect();


### PR DESCRIPTION
Two security-flavored triage fixes.

## #320 — responsible disclosure gap
The report is a disclosure-process request (no PoC was shared). Rather than chase an unverified claim, this adds **`SECURITY.md`** so GitHub shows a "Report a vulnerability" button and reporters have a private channel (PVR + ruv@ruv.net), with scope and response SLAs. **Action still required by a maintainer:** enable Private Vulnerability Reporting in repo Settings → Code security.

## #560 — missing `Access-Control-Allow-Origin`
`mcp-brain-server` uses a per-origin CORS allowlist; the requester's browser origins weren't on it (hence `vary: origin` but no `Access-Control-Allow-Origin`). Added `https://app.conceptmapping.org` and `https://conceptmapping.org` to the default allowlist. Kept an explicit allowlist (not `*`) since callers use Bearer tokens, not cookies. `cargo check -p mcp-brain-server` clean.

> Note: production also honors `CORS_ORIGINS` env — the deployment's value should be updated to match (or it overrides this default).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)