### PR TITLE
fix(graph-node): batchInsert nodes missing from label index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5202,7 +5202,7 @@ dependencies = [
  "hex",
  "regex-lite",
  "reqwest 0.12.28",
- "ruvector-sona 0.2.0",
+ "ruvector-sona 0.2.1",
  "serde",
  "serde_json",
  "sha3",
@@ -5237,7 +5237,7 @@ dependencies = [
  "ruvector-mincut 2.2.3",
  "ruvector-nervous-system",
  "ruvector-solver",
- "ruvector-sona 0.2.0",
+ "ruvector-sona 0.2.1",
  "ruvector-sparsifier",
  "ruvllm 2.2.3",
  "rvf-crypto",
@@ -7247,7 +7247,7 @@ dependencies = [
  "ruvector-mincut 2.2.3",
  "ruvector-nervous-system",
  "ruvector-raft",
- "ruvector-sona 0.2.0",
+ "ruvector-sona 0.2.1",
  "ruvllm 2.3.0",
  "serde",
  "serde_json",
@@ -10444,6 +10444,20 @@ dependencies = [
 [[package]]
 name = "ruvector-sona"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a9465310393f43fc9ba2409cbf819c543ef16e0eb1791090351bfc4833c158"
+dependencies = [
+ "crossbeam",
+ "getrandom 0.2.17",
+ "parking_lot 0.12.5",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ruvector-sona"
+version = "0.2.1"
 dependencies = [
  "console_error_panic_hook",
  "criterion 0.5.1",
@@ -10460,20 +10474,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "ruvector-sona"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a9465310393f43fc9ba2409cbf819c543ef16e0eb1791090351bfc4833c158"
-dependencies = [
- "crossbeam",
- "getrandom 0.2.17",
- "parking_lot 0.12.5",
- "rand 0.8.6",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -10576,7 +10576,7 @@ version = "2.2.3"
 
 [[package]]
 name = "ruvector-timesfm"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "anyhow",
  "candle-core 0.9.2",
@@ -10926,7 +10926,7 @@ dependencies = [
  "ruvector-core 2.2.3",
  "ruvector-gnn",
  "ruvector-graph",
- "ruvector-sona 0.2.0",
+ "ruvector-sona 0.2.1",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -10962,7 +10962,7 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "ruvector-core 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ruvector-sona 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruvector-sona 0.2.0",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -11245,7 +11245,7 @@ dependencies = [
  "dashmap 6.2.1",
  "mockall",
  "parking_lot 0.12.5",
- "ruvector-sona 0.2.0",
+ "ruvector-sona 0.2.1",
  "rvagent-backends",
  "rvagent-core",
  "serde",
@@ -12760,7 +12760,7 @@ dependencies = [
 
 [[package]]
 name = "timesfm"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "anyhow",
  "candle-core 0.9.2",

--- a/crates/ruvector-graph-node/src/lib.rs
+++ b/crates/ruvector-graph-node/src/lib.rs
@@ -773,7 +773,8 @@ mod tests {
                 vec![0.0, 0.0, 0.0, 1.0],
                 1.0,
             );
-            hg.add_hyperedge(edge).expect("add_hyperedge should succeed");
+            hg.add_hyperedge(edge)
+                .expect("add_hyperedge should succeed");
         }
 
         // 1. Label scan (the bug): every batch-inserted node must appear.
@@ -786,9 +787,18 @@ mod tests {
 
         // 2. kHop adjacency: p0's 2-hop ball includes itself, p1 and p2.
         let neighbors = hg.k_hop_neighbors("p0".to_string(), 2);
-        assert!(neighbors.contains("p0"), "kHop ball includes the start node");
-        assert!(neighbors.contains("p1"), "kHop ball includes 1-hop neighbor");
-        assert!(neighbors.contains("p2"), "kHop ball includes 2-hop neighbor");
+        assert!(
+            neighbors.contains("p0"),
+            "kHop ball includes the start node"
+        );
+        assert!(
+            neighbors.contains("p1"),
+            "kHop ball includes 1-hop neighbor"
+        );
+        assert!(
+            neighbors.contains("p2"),
+            "kHop ball includes 2-hop neighbor"
+        );
 
         // 3. stats entity count stays consistent with the above.
         let stats = hg.stats();

--- a/crates/ruvector-graph-node/src/lib.rs
+++ b/crates/ruvector-graph-node/src/lib.rs
@@ -17,6 +17,7 @@ use ruvector_graph::cypher::{parse_cypher, Statement};
 use ruvector_graph::node::NodeBuilder;
 use ruvector_graph::storage::GraphStorage;
 use ruvector_graph::GraphDB;
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 mod streaming;
@@ -44,6 +45,56 @@ pub struct GraphDatabase {
     storage: Option<Arc<RwLock<GraphStorage>>>,
     /// Path to storage file (if persisted)
     storage_path: Option<String>,
+}
+
+/// Register a node into BOTH backing indexes so they stay consistent:
+///   1. the hypergraph adjacency / vector index (used by `kHopNeighbors`,
+///      `stats`, and `searchHyperedges`), and
+///   2. the property graph + label index (used by the Cypher
+///      `MATCH (n:Label) RETURN n` label scan).
+///
+/// This is the single source of truth shared by `create_node` and
+/// `batch_insert`. Previously `batch_insert` only populated the hypergraph,
+/// so bulk-loaded nodes were counted in `stats()` and traversable by
+/// `kHopNeighbors` but invisible to the label-scoped Cypher scan.
+fn register_node(
+    hg: &mut CoreHypergraphIndex,
+    gdb: &mut GraphDB,
+    storage: Option<&Arc<RwLock<GraphStorage>>>,
+    id: String,
+    embedding: Vec<f32>,
+    labels: Option<Vec<String>>,
+    properties: Option<HashMap<String, String>>,
+) -> Result<()> {
+    // 1. Adjacency / vector index (kHop, stats, hyperedge search).
+    hg.add_entity(id.clone(), embedding);
+
+    // 2. Property graph + label index (Cypher label scan).
+    let mut builder = NodeBuilder::new().id(&id);
+    if let Some(node_labels) = labels {
+        for label in node_labels {
+            builder = builder.label(&label);
+        }
+    }
+    if let Some(props) = properties {
+        for (key, value) in props {
+            builder = builder.property(&key, value);
+        }
+    }
+    let graph_node = builder.build();
+
+    // Persist to storage if enabled (mirrors create_node behaviour).
+    if let Some(storage_arc) = storage {
+        let storage_guard = storage_arc.write().expect("Storage RwLock poisoned");
+        storage_guard
+            .insert_node(&graph_node)
+            .map_err(|e| Error::from_reason(format!("Failed to persist node: {}", e)))?;
+    }
+
+    gdb.create_node(graph_node)
+        .map_err(|e| Error::from_reason(format!("Failed to create node: {}", e)))?;
+
+    Ok(())
 }
 
 #[napi]
@@ -145,40 +196,18 @@ impl GraphDatabase {
         let labels = node.labels.clone();
 
         tokio::task::spawn_blocking(move || {
-            // Add to hypergraph index
             let mut hg = hypergraph.write().expect("RwLock poisoned");
-            hg.add_entity(id.clone(), embedding);
-
-            // Add to property graph
             let mut gdb = graph_db.write().expect("RwLock poisoned");
-            let mut builder = NodeBuilder::new().id(&id);
 
-            // Add labels if provided
-            if let Some(node_labels) = labels {
-                for label in node_labels {
-                    builder = builder.label(&label);
-                }
-            }
-
-            // Add properties if provided
-            if let Some(props) = properties {
-                for (key, value) in props {
-                    builder = builder.property(&key, value);
-                }
-            }
-
-            let graph_node = builder.build();
-
-            // Persist to storage if enabled
-            if let Some(ref storage_arc) = storage {
-                let storage_guard = storage_arc.write().expect("Storage RwLock poisoned");
-                storage_guard
-                    .insert_node(&graph_node)
-                    .map_err(|e| Error::from_reason(format!("Failed to persist node: {}", e)))?;
-            }
-
-            gdb.create_node(graph_node)
-                .map_err(|e| Error::from_reason(format!("Failed to create node: {}", e)))?;
+            register_node(
+                &mut hg,
+                &mut gdb,
+                storage.as_ref(),
+                id.clone(),
+                embedding,
+                labels,
+                properties,
+            )?;
 
             Ok::<String, Error>(id)
         })
@@ -482,18 +511,32 @@ impl GraphDatabase {
     #[napi]
     pub async fn batch_insert(&self, batch: JsBatchInsert) -> Result<JsBatchResult> {
         let hypergraph = self.hypergraph.clone();
+        let graph_db = self.graph_db.clone();
+        let storage = self.storage.clone();
         let nodes = batch.nodes;
         let edges = batch.edges;
 
         tokio::task::spawn_blocking(move || {
             let mut hg = hypergraph.write().expect("RwLock poisoned");
+            let mut gdb = graph_db.write().expect("RwLock poisoned");
             let mut node_ids = Vec::new();
             let mut edge_ids = Vec::new();
 
-            // Insert nodes
+            // Insert nodes into BOTH the hypergraph index and the property
+            // graph + label index (so bulk-loaded nodes are also visible to
+            // the Cypher `MATCH (n:Label)` scan, not just kHop/stats).
             for node in nodes {
-                hg.add_entity(node.id.clone(), node.embedding.to_vec());
-                node_ids.push(node.id);
+                let id = node.id.clone();
+                register_node(
+                    &mut hg,
+                    &mut gdb,
+                    storage.as_ref(),
+                    id.clone(),
+                    node.embedding.to_vec(),
+                    node.labels,
+                    node.properties,
+                )?;
+                node_ids.push(id);
             }
 
             // Insert edges
@@ -684,4 +727,74 @@ pub fn version() -> String {
 #[napi]
 pub fn hello() -> String {
     "Hello from RuVector Graph Node.js bindings!".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for the `batchInsert` ↔ label-index consistency bug.
+    ///
+    /// Both `create_node` and `batch_insert` funnel through `register_node`.
+    /// This test drives `register_node` directly (the same code path the batch
+    /// insert uses) and asserts that the resulting node is consistently visible
+    /// through all three read surfaces:
+    ///   1. `get_nodes_by_label` — the Cypher `MATCH (n:Label)` label scan,
+    ///   2. `k_hop_neighbors`    — undirected adjacency traversal,
+    ///   3. `stats`              — entity counts.
+    ///
+    /// Before the fix the batch path skipped (1), so this would report 0 nodes
+    /// for the label scan while (2) and (3) saw the nodes.
+    #[test]
+    fn batch_inserted_nodes_are_visible_to_label_scan_khop_and_stats() {
+        let mut hg = CoreHypergraphIndex::new(DistanceMetric::Cosine);
+        let mut gdb = GraphDB::new();
+
+        let n = 5usize;
+        // Insert N labeled nodes via the shared registration path.
+        for i in 0..n {
+            register_node(
+                &mut hg,
+                &mut gdb,
+                None,
+                format!("p{i}"),
+                vec![i as f32, i as f32, i as f32, i as f32],
+                Some(vec!["Person".to_string()]),
+                Some(HashMap::from([("name".to_string(), format!("name{i}"))])),
+            )
+            .expect("register_node should succeed");
+        }
+
+        // Chain edges p0->p1->...->p{n-1} so kHop has something to traverse.
+        for i in 0..(n - 1) {
+            let edge = CoreHyperedge::new(
+                vec![format!("p{i}"), format!("p{}", i + 1)],
+                "knows".to_string(),
+                vec![0.0, 0.0, 0.0, 1.0],
+                1.0,
+            );
+            hg.add_hyperedge(edge).expect("add_hyperedge should succeed");
+        }
+
+        // 1. Label scan (the bug): every batch-inserted node must appear.
+        let by_label = gdb.get_nodes_by_label("Person");
+        assert_eq!(
+            by_label.len(),
+            n,
+            "label-scoped MATCH must see all {n} batch-inserted nodes (regression: was 0)"
+        );
+
+        // 2. kHop adjacency: p0's 2-hop ball includes itself, p1 and p2.
+        let neighbors = hg.k_hop_neighbors("p0".to_string(), 2);
+        assert!(neighbors.contains("p0"), "kHop ball includes the start node");
+        assert!(neighbors.contains("p1"), "kHop ball includes 1-hop neighbor");
+        assert!(neighbors.contains("p2"), "kHop ball includes 2-hop neighbor");
+
+        // 3. stats entity count stays consistent with the above.
+        let stats = hg.stats();
+        assert_eq!(
+            stats.total_entities, n,
+            "stats() entity count must match the inserted node count"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`@ruvector/graph-node`'s `batchInsert` produced **query-invisible nodes**: nodes inserted via the fast bulk path were counted in `stats()` and were traversable by `kHopNeighbors`, but were **not** added to the property-graph label index that the only working Cypher pattern (`MATCH (n:Label) RETURN n`) reads. A user who bulk-loads and then queries by label gets silent empty results — a correctness bug in the fastest ingest path.

## Reproduction (before fix)

```js
const { GraphDatabase } = require('@ruvector/graph-node');
const db = new GraphDatabase({ distanceMetric: 'Cosine', dimensions: 4 });
const nodes = [], edges = [];
for (let i = 0; i < 50; i++)
  nodes.push({ id: `p${i}`, embedding: new Float32Array([i,i,i,i]), labels: ['Person'], properties: { name: `n${i}` } });
for (let i = 0; i < 49; i++)
  edges.push({ from: `p${i}`, to: `p${i+1}`, description: 'knows', embedding: new Float32Array([0,0,0,1]) });

await db.batchInsert({ nodes, edges });
console.log((await db.stats()).totalNodes);                 // 50  ✅
console.log((await db.kHopNeighbors('p0', 2)).length);      // 3   ✅
console.log((await db.query('MATCH (n:Person) RETURN n')).nodes.length); // 0  ❌ (expected 50)
```

`stats()` and `kHopNeighbors` see the nodes; the label scan returns 0.

## Root cause

In `crates/ruvector-graph-node/src/lib.rs`:

- `create_node` inserted into **both** backing indexes: the hypergraph adjacency/vector index (`hg.add_entity`, used by `kHopNeighbors`/`stats`/`searchHyperedges`) **and** the property graph + label index (`gdb.create_node`, read by the Cypher label scan).
- `batch_insert` only called `hg.add_entity` per node — it never called `gdb.create_node`, and it silently ignored each node's `labels`/`properties`.

So the two indexes diverged for bulk-loaded data.

## Fix

Extract the shared registration logic into a single `register_node` helper (single source of truth) that populates the hypergraph index, the property graph + label index, and optional persistent storage. Both `create_node` and `batch_insert` now call it, so all read surfaces stay consistent. `batch_insert` now also honors per-node `labels`/`properties` (previously dropped).

## Test

Added a Rust regression test (`cargo test -p ruvector-graph-node`) asserting that nodes registered via the shared path are consistently visible through all three read surfaces — label-scoped scan (`get_nodes_by_label`), kHop adjacency (`k_hop_neighbors`), and `stats()` entity count.

```
running 3 tests
test transactions::tests::test_transaction_lifecycle ... ok
test transactions::tests::test_transaction_rollback ... ok
test tests::batch_inserted_nodes_are_visible_to_label_scan_khop_and_stats ... ok
test result: ok. 3 passed; 0 failed
```

Verified end-to-end after rebuilding the NAPI binding (`napi build --platform --release`): the repro above now returns `MATCH (n:Person) = 50`, plus a mixed `batchInsert` + `createNode` case returns the correct per-label counts, with `stats`/`kHop` unchanged.

## Out of scope / known issues (filed, not fixed here)

Surfaced by the same benchmarking but deliberately **not** addressed in this focused fix:

- **Inline property filter silently ignored** — `MATCH (n:Person {name:"Alice"})` returns *all* `Person` nodes instead of filtering. The query executor reads only the label, not the inline property map.
- **Relationship / path / `WHERE` / aggregation patterns return empty** — e.g. `MATCH (a)-[r]->(b) RETURN a,r,b`, `MATCH (a)-[*1..2]->(b)`, `MATCH (n) WHERE n.name="x"`, `RETURN count(n)`. The supported Cypher subset is effectively just `MATCH (n:Label) RETURN n`. This is a larger feature gap, not a one-line correctness fix, and is left as a separate effort.
- **Bare `MATCH (n) RETURN n`** (no label) returns 0 — the executor only scans by label.

## Provenance

Discovered via [agent-harness-generator](https://github.com/) ruvector benchmarking — see `GRAPH-ANALYTICS-PROOF.md §5` (the `batchInsert ↔ Cypher` consistency bug, proven with a known-answer table). $0 to find and fix (local Rust build + test, no LLM/paid API).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)