### PR TITLE
fix(ci): grant contents:write to build-native reusable workflow call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,8 @@ jobs:
     needs: validate
     if: always() && (needs.validate.result == 'success' || needs.validate.result == 'skipped')
     uses: ./.github/workflows/build-native.yml
+    permissions:
+      contents: write
     with:
       skip_commit: true
 


### PR DESCRIPTION
## Summary
- `release.yml` calls `build-native.yml` as a reusable workflow (`uses:`) without a `permissions:` block.
- `build-native.yml`'s `commit-binaries` job statically declares `permissions: contents: write`.
- GitHub validates every declared job's permissions in a called workflow at parse time, regardless of runtime `if:` conditions, and rejects the whole run before scheduling any jobs if the caller doesn't grant it.
- This has made every Release Pipeline run fail with `startup_failure` (0 jobs, 0 check-runs) since at least 2026-04-20, confirmed via the run page's own annotation:
  > The nested job 'commit-binaries' is requesting 'contents: write', but is only allowed 'contents: read'.
- Fix: add `permissions: contents: write` to the `build-native` job in `release.yml`.

## Test plan
- [x] YAML re-parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`)
- [x] Confirmed `publish-all.yml` (which does not call `build-native.yml` reusably) succeeds on the same tag pushes where `release.yml` fails — isolates the cause to this reusable-workflow call
- [ ] Maintainer: trigger a `workflow_dispatch` (dry_run) on `release.yml` post-merge to confirm it clears `startup_failure`