### PR TITLE
chore(release): publish ruvector-mragent 0.1.0 to npm

### DIFF
--- a/examples/mragent/LICENSE
+++ b/examples/mragent/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ruvnet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/mragent/package.json
+++ b/examples/mragent/package.json
@@ -1,9 +1,28 @@
 {
   "name": "ruvector-mragent",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "type": "module",
   "description": "MRAgent — Cue-Tag-Content graph memory over RuVector, with a Meta-Harness Darwin loop that evolves the reconstruction harness (freeze the model, evolve the harness).",
+  "homepage": "https://github.com/ruvnet/ruvector/tree/main/examples/mragent#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ruvnet/ruvector.git",
+    "directory": "examples/mragent"
+  },
+  "files": [
+    "agent/",
+    "harness/",
+    "data/",
+    "tools/",
+    "test/",
+    "*.mjs",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "probe": "node probeDarwin.mjs",
     "optimize": "node optimize.mjs",


### PR DESCRIPTION
Makes `examples/mragent` npm-publishable (private:false, public access, files whitelist, repository metadata, MIT LICENSE) and records the published 0.1.0. The package ships the Cue-Tag-Content graph memory + Darwin harness optimizer including the GPU LLM write-layer.

Published: https://www.npmjs.com/package/ruvector-mragent

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)