### PR TITLE
fix(embeddings): reconcile bge-small convention between Lattice providers

### DIFF
--- a/crates/ruvector-core/src/embeddings.rs
+++ b/crates/ruvector-core/src/embeddings.rs
@@ -1137,6 +1137,86 @@ pub mod lattice_native {
                 .expect("embed_query must not panic or error from inside a Tokio runtime");
             assert_eq!(query.len(), provider.dimensions());
         }
+
+        /// Cross-provider contract test (maintainer follow-up on #663).
+        ///
+        /// This provider never builds the prefixed query string itself: `embed_query`
+        /// forwards raw `text` to `EmbeddingService::embed_query`, which prepends
+        /// `model.query_instruction()` internally (see `send_request` above and
+        /// `lattice_embed::EmbeddingService::embed_query`'s default impl). So the
+        /// prefix this provider *effectively* applies for a given model **is**
+        /// `LatticeEmbeddingModel::query_instruction()` / `document_instruction()` --
+        /// both documented `**Stable**` in lattice-embed's own API-stability
+        /// convention (`crates/embed/src/model.rs` in ohdearquant/lattice).
+        ///
+        /// `ruvector-extensions`' WASM sibling provider has no such delegation
+        /// (`@khive-ai/lattice-embed-wasm`'s `embed()` binding takes raw text only,
+        /// no prefix concept), so it hardcodes the same prefixes as a TS literal
+        /// map (`LATTICE_WASM_QUERY_INSTRUCTIONS` in
+        /// `npm/packages/ruvector-extensions/src/embeddings.ts`) and asserts against
+        /// the identical fixture in its own contract test
+        /// (`npm/packages/ruvector-extensions/tests/lattice-prefix-contract.test.ts`).
+        /// Both tests read `fixtures/lattice-embed/query-prefixes.json` at the repo
+        /// root, so a future lattice-embed bump that changes either model's
+        /// convention fails this test on the Rust side (and its TS sibling
+        /// independently), instead of the two providers silently re-diverging the
+        /// way they did before #663.
+        #[test]
+        fn cross_provider_query_prefix_contract() {
+            let fixture: serde_json::Value = serde_json::from_str(include_str!(
+                "../../../fixtures/lattice-embed/query-prefixes.json"
+            ))
+            .expect("fixtures/lattice-embed/query-prefixes.json must be valid JSON");
+
+            let models = fixture["models"]
+                .as_object()
+                .expect("fixture must have a top-level 'models' object");
+            assert!(
+                !models.is_empty(),
+                "fixture 'models' must not be empty -- an empty fixture would make this \
+                 contract test vacuously pass"
+            );
+            assert!(
+                models.contains_key("bge-small"),
+                "fixture must cover 'bge-small' -- the model #662 was about"
+            );
+            assert!(
+                models.contains_key("minilm"),
+                "fixture must cover 'minilm' as the symmetric control case"
+            );
+
+            for (alias, expected) in models {
+                let model: LatticeEmbeddingModel = alias.parse().unwrap_or_else(|e| {
+                    panic!(
+                        "fixture alias '{alias}' must be a valid lattice_embed::EmbeddingModel: {e}"
+                    )
+                });
+
+                let expected_query_prefix = expected["query_prefix"].as_str();
+                assert_eq!(
+                    model.query_instruction(),
+                    expected_query_prefix,
+                    "query prefix mismatch for '{alias}': lattice_embed::EmbeddingModel::\
+                     query_instruction() returned {:?} but fixtures/lattice-embed/\
+                     query-prefixes.json expects {:?}. If lattice-embed intentionally changed \
+                     this model's convention, update the fixture AND the TS sibling test in \
+                     npm/packages/ruvector-extensions/tests/lattice-prefix-contract.test.ts \
+                     together.",
+                    model.query_instruction(),
+                    expected_query_prefix
+                );
+
+                let expected_passage_prefix = expected["passage_prefix"].as_str();
+                assert_eq!(
+                    model.document_instruction(),
+                    expected_passage_prefix,
+                    "passage prefix mismatch for '{alias}': lattice_embed::EmbeddingModel::\
+                     document_instruction() returned {:?} but the fixture expects {:?}",
+                    model.document_instruction(),
+                    expected_passage_prefix
+                );
+            }
+        }
     }
 }
 

