### PR TITLE
style(ruvllm): rustfmt lattice_backend.rs

### DIFF
--- a/crates/ruvllm/src/backends/lattice_backend.rs
+++ b/crates/ruvllm/src/backends/lattice_backend.rs
@@ -707,10 +707,7 @@ mod tests {
 
     #[test]
     fn safetensors_precision_label_follows_torch_dtype() {
-        let dir = std::env::temp_dir().join(format!(
-            "lattice-dtype-test-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("lattice-dtype-test-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let cfg = dir.join("config.json");
         for (dtype, expected) in [


### PR DESCRIPTION
Formatting-only fix: `cargo fmt` collapses a multi-line `format!()` in the `safetensors_precision_label_follows_torch_dtype` test onto a single line.

This is the sole diff `cargo fmt --check` reports against `main`, so it greens the **Rustfmt** and **Clippy + fmt** CI jobs (currently red on main, flagging `crates/ruvllm/src/backends/lattice_backend.rs:707`). No logic change.