### PR TITLE
fix(ruvllm): saveCheckpoint(path) actually persists to disk — 2.5.7

### DIFF
--- a/npm/packages/ruvllm/package.json
+++ b/npm/packages/ruvllm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ruvector/ruvllm",
-  "version": "2.5.6",
-  "description": "Self-learning LLM runtime — TurboQuant KV-cache (6-8x compression), SONA adaptive learning, FlashAttention, speculative decoding, GGUF inference",
+  "version": "2.5.7",
+  "description": "Self-learning LLM runtime \u2014 TurboQuant KV-cache (6-8x compression), SONA adaptive learning, FlashAttention, speculative decoding, GGUF inference",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/cjs/index.d.ts",

--- a/npm/packages/ruvllm/src/training.ts
+++ b/npm/packages/ruvllm/src/training.ts
@@ -23,6 +23,8 @@
  * ```
  */
 
+import { writeFileSync, readFileSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
 import { Embedding, TrainingConfig, TrainingResult } from './types';
 import { LoraAdapter } from './lora';
 import { EwcManager } from './sona';
@@ -93,6 +95,27 @@ export interface Checkpoint {
   /** Timestamp */
   timestamp: number;
 }
+
+/**
+ * Result of a saveCheckpoint() call.
+ */
+export interface CheckpointSaveResult {
+  /** Index of the checkpoint in the in-memory checkpoint list */
+  index: number;
+  /** Epoch the checkpoint captured */
+  epoch: number;
+  /** Step the checkpoint captured */
+  step: number;
+  /** Training loss at checkpoint time */
+  loss: number;
+  /** Absolute or as-given file path, when persisted to disk */
+  path?: string;
+  /** Serialized size in bytes, when persisted to disk */
+  bytes?: number;
+}
+
+/** On-disk checkpoint envelope (versioned for forward compatibility). */
+const CHECKPOINT_FORMAT_VERSION = 1;
 
 /**
  * Learning Rate Scheduler
@@ -448,23 +471,71 @@ export class TrainingPipeline {
   }
 
   /**
-   * Save checkpoint
+   * Save a checkpoint.
+   *
+   * Always records the checkpoint in the in-memory list (the behavior the
+   * training loop relies on). When `path` is given, additionally persists
+   * the checkpoint to disk as versioned JSON — before v2.5.7 this method
+   * was private, ignored any argument, and never wrote a file, so callers
+   * passing a path got `undefined` back and zero bytes on disk.
+   *
+   * @param path Optional file path; parent directories are created.
+   * @returns Where the checkpoint went — in-memory index, and file
+   *          path + byte size when persisted.
    */
-  private saveCheckpoint(): void {
-    this.checkpoints.push({
+  saveCheckpoint(path?: string): CheckpointSaveResult {
+    const checkpoint: Checkpoint = {
       epoch: this.currentEpoch,
       step: this.currentStep,
       loss: this.metrics.avgLoss(100),
       weights: this.adapter.toJSON(),
       timestamp: Date.now(),
-    });
+    };
+    this.checkpoints.push(checkpoint);
+
+    const result: CheckpointSaveResult = {
+      index: this.checkpoints.length - 1,
+      epoch: checkpoint.epoch,
+      step: checkpoint.step,
+      loss: checkpoint.loss,
+    };
+
+    if (path) {
+      const envelope = {
+        format: 'ruvllm-checkpoint',
+        version: CHECKPOINT_FORMAT_VERSION,
+        ...checkpoint,
+      };
+      const serialized = JSON.stringify(envelope);
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, serialized, 'utf-8');
+      result.path = path;
+      result.bytes = Buffer.byteLength(serialized, 'utf-8');
+    }
+
+    return result;
   }
 
   /**
-   * Load checkpoint
+   * Load a checkpoint — by in-memory index, or from a file previously
+   * written by `saveCheckpoint(path)`.
    */
-  loadCheckpoint(index: number): boolean {
-    const checkpoint = this.checkpoints[index];
+  loadCheckpoint(indexOrPath: number | string): boolean {
+    let checkpoint: Checkpoint | undefined;
+
+    if (typeof indexOrPath === 'number') {
+      checkpoint = this.checkpoints[indexOrPath];
+    } else {
+      try {
+        const parsed = JSON.parse(readFileSync(indexOrPath, 'utf-8'));
+        if (parsed?.format !== 'ruvllm-checkpoint' || typeof parsed.weights !== 'string') {
+          return false;
+        }
+        checkpoint = parsed as Checkpoint;
+      } catch {
+        return false;
+      }
+    }
     if (!checkpoint) return false;
 
     this.adapter = LoraAdapter.fromJSON(checkpoint.weights);

--- a/npm/packages/ruvllm/test/checkpoint.test.js
+++ b/npm/packages/ruvllm/test/checkpoint.test.js
@@ -1,0 +1,99 @@
+/**
+ * Checkpoint persistence — regression for ruvnet/ruflo#2549 (downstream
+ * report): saveCheckpoint() was private, ignored its argument, returned
+ * undefined, and wrote zero bytes. It must now persist to disk when given
+ * a path and round-trip through loadCheckpoint(path).
+ */
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { existsSync, readFileSync, rmSync, mkdtempSync } = require('node:fs');
+const { join } = require('node:path');
+const { tmpdir } = require('node:os');
+
+const { TrainingPipeline } = require('../dist/cjs/index.js');
+
+function vec(seed) {
+  return Array.from({ length: 8 }, (_, i) => Math.sin(seed + i));
+}
+
+function trainedPipeline() {
+  const tp = new TrainingPipeline({
+    learningRate: 0.01,
+    batchSize: 2,
+    epochs: 1,
+    inputDim: 8,
+    outputDim: 8,
+  });
+  tp.addBatch([vec(1), vec(2)], [vec(1.1), vec(2.1)], [0.9, 0.8]);
+  tp.train();
+  return tp;
+}
+
+test('saveCheckpoint() with no path records in-memory and returns metadata', () => {
+  const tp = trainedPipeline();
+  const r = tp.saveCheckpoint();
+  assert.ok(r && typeof r === 'object', 'returns a result object, not undefined');
+  assert.strictEqual(typeof r.index, 'number');
+  assert.strictEqual(typeof r.loss, 'number');
+  assert.strictEqual(r.path, undefined);
+});
+
+test('saveCheckpoint(path) writes a non-empty file and reports bytes', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'ruvllm-ckpt-'));
+  const path = join(dir, 'nested', 'ckpt.json');
+  try {
+    const tp = trainedPipeline();
+    const r = tp.saveCheckpoint(path);
+    assert.strictEqual(r.path, path);
+    assert.ok(r.bytes > 0, `bytes must be > 0, got ${r.bytes}`);
+    assert.ok(existsSync(path), 'file must exist on disk');
+    const onDisk = JSON.parse(readFileSync(path, 'utf-8'));
+    assert.strictEqual(onDisk.format, 'ruvllm-checkpoint');
+    assert.strictEqual(typeof onDisk.weights, 'string');
+    assert.strictEqual(readFileSync(path, 'utf-8').length, r.bytes);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadCheckpoint(path) round-trips weights from disk', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'ruvllm-ckpt-'));
+  const path = join(dir, 'ckpt.json');
+  try {
+    const tp = trainedPipeline();
+    const before = tp.getAdapter().toJSON();
+    tp.saveCheckpoint(path);
+
+    // Fresh pipeline, load from disk.
+    const tp2 = new TrainingPipeline({
+      learningRate: 0.01,
+      batchSize: 2,
+      epochs: 1,
+      inputDim: 8,
+      outputDim: 8,
+    });
+    assert.strictEqual(tp2.loadCheckpoint(path), true);
+    assert.strictEqual(tp2.getAdapter().toJSON(), before, 'weights round-trip');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadCheckpoint by in-memory index still works (back-compat)', () => {
+  const tp = trainedPipeline();
+  const r = tp.saveCheckpoint();
+  assert.strictEqual(tp.loadCheckpoint(r.index), true);
+});
+
+test('loadCheckpoint rejects missing files and foreign JSON', () => {
+  const tp = trainedPipeline();
+  assert.strictEqual(tp.loadCheckpoint('/nonexistent/nope.json'), false);
+  const dir = mkdtempSync(join(tmpdir(), 'ruvllm-ckpt-'));
+  const path = join(dir, 'foreign.json');
+  try {
+    require('node:fs').writeFileSync(path, JSON.stringify({ hello: 'world' }));
+    assert.strictEqual(tp.loadCheckpoint(path), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes the checkpoint-persistence defect reported downstream in ruvnet/ruflo#2549: `saveCheckpoint()` was private, ignored its argument, returned `undefined`, and wrote zero bytes — the public API surface implied file persistence that did not exist.

## Changes
- `saveCheckpoint(path?)` public: in-memory recording unchanged; with a path, writes a versioned JSON envelope (`format: ruvllm-checkpoint`, parent dirs created) and returns `{index, epoch, step, loss, path, bytes}`
- `loadCheckpoint(indexOrPath)`: in-memory index (back-compat) or file path; rejects foreign/malformed JSON
- 5 new tests (`test/checkpoint.test.js`, node --test convention)

## Proof (the exact downstream repro)
```
saveCheckpoint → {"index":1,"epoch":0,"step":1,"loss":0.000124,"path":"./ckpt-proof.json","bytes":49713}
loadCheckpoint(path) → true      # fresh pipeline, weights round-trip verified
```

Suite: 97/101 — the 4 failures are pre-existing native-binding tests (no `build:native` in this tree), identical at baseline.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

https://claude.ai/code/session_01S7GYqnVUVxBfZ5W8znqry3