--- a/crates/ruvector-core/src/embeddings.rs
+++ b/crates/ruvector-core/src/embeddings.rs
@@ -783,6 +783,17 @@ pub use onnx::OnnxEmbedding;
 /// symmetric (contrastive training on raw text, no prefix), so its two methods
 /// are equivalent.
 ///
+/// ## Normalization
+/// Both [`EmbeddingProvider::embed`] and [`LatticeEmbedding::embed_query`]
+/// return L2-normalized vectors (unit length): `lattice-embed`'s BERT-family
+/// encode path (used for BGE, E5, and MiniLM) calls `l2_normalize`
+/// unconditionally on the pooled output, both for single-text and batched
+/// encoding (`BertModel::encode` / `encode_batch` in
+/// `crates/inference/src/model/bert.rs`, upstream in
+/// [`lattice-embed`](https://crates.io/crates/lattice-embed)'s
+/// `lattice-inference` dependency). This holds regardless of distance
+/// metric — safe to use with a dot-product index as well as cosine.
+///
 /// # Example
 /// ```rust,no_run
 /// use ruvector_core::embeddings::{EmbeddingProvider, LatticeEmbedding};
@@ -1073,6 +1084,37 @@ pub mod lattice_native {
                 LatticeEmbedding::from_pretrained("bge-small-en-v1.5").is_ok(),
                 "native local model 'bge-small-en-v1.5' must construct successfully"
             );
+        }
+
+        /// #662: pins the bge-small alias surface this provider accepts.
+        /// `ruvector-extensions`' `LatticeWasmEmbeddings` (the WASM sibling of
+        /// this provider) mirrors this same alias set
+        /// (`normalizeLatticeWasmModel` in
+        /// `npm/packages/ruvector-extensions/src/embeddings.ts`) so a model id
+        /// valid for one Lattice-backed provider is valid for the other.
+        #[test]
+        fn from_pretrained_accepts_bge_small_alias_surface() {
+            for alias in [
+                "bge-small-en-v1.5",
+                "bge-small-en",
+                "bge-small",
+                "small",
+                "BAAI/bge-small-en-v1.5",
+                "BGE_SMALL_EN_V1.5",
+            ] {
+                let provider = LatticeEmbedding::from_pretrained(alias)
+                    .unwrap_or_else(|e| panic!("alias '{alias}' must resolve to bge-small: {e}"));
+                assert_eq!(
+                    provider.dimensions(),
+                    384,
+                    "alias '{alias}' resolved to the wrong dimensionality"
+                );
+                assert_eq!(
+                    provider.name(),
+                    "BAAI/bge-small-en-v1.5",
+                    "alias '{alias}' resolved to a different model than 'bge-small-en-v1.5'"
+                );
+            }
         }
 
         /// Regression test for the nested-runtime panic: `embed` / `embed_query`

--- a/fixtures/lattice-embed/query-prefixes.json
+++ b/fixtures/lattice-embed/query-prefixes.json
@@ -1,0 +1,14 @@
+{
+  "description": "Cross-provider contract fixture (issue #662, PR #663 follow-up). Pins the query-side and passage-side retrieval-instruction prefix each Lattice-backed embedding provider must apply for a given model, so the Rust provider (crates/ruvector-core::embeddings::lattice_native::LatticeEmbedding) and the TS/WASM provider (npm/packages/ruvector-extensions::LatticeWasmEmbeddings) cannot silently re-diverge the way they did before #663. Both providers' contract tests read this same file and fail if either side stops matching it -- a lattice-embed convention bump must update this fixture (and both tests) deliberately, not by accident.",
+  "source_of_truth": "lattice_embed::EmbeddingModel::query_instruction() / document_instruction() -- crates/embed/src/model.rs in ohdearquant/lattice, both documented '**Stable**' in that crate's own API-stability convention.",
+  "models": {
+    "bge-small": {
+      "query_prefix": "Represent this sentence for searching relevant passages: ",
+      "passage_prefix": null
+    },
+    "minilm": {
+      "query_prefix": null,
+      "passage_prefix": null
+    }
+  }
+}

