### PR TITLE
chore: bump lattice-embed and lattice-inference to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4927,9 +4927,9 @@ dependencies = [
 
 [[package]]
 name = "lattice-embed"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c40a349ed412ca8a4b89ad4f0c19cca28e9de969a570bada665e6df195d745"
+checksum = "3b2844bae6b81b016ab5b1fbf0429b4ccec864e901fa7e265e3df93042e343cc"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4946,9 +4946,9 @@ dependencies = [
 
 [[package]]
 name = "lattice-inference"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf759944705182b487cc3a1d99687fa518f031c8239857d351297c9cecabd42"
+checksum = "f84427773b992aa51d76f47d5585ccc36fe99b28350a7635de3e5565d140e2d0"
 dependencies = [
  "axum 0.8.9",
  "clap",

--- a/crates/ruvector-core/Cargo.toml
+++ b/crates/ruvector-core/Cargo.toml
@@ -56,11 +56,11 @@ tokenizers = { version = "0.20", default-features = false, features = ["onig"], 
 hf-hub = { version = "0.4", optional = true }
 
 # Native (pure-Rust) local embeddings via lattice-embed (not available in WASM).
-# NOTE: lattice-embed 0.5.1 requires Rust >= 1.93 (edition 2024). Cargo cannot
+# NOTE: lattice-embed 0.6 requires Rust >= 1.93 (edition 2024). Cargo cannot
 # express a per-feature `rust-version`, so enabling the `lattice-embeddings`
 # feature raises the effective MSRV above this crate's workspace-inherited
 # 1.77 for anyone who turns it on. The default build is unaffected.
-lattice-embed = { version = "0.5.1", optional = true }
+lattice-embed = { version = "0.6", optional = true }
 tokio = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/ruvllm/Cargo.toml
+++ b/crates/ruvllm/Cargo.toml
@@ -108,7 +108,7 @@ objc = { version = "0.2", optional = true }
 
 # Lattice pure-Rust Qwen3.5 inference engine, Metal GPU forward pass
 # (macOS only, optional, default-OFF — see the `lattice` feature below).
-lattice-inference = { version = "0.5.0", optional = true, default-features = false, features = ["metal-gpu", "f16", "std"] }
+lattice-inference = { version = "0.6", optional = true, default-features = false, features = ["metal-gpu", "f16", "std"] }
 
 # Core ML bindings (macOS/iOS) - for Apple Neural Engine acceleration
 objc2 = { version = "0.6", optional = true }


### PR DESCRIPTION
lattice 0.6.0 is now the current release on crates.io. This updates the two version pins that were still on 0.5.x:

- `crates/ruvector-core/Cargo.toml`: `lattice-embed` 0.5.1 -> 0.6 (optional `lattice-embeddings` feature)
- `crates/ruvllm/Cargo.toml`: `lattice-inference` 0.5.0 -> 0.6 (optional `lattice` feature, default-off)

No API migration needed for the surface this repo actually uses: `lattice_backend.rs` only calls `MetalQwen35State`, `Qwen35Model`, `GenerateConfig`/`Qwen35Config`, and the tokenizer trait; it doesn't construct `ChatCompletionOutput` literally or call any of the GDN training APIs that changed shape in 0.6.0, so those changes don't affect it.

Verification:
- `cargo update -p lattice-embed -p lattice-inference` (Cargo.lock now pins 0.6.0 for both)
- `cargo build -p ruvector-core --features lattice-embeddings` -> success
- `cargo build -p ruvllm --features lattice` -> success
- `cargo test -p ruvllm --features lattice --lib backends::lattice_backend::` -> 7 passed, 0 failed
- Confirmed the existing MSRV comment next to the `lattice-embed` pin (Rust >= 1.93) still matches 0.6.0's `rust-version`