### PR TITLE
fix(deps): clear RUSTSEC advisory failures in supply-chain CI

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -19,6 +19,25 @@ ignore = [
     # Re-evaluate when the `rsa` crate ships a constant-time implementation.
     "RUSTSEC-2023-0071",
 
+    # quick-xml 0.26.0 — memory-exhaustion DoS via unbounded namespace-
+    # declaration allocation (RUSTSEC-2026-0195) and quadratic run time on
+    # duplicate-attribute checks (RUSTSEC-2026-0194), both severity 7.5.
+    # Pulled transitively only via `inferno` (flamegraph rendering) <-
+    # `pprof` (optional `profiling` feature of ruvector-bench, never a
+    # production dependency). No lockfile-only bump is possible: `pprof`
+    # 0.15.0 (the newest release on crates.io as of this review) still
+    # requires `inferno = "^0.11"`, and `inferno` 0.11.21 (the newest
+    # patch in that line) still requires `quick-xml = "^0.26"` — verified
+    # directly via `cargo update -p inferno`/`cargo update -p quick-xml`
+    # dry runs, not from changelog inspection alone. quick-xml here only
+    # parses profiler-internal XML on the local machine (never
+    # network-facing or attacker-supplied input), so the DoS surface is
+    # not reachable in our usage even before a fix ships. Re-review when
+    # `pprof` cuts a release depending on `inferno` >=0.12, or track
+    # https://github.com/jonhoo/inferno for a quick-xml bump.
+    "RUSTSEC-2026-0195",
+    "RUSTSEC-2026-0194",
+
     # ------------------------------------------------------------------
     # "Unmaintained" warnings (informational, not vulnerabilities)
     # ------------------------------------------------------------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1846,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -125,6 +125,21 @@ ignore = [
     # 2026-08-01.
     "RUSTSEC-2026-0105",
 
+    # ttf-parser — unmaintained, upstream author stated no further fixes
+    # will be released (RUSTSEC-2026-0192); the advisory itself states
+    # "No safe upgrade is available!". Reaches the graph at three
+    # independent versions, none of them fixable by a version bump:
+    #   0.15.2 via rusttype 0.9.3 -> owned_ttf_parser (dev-only, scipix)
+    #   0.20.0 via plotters 0.3.7 -> criterion (dev-dep, workspace-wide) and
+    #           -> ruvector-bench's own chart rendering (publish = false)
+    #   0.25.1 via imageproc 0.25.1 -> ab_glyph -> owned_ttf_parser (scipix)
+    # All three paths are dev-dependencies or unpublished bench-only tooling,
+    # never linked into a published/production artifact; font-parsing
+    # inputs are local example assets, not attacker-controlled. Re-review
+    # 2026-08-01 or when a maintained fork (e.g. skrifa) is adopted by
+    # rusttype/plotters/imageproc upstream.
+    "RUSTSEC-2026-0192",
+
     # memmap2 0.9.x — unsound `Unchecked pointer offset` API (RUSTSEC-2026-0186,
     # "unsound", not an exploitable vuln). Transitive via safetensors/candle
     # mmap loading and other crates; no fixed release on the 0.9 line yet.


### PR DESCRIPTION
> _PR authored by an AI agent on behalf of @ohdearquant._

Dependency cleanup scoped strictly to the advisories your own supply-chain CI
(`supply-chain.yml`) flags red, plus two more that `cargo-audit`/`cargo-deny`
already surface but aren't gating CI yet. No drive-by version-freshness bumps.

## What was red and what fixed it

| # | RUSTSEC ID | Crate | Type | Old → New | Direct/Transitive | Fix |
|---|-----------|-------|------|-----------|--------------------|-----|
| 1 | [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) | crossbeam-epoch | vulnerability | 0.9.18 → 0.9.20 | transitive (via `crossbeam` 0.8.4, pulled by `ruvector-core` and most of the workspace) | `cargo update -p crossbeam-epoch --precise 0.9.20` — lockfile-only, no code changes |
| 2 | [RUSTSEC-2026-0192](https://rustsec.org/advisories/RUSTSEC-2026-0192) | ttf-parser | unmaintained | n/a — no fix exists | transitive, 3 independent paths (0.15.2, 0.20.0, 0.25.1) | documented in `deny.toml` ignore list (see below) |
| 3a | [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) | quick-xml | vulnerability (7.5) | n/a — blocked upstream | transitive (via `inferno` ← `pprof`, optional `profiling` feature) | documented in `.cargo/audit.toml` ignore list (see below) |
| 3b | [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) | quick-xml | vulnerability (7.5) | n/a — blocked upstream | same as 3a | same as 3a |

Row 1 was the only one of the four actually fixable by a version bump; it's
its own commit. Rows 2/3 both had no clean upgrade path, so instead of
forcing something invasive I documented them the same way this repo already
documents every other unfixable transitive advisory — a dated, justified
entry in the existing ignore list, not a silent skip.

### 1. crossbeam-epoch 0.9.18 → 0.9.20 (RUSTSEC-2026-0204)

Invalid-pointer-dereference bug in `crossbeam-epoch`'s `fmt::Pointer` impl
for `Atomic`/`Shared` when the underlying pointer is invalid. Fixed upstream
in 0.9.20. `crossbeam` 0.8.4's own version requirement (`^0.9`) already
permits 0.9.20, so this is a pure lockfile bump — `Cargo.toml` is untouched.

### 2. ttf-parser — RUSTSEC-2026-0192 (documented, not fixed)

The advisory text itself says *"No safe upgrade is available!"* — the
upstream author has stated the crate won't receive further fixes. It's
in the graph via three independent paths, none of them reachable by a
version bump:

- `0.15.2` via `rusttype 0.9.3 → owned_ttf_parser` (dev-only, `ruvector-scipix` example)
- `0.20.0` via `plotters 0.3.7 → criterion` (dev-dep, workspace-wide) and via `ruvector-bench`'s own chart rendering (`publish = false`)
- `0.25.1` via `imageproc 0.25.1 → ab_glyph → owned_ttf_parser` (`ruvector-scipix` example)

All three paths are dev-dependencies or unpublished bench-only tooling —
none reach a published/production artifact — and the font-parsing inputs
in all three are local example assets, not attacker-controlled. This was
the thing actually failing `cargo deny check advisories`
(`error[unmaintained]`), one of the workspace's five supply-chain CI
layers. I added it to `deny.toml`'s `advisories.ignore` list with a
re-review trigger (adoption of a maintained fork such as `skrifa` by
`rusttype`/`plotters`/`imageproc` upstream), matching the file's existing
entry style for `RUSTSEC-2026-0105` (rusttype, same chain).
Longer-term dependency alternatives for this chain are tracked in #681.

### 3. quick-xml 0.26.0 — RUSTSEC-2026-0195 / RUSTSEC-2026-0194 (documented, not fixed)

Two DoS advisories, both severity 7.5: unbounded namespace-declaration
allocation, and quadratic run time on duplicate-attribute checks. I
checked whether a version bump was possible before concluding it wasn't:

- `quick-xml` is pulled only via `inferno` (flamegraph rendering) ←
  `pprof` (the optional `profiling` feature of `ruvector-bench`, never a
  production dependency).
- `pprof`'s newest release on crates.io (`0.15.0`) still requires
  `inferno = "^0.11"`.
- `inferno 0.11.21` (the newest patch already in the workspace's lockfile
  within that `^0.11` range — confirmed via `cargo update -p inferno`,
  which reported 0 packages needing changes) still requires
  `quick-xml = "^0.26"`.

I verified this directly rather than trusting changelogs: I temporarily
bumped `ruvector-bench`'s `pprof` requirement to `"0.15"` and ran
`cargo update -p pprof --precise 0.15.0`, then tried
`cargo update -p inferno --precise 0.12.7`, which failed with
`inferno = "^0.11"` still required by `pprof 0.15.0`. I reverted that
exploratory change; it's not in the final diff.

quick-xml in this path only parses profiler-internal XML produced
locally by the flamegraph tooling — never network-facing or
attacker-supplied input — so the DoS surface isn't reachable in your
usage even pre-fix. This is currently a `cargo-audit` failure (the
"vulnerability" type, which is the only type that fails your
`cargo-audit` CI step by default) but wasn't yet showing up as a
`cargo-deny` failure, because `quick-xml` sits behind a non-default
feature and isn't part of `cargo-deny`'s default-feature reachability
graph (it does show up under `cargo audit`, which scans the full
`Cargo.lock` regardless of feature reachability — that's why it was
still red on the layer-2 CI job). I added both IDs to
`.cargo/audit.toml`'s ignore list with a re-review trigger (`pprof`
depending on `inferno >= 0.12`), matching that file's existing entry
style for `RUSTSEC-2026-0002` (the same `pprof`/`profiling` feature,
different advisory).
Longer-term alternatives (including pprof's protobuf output mode, which
drops the inferno/quick-xml chain entirely) are tracked in #680.

## Before / after

**`cargo audit`** (workspace root):
- Before: `error: 3 vulnerabilities found!` (crossbeam-epoch, quick-xml ×2) / `warning: 8 allowed warnings found`
- After: `warning: 8 allowed warnings found` — 0 vulnerabilities, same 8 pre-existing informational warnings (unmaintained/unsound notices already tracked elsewhere in this file, untouched by this PR)

**`cargo deny check`** (all four sub-checks):
- Before: `advisories FAILED` (crossbeam-epoch vulnerability + ttf-parser ×3 unmaintained), `bans ok, licenses ok, sources ok`
- After: `advisories ok, bans ok, licenses ok, sources ok`

**`npm audit --omit=dev --audit-level=critical`** (`npm/` workspace, the
gate your CI actually enforces): unchanged, still green — 0 critical
before and after. See the npm section below for what I found and why I
didn't touch it.

## Test evidence

- `cargo build -p ruvector-core && cargo test -p ruvector-core --lib` (the
  crate that pulls `crossbeam` most broadly): 228 passed, 0 failed, 1
  ignored.
- `cargo build -p ruvector-bench --features profiling` (the crate that
  pulls `pprof`/`inferno`/`quick-xml`/`ttf-parser`): builds clean,
  unchanged from before this PR (no code in this PR touches
  `ruvector-bench` — the quick-xml/ttf-parser advisories are documented,
  not bumped).
- `cargo deny check` and `cargo audit` both re-run clean after every
  commit (see before/after above).

## npm — found, not fixed here

`npm/package-lock.json` (the only tracked npm lockfile, per your own CI
comment) currently carries 36 advisories via `npm audit --omit=dev`: 0
critical, 23 high, 13 moderate. Your `supply-chain.yml` gate
(`--audit-level=critical`) is green both before and after this PR — none
of these are "red" by your own CI's definition, and several are already
covered by the `overrides` block in `npm/package.json` (though a couple,
like `protobufjs`, have had new advisories land since that override was
last set — e.g. `GHSA-wcpc-wj8m-hjx6`, unbounded `Any` expansion DoS,
high, on top of the range your existing `protobufjs >=7.5.6` override
already permits).

Most of these (`protobufjs`, `@grpc/grpc-js`, `undici`, `ws`, `form-data`,
`minimatch`, `hono`, `http-proxy-middleware`, several `@google-cloud/*`
packages) report `fixAvailable: true` with no `isSemVerMajor` flag —
i.e. `npm audit fix` without `--force` should clear them non-breakingly.
A handful (`fastify` family, `node-cron`, `uuid`) only have a
semver-major fix path and would need real review, matching your own
Q3-2026 cutover-plan note in the workflow file.

I could not actually run `npm audit fix` to verify or apply this: it
requires `npm install`, and this workspace ships per-platform native
binaries as **local workspace packages** (not npm-registry
`optionalDependencies`) — e.g. `packages/router-darwin-x64` declares
`"os": ["darwin"], "cpu": ["x64"]`. npm workspace linking doesn't skip
platform-mismatched *workspace* members the way it does for registry
optional deps, so on my arm64 host every install attempt fails hard with
`EBADPLATFORM` on that package before it gets anywhere near resolving
the actual advisories (I tried `--omit=optional` too; same result — it's
a workspace-link failure, not an optional-dependency one). This should
run cleanly on your CI's x64 runner or any real x64/Rosetta machine.
Recommend running `npm audit fix` there and reviewing the `fastify` /
`node-cron` / `uuid` majors as a separate, deliberate follow-up PR rather
than bundling them here.

## Known remaining (informational only, not gating anything)

These already show up as `cargo audit` warnings today and are untouched
by this PR — none of them fail any current CI gate, and all but two were
already documented in `deny.toml` / `.cargo/audit.toml` before this PR:

- `RUSTSEC-2026-0163` (pqcrypto-internals, unmaintained) and
  `RUSTSEC-2026-0162` (pqcrypto-traits, unmaintained) — same PQClean
  archival situation as the already-ignored `pqcrypto-dilithium` /
  `pqcrypto-kyber` entries, just not yet added to either ignore list.
  Informational only (`cargo audit` warns, doesn't fail; not in
  `cargo-deny`'s default-feature reachability graph either, so it isn't
  failing that check now). Left alone here to keep this PR's diff to
  exactly what's failing CI plus the two advisories your `cargo-audit`
  step already flags red.
- `RUSTSEC-2026-0173` (proc-macro-error2, unmaintained), `RUSTSEC-2026-0190`
  (anyhow, unsound `downcast_mut`), `RUSTSEC-2026-0186` (memmap2, unsound
  pointer offset) — already documented in `deny.toml`, unaffected by this
  PR.

## Scope note

I stuck to what's actually red plus the two `cargo-audit` findings your
CI doesn't gate on yet, rather than doing a general version-freshness
sweep. In particular I deliberately did **not** touch `rand` anywhere in
the workspace — `ruvector-diskann` (and possibly others) still use the
`rand` 0.8-era API (`thread_rng`/`gen`), and a `rand` major bump would
cascade into real call-site migrations across the workspace, which is a
separate, larger piece of work than "clean up the red."