--- a/npm/packages/ruvector-extensions/src/embeddings.ts
+++ b/npm/packages/ruvector-extensions/src/embeddings.ts
@@ -778,13 +778,75 @@ export interface LatticeWasmEmbeddingsConfig {
 }
 
 /**
- * Known lattice-embed-wasm models and their output dimensionality. Both are
- * symmetric BERT-family encoders (no query/passage prefix at the wasm layer).
+ * Known lattice-embed-wasm models and their output dimensionality.
+ *
+ * `bge-small` is an asymmetric retriever (see
+ * {@link LATTICE_WASM_QUERY_INSTRUCTIONS} below); `minilm` is genuinely
+ * symmetric (contrastive training on raw text, no prefix on either side).
  */
 const LATTICE_WASM_MODEL_DIMENSIONS: Record<string, number> = {
   minilm: 384,
   'bge-small': 384,
 };
+
+/**
+ * Query-side retrieval-instruction prefixes, keyed by the canonical model
+ * name from {@link LATTICE_WASM_MODEL_DIMENSIONS}. Mirrors
+ * `lattice_embed::EmbeddingModel::query_instruction()` for
+ * `BgeSmallEnV15` (`crates/embed/src/model.rs` in ohdearquant/lattice) and
+ * `LatticeEmbedding::embed_query` in `ruvector-core`'s own Lattice provider
+ * (`crates/ruvector-core/src/embeddings.rs`) -- BGE-v1.5 is an asymmetric
+ * retriever: the query side gets this instruction prefix, the passage side
+ * stays raw. `minilm` has no entry here (symmetric, no prefix).
+ */
+const LATTICE_WASM_QUERY_INSTRUCTIONS: Record<string, string> = {
+  'bge-small': 'Represent this sentence for searching relevant passages: ',
+};
+
+/**
+ * Applies the model's query-side retrieval-instruction prefix, if it has
+ * one. A pure function (exported, in addition to being used internally by
+ * {@link LatticeWasmEmbeddings.embedQuery}) so the query/passage asymmetry
+ * is unit-testable without depending on the optional
+ * `@khive-ai/lattice-embed-wasm` peer package.
+ *
+ * @param model - A canonical model name from
+ *   {@link LATTICE_WASM_MODEL_DIMENSIONS} (e.g. as returned by
+ *   {@link LatticeWasmEmbeddings.getModel}), not a raw user-supplied alias.
+ */
+export function applyLatticeWasmQueryPrefix(model: string, text: string): string {
+  const prefix = LATTICE_WASM_QUERY_INSTRUCTIONS[model];
+  return prefix ? `${prefix}${text}` : text;
+}
+
+/**
+ * Normalizes a user-supplied lattice-embed-wasm model identifier to one of
+ * the canonical keys in {@link LATTICE_WASM_MODEL_DIMENSIONS} ('minilm' or
+ * 'bge-small'). Accepts the same alias surface lattice-embed's own
+ * `EmbeddingModel::from_str` accepts for these two model families --
+ * case/underscore-insensitive, HuggingFace ids, short names (see
+ * `crates/embed/src/model.rs` in ohdearquant/lattice) -- so a model id
+ * valid for the Rust `LatticeEmbedding` provider in `ruvector-core` is also
+ * valid here (#662). Returns `undefined` for anything else.
+ */
+export function normalizeLatticeWasmModel(model: string): string | undefined {
+  const normalized = model.toLowerCase().trim().replace(/_/g, '-').replace('baai/', '');
+
+  switch (normalized) {
+    case 'bge-small-en-v1.5':
+    case 'bge-small-en':
+    case 'bge-small':
+    case 'small':
+      return 'bge-small';
+    case 'all-minilm-l6-v2':
+    case 'minilm':
+    case 'all-minilm':
+    case 'sentence-transformers/all-minilm-l6-v2':
+      return 'minilm';
+    default:
+      return undefined;
+  }
+}
 
 /**
  * Local embeddings provider backed by `@khive-ai/lattice-embed-wasm`, a
@@ -794,8 +856,16 @@ const LATTICE_WASM_MODEL_DIMENSIONS: Record<string, number> = {
  * provider does not run in a browser. Single-text only: the wasm package
  * exposes no batch API, so {@link getMaxBatchSize} honestly reports `1`
  * rather than simulating a larger batch. Output embeddings are
- * L2-normalized and symmetric (no query/passage asymmetry at the wasm
- * layer, unlike some hosted embedding APIs).
+ * L2-normalized (matching the `native` lattice-embed path's guarantee --
+ * `BertModel::encode`/`encode_batch` call `l2_normalize` unconditionally,
+ * see `crates/inference/src/model/bert.rs` in ohdearquant/lattice).
+ *
+ * `bge-small` is an asymmetric retriever: {@link embedQuery} applies the
+ * BGE-v1.5 retrieval-instruction prefix, {@link embedText}/{@link embedTexts}
+ * do not (passage side, matching `LatticeEmbedding::embed`/`embed_query` in
+ * ruvector-core's Rust provider and `lattice-embed`'s own
+ * `query_instruction()`/`document_instruction()` split). `minilm` is
+ * genuinely symmetric, so its query and passage embeddings are identical.
  *
  * This is a convenience local-embedder option at parity with the existing
  * `HuggingFaceEmbeddings` (transformers.js) local path above, not a faster
@@ -813,19 +883,19 @@ export class LatticeWasmEmbeddings extends EmbeddingProvider {
   constructor(config: LatticeWasmEmbeddingsConfig = {}) {
     super(config.retryConfig);
 
-    const model = config.model || 'minilm';
-    const dimension = LATTICE_WASM_MODEL_DIMENSIONS[model];
+    const requested = config.model || 'minilm';
+    const model = normalizeLatticeWasmModel(requested);
 
-    if (dimension === undefined) {
+    if (model === undefined) {
       throw new Error(
-        `Unknown lattice-embed-wasm model "${model}". Supported models: ${Object.keys(
+        `Unknown lattice-embed-wasm model "${requested}". Supported models: ${Object.keys(
           LATTICE_WASM_MODEL_DIMENSIONS
-        ).join(', ')}`
+        ).join(', ')} (aliases accepted, e.g. "bge-small-en-v1.5", "BAAI/bge-small-en-v1.5").`
       );
     }
 
     this.model = model;
-    this.dimension = dimension;
+    this.dimension = LATTICE_WASM_MODEL_DIMENSIONS[model];
   }
 
   getMaxBatchSize(): number {
@@ -836,6 +906,30 @@ export class LatticeWasmEmbeddings extends EmbeddingProvider {
 
   getDimension(): number {
     return this.dimension;
+  }
+
+  /**
+   * The canonical model name this provider resolved to ('minilm' or
+   * 'bge-small'), regardless of which accepted alias the caller passed to
+   * the constructor.
+   */
+  getModel(): string {
+    return this.model;
+  }
+
+  /**
+   * Embed **query** text, applying the model's retrieval-instruction prefix
+   * if it uses one (currently only `bge-small`; `minilm` is symmetric and
+   * this passes the text through unchanged). Mirrors
+   * `LatticeEmbedding::embed_query` in ruvector-core's Rust provider and
+   * `lattice-embed`'s own `EmbeddingModel::query_instruction()`. Use
+   * {@link embedText}/{@link embedTexts} for the passage/document side (no
+   * prefix applied there).
+   */
+  async embedQuery(text: string): Promise<number[]> {
+    const prefixed = applyLatticeWasmQueryPrefix(this.model, text);
+    const result = await this.embedTexts([prefixed]);
+    return result.embeddings[0].embedding;
   }
 
   async embedTexts(texts: string[]): Promise<BatchEmbeddingResult> {

--- a/npm/packages/ruvector-extensions/tests/embeddings.test.ts
+++ b/npm/packages/ruvector-extensions/tests/embeddings.test.ts
@@ -14,6 +14,8 @@ import {
   AnthropicEmbeddings,
   HuggingFaceEmbeddings,
   LatticeWasmEmbeddings,
+  applyLatticeWasmQueryPrefix,
+  normalizeLatticeWasmModel,
   type BatchEmbeddingResult,
   type EmbeddingError,
 } from '../src/embeddings.js';
@@ -291,6 +293,84 @@ describe('LatticeWasmEmbeddings', () => {
     for (const value of embedding) sumSquares += value * value;
     const norm = Math.sqrt(sumSquares);
     assert.ok(Math.abs(norm - 1.0) < 1e-3, `expected L2 norm near 1.0, got ${norm}`);
+  });
+});
+
+// ============================================================================
+// LatticeWasmEmbeddings: query/passage asymmetry + model alias reconciliation
+//
+// Regression coverage for #662 (symmetric-vs-asymmetric bge-small mismatch
+// between this provider and ruvector-core's LatticeEmbedding). Exercises the
+// pure helper functions directly rather than the wasm layer itself, so these
+// tests run without the optional @khive-ai/lattice-embed-wasm peer package.
+// ============================================================================
+
+describe('LatticeWasmEmbeddings query/passage prefix asymmetry (#662)', () => {
+  it('prefixes bge-small queries with the BGE-v1.5 retrieval instruction', () => {
+    const text = 'Where is the Eiffel Tower?';
+    assert.strictEqual(
+      applyLatticeWasmQueryPrefix('bge-small', text),
+      `Represent this sentence for searching relevant passages: ${text}`
+    );
+  });
+
+  it('leaves minilm queries unprefixed (genuinely symmetric model)', () => {
+    const text = 'Where is the Eiffel Tower?';
+    assert.strictEqual(applyLatticeWasmQueryPrefix('minilm', text), text);
+  });
+
+  it('bge-small query text differs from passage text; minilm query and passage text are identical', () => {
+    const text = 'Where is the Eiffel Tower?';
+    // Passage side: LatticeWasmEmbeddings.embedText/embedTexts never prefix,
+    // so plain `text` is what reaches the wasm embed() call for documents.
+    assert.notStrictEqual(applyLatticeWasmQueryPrefix('bge-small', text), text);
+    assert.strictEqual(applyLatticeWasmQueryPrefix('minilm', text), text);
+  });
+
+  it('LatticeWasmEmbeddings.embedQuery resolves the model before prefixing, so aliases behave like the canonical name', () => {
+    const viaAlias = new LatticeWasmEmbeddings({ model: 'bge-small-en-v1.5' });
+    const viaCanonical = new LatticeWasmEmbeddings({ model: 'bge-small' });
+    assert.strictEqual(viaAlias.getModel(), viaCanonical.getModel());
+  });
+});
+
+describe('LatticeWasmEmbeddings model alias parsing (#662)', () => {
+  it('accepts the same bge-small alias surface as lattice-embed\'s EmbeddingModel::from_str', () => {
+    for (const alias of [
+      'bge-small',
+      'bge-small-en',
+      'bge-small-en-v1.5',
+      'small',
+      'BAAI/bge-small-en-v1.5',
+      'BGE_SMALL_EN_V1.5',
+    ]) {
+      const provider = new LatticeWasmEmbeddings({ model: alias });
+      assert.strictEqual(provider.getModel(), 'bge-small', `alias "${alias}"`);
+      assert.strictEqual(provider.getDimension(), 384, `alias "${alias}"`);
+    }
+  });
+
+  it('accepts the minilm alias surface', () => {
+    for (const alias of [
+      'minilm',
+      'all-minilm',
+      'all-minilm-l6-v2',
+      'sentence-transformers/all-MiniLM-L6-v2',
+    ]) {
+      const provider = new LatticeWasmEmbeddings({ model: alias });
+      assert.strictEqual(provider.getModel(), 'minilm', `alias "${alias}"`);
+    }
+  });
+
+  it('normalizeLatticeWasmModel returns undefined for unrecognized ids', () => {
+    assert.strictEqual(normalizeLatticeWasmModel('not-a-real-model'), undefined);
+  });
+
+  it('still rejects unknown models at construction', () => {
+    assert.throws(
+      () => new LatticeWasmEmbeddings({ model: 'not-a-real-model' }),
+      /Unknown lattice-embed-wasm model/
+    );
   });
 });
 

--- a/npm/packages/ruvector-extensions/tests/lattice-prefix-contract.test.ts
+++ b/npm/packages/ruvector-extensions/tests/lattice-prefix-contract.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @fileoverview Cross-provider query/passage prefix contract test (#662 follow-up)
+ *
+ * Reads the SAME fixture the Rust side asserts against
+ * (`fixtures/lattice-embed/query-prefixes.json` at the repo root, consumed by
+ * `crates/ruvector-core/src/embeddings.rs`'s
+ * `lattice_native::tests::cross_provider_query_prefix_contract`), so this
+ * TS/WASM `LatticeWasmEmbeddings` provider and the Rust `LatticeEmbedding`
+ * provider cannot silently re-diverge on which prefix a model gets -- the
+ * failure mode #662 was, and #663 fixed for `bge-small` on this side.
+ *
+ * No model weights or the optional `@khive-ai/lattice-embed-wasm` peer
+ * package are needed: `applyLatticeWasmQueryPrefix` is a pure function over
+ * the model's canonical name, exercised directly (same approach the existing
+ * `embeddings.test.ts` #662 tests already use).
+ *
+ * @author ruv.io Team <info@ruv.io>
+ * @license MIT
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { applyLatticeWasmQueryPrefix } from '../src/embeddings.js';
+
+interface PrefixFixtureEntry {
+  query_prefix: string | null;
+  passage_prefix: string | null;
+}
+
+interface PrefixFixture {
+  models: Record<string, PrefixFixtureEntry>;
+}
+
+const FIXTURE_PATH = fileURLToPath(
+  new URL('../../../../fixtures/lattice-embed/query-prefixes.json', import.meta.url)
+);
+
+function loadFixture(): PrefixFixture {
+  const raw = readFileSync(FIXTURE_PATH, 'utf8');
+  return JSON.parse(raw) as PrefixFixture;
+}
+
+const fixture = loadFixture();
+const modelNames = Object.keys(fixture.models);
+
+describe('LatticeWasmEmbeddings cross-provider query prefix contract (#662 follow-up)', () => {
+  it('the shared fixture is non-empty and covers bge-small + minilm', () => {
+    assert.ok(modelNames.length > 0, 'fixture must not be empty');
+    assert.ok(
+      modelNames.includes('bge-small'),
+      "fixture must cover 'bge-small' -- the model #662 was about"
+    );
+    assert.ok(
+      modelNames.includes('minilm'),
+      "fixture must cover 'minilm' as the symmetric control case"
+    );
+  });
+
+  for (const model of modelNames) {
+    const expected = fixture.models[model];
+
+    it(`applyLatticeWasmQueryPrefix('${model}', ...) matches the shared fixture's query_prefix`, () => {
+      const text = 'contract-test-probe';
+      const expectedOutput = expected.query_prefix ? `${expected.query_prefix}${text}` : text;
+      assert.strictEqual(
+        applyLatticeWasmQueryPrefix(model, text),
+        expectedOutput,
+        `model '${model}': expected query prefix ${JSON.stringify(expected.query_prefix)} ` +
+          `from fixtures/lattice-embed/query-prefixes.json to match ` +
+          `LATTICE_WASM_QUERY_INSTRUCTIONS in src/embeddings.ts. If lattice-embed intentionally ` +
+          `changed this model's convention, update the fixture AND the Rust sibling test in ` +
+          `crates/ruvector-core/src/embeddings.rs (lattice_native::tests::` +
+          `cross_provider_query_prefix_contract) together.`
+      );
+    });
+
+    it(`'${model}' has no TS-side passage prefix, so the fixture's passage_prefix must be null`, () => {
+      // LatticeWasmEmbeddings never prefixes the passage/document side --
+      // embedText/embedTexts pass text through unchanged, and there is no
+      // applyLatticeWasmPassagePrefix counterpart to call. If this assertion
+      // ever fails, a model in the fixture has grown a non-null
+      // passage_prefix and this provider needs a matching passage-prefix
+      // path before the assertion (and this comment) can be updated
+      // honestly.
+      assert.strictEqual(
+        expected.passage_prefix,
+        null,
+        `model '${model}': fixture declares a non-null passage_prefix but ` +
+          `LatticeWasmEmbeddings has no passage-prefix implementation to check it against`
+      );
+    });
+  }
+});


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Fixes #662.

## Summary

Aligns both Lattice-backed embedding providers — `LatticeWasmEmbeddings` (npm/packages/ruvector-extensions, #651) and `LatticeEmbedding` (crates/ruvector-core, #648) — with `lattice-embed`'s own native convention for `bge-small`, so a corpus indexed with one provider and queried with the other lands in the same vector space.

**Authoritative convention** (source: `EmbeddingModel::query_instruction()` / `document_instruction()` in [`crates/embed/src/model.rs`](https://github.com/ohdearquant/lattice/blob/main/crates/embed/src/model.rs), the upstream crate both providers wrap): BGE-v1.5 is an **asymmetric retriever**. Queries get the retrieval-instruction prefix `"Represent this sentence for searching relevant passages: "`; passages/documents are embedded raw, with no prefix.

## What changed

1. **Query/passage asymmetry (WASM side)** — `LatticeWasmEmbeddings` gains an `embedQuery(text)` method that applies the BGE-v1.5 instruction prefix for `bge-small` before embedding (passages via `embedText`/`embedTexts` stay unprefixed, unchanged). `minilm` is genuinely symmetric, so its query and passage text are identical either way. This mirrors `LatticeEmbedding::embed_query()` / `EmbeddingProvider::embed()` on the Rust side, which already implements this split.
2. **Model-name registry** — `LatticeWasmEmbeddings` now accepts the same `bge-small` alias surface `lattice-embed`'s own `EmbeddingModel::from_str` accepts (`bge-small`, `bge-small-en`, `bge-small-en-v1.5`, `small`, `BAAI/bge-small-en-v1.5`, case/underscore-insensitive), normalized via a new `normalizeLatticeWasmModel()` helper to a canonical name exposed through a new `getModel()` accessor. A model id valid for the Rust provider is now valid for the WASM provider too.
3. **Normalization guarantee** — documented on both providers that native BERT-family encoding (BGE/E5/MiniLM) is unconditionally L2-normalized: `BertModel::encode`/`encode_batch` call `l2_normalize` on the pooled output regardless of input, in [`crates/inference/src/model/bert.rs`](https://github.com/ohdearquant/lattice/blob/main/crates/inference/src/model/bert.rs) (the `lattice-inference` dependency both providers ultimately run through). The WASM side already documented this; the doc comment is now added to the Rust `LatticeEmbedding` module docs as well, so both surfaces state the same guarantee explicitly. Safe to use with a dot-product index, not just cosine.

## Test evidence

**TypeScript** (`npm/packages/ruvector-extensions`) — new tests added to `tests/embeddings.test.ts` under `LatticeWasmEmbeddings query/passage prefix asymmetry (#662)` and `LatticeWasmEmbeddings model alias parsing (#662)`. Ran locally via `tsc` + `node --test` (this package has no dedicated CI workflow yet — checked `.github/workflows/*.yml`, only `npm/packages/ruvector` has one):

```
▶ LatticeWasmEmbeddings query/passage prefix asymmetry (#662)
  ✔ prefixes bge-small queries with the BGE-v1.5 retrieval instruction
  ✔ leaves minilm queries unprefixed (genuinely symmetric model)
  ✔ bge-small query text differs from passage text; minilm query and passage text are identical
  ✔ LatticeWasmEmbeddings.embedQuery resolves the model before prefixing, so aliases behave like the canonical name
✔ LatticeWasmEmbeddings query/passage prefix asymmetry (#662)
▶ LatticeWasmEmbeddings model alias parsing (#662)
  ✔ accepts the same bge-small alias surface as lattice-embed's EmbeddingModel::from_str
  ✔ accepts the minilm alias surface
  ✔ normalizeLatticeWasmModel returns undefined for unrecognized ids
  ✔ still rejects unknown models at construction
✔ LatticeWasmEmbeddings model alias parsing (#662)
```

Full existing `LatticeWasmEmbeddings` suite (including the pre-existing live-weights test, which self-skips without the optional peer package) still passes; two pre-existing failures in the unrelated `Retry Logic` suite are untouched by this change and reproduce identically on `main`.

**Rust** (`ruvector-core`, `lattice-embeddings` feature):

```
$ cargo test -p ruvector-core --features lattice-embeddings --lib lattice_native::tests
running 4 tests
test embeddings::lattice_native::tests::embed_from_inside_async_runtime_does_not_panic ... ok
test embeddings::lattice_native::tests::from_pretrained_accepts_bge_small_alias_surface ... ok
test embeddings::lattice_native::tests::from_pretrained_accepts_native_local_model ... ok
test embeddings::lattice_native::tests::from_pretrained_rejects_remote_only_models ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured

$ cargo clippy -p ruvector-core --features lattice-embeddings --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) — no warnings

$ cargo test -p ruvector-core --features lattice-embeddings --doc embeddings
running 6 tests
test result: ok. 5 passed; 0 failed; 1 ignored (unrelated pre-existing `ignore` doctest)
```

`cargo doc -p ruvector-core --features lattice-embeddings --no-deps` builds clean for `embeddings.rs` (9 pre-existing rustdoc warnings elsewhere in the crate, none touching this file).

## Not verified

- No CI workflow currently exercises `npm/packages/ruvector-extensions` (only `npm/packages/ruvector` has a dedicated workflow), so the TypeScript test evidence above is from a local `npm install --no-workspaces` + `tsc` + `node --test` run, not a CI run.
- The live-weights WASM test (pre-existing, unmodified) self-skips in this environment since `@khive-ai/lattice-embed-wasm` is an optional peer dependency not installed locally.
