### PR TITLE
chore(deps): bump lattice deps to 0.6.1 (crates + wasm peer)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1473,7 +1473,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2386,7 +2386,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2655,7 +2655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4729,7 +4729,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4927,15 +4927,15 @@ dependencies = [
 
 [[package]]
 name = "lattice-embed"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2844bae6b81b016ab5b1fbf0429b4ccec864e901fa7e265e3df93042e343cc"
+checksum = "188e4627dabd63544da5a57daabfe3105bf4d4970840f2e5a5c7f01123835ecb"
 dependencies = [
  "async-trait",
  "blake3",
  "chrono",
  "lattice-inference",
- "lru 0.12.5",
+ "lru 0.16.4",
  "parking_lot 0.12.5",
  "serde",
  "serde_json",
@@ -4946,9 +4946,9 @@ dependencies = [
 
 [[package]]
 name = "lattice-inference"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84427773b992aa51d76f47d5585ccc36fe99b28350a7635de3e5565d140e2d0"
+checksum = "b113852e4c522b6607cd8e01842b5dff7de307d4cc9223dfd798b0136e2aa62b"
 dependencies = [
  "axum 0.8.9",
  "clap",
@@ -6128,7 +6128,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8653,7 +8653,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12030,7 +12030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12630,7 +12630,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12721,7 +12721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14247,7 +14247,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/ruvector-core/Cargo.toml
+++ b/crates/ruvector-core/Cargo.toml
@@ -60,7 +60,7 @@ hf-hub = { version = "0.4", optional = true }
 # express a per-feature `rust-version`, so enabling the `lattice-embeddings`
 # feature raises the effective MSRV above this crate's workspace-inherited
 # 1.77 for anyone who turns it on. The default build is unaffected.
-lattice-embed = { version = "0.6", optional = true }
+lattice-embed = { version = "0.6.1", optional = true }
 tokio = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/ruvllm/Cargo.toml
+++ b/crates/ruvllm/Cargo.toml
@@ -108,7 +108,7 @@ objc = { version = "0.2", optional = true }
 
 # Lattice pure-Rust Qwen3.5 inference engine, Metal GPU forward pass
 # (macOS only, optional, default-OFF — see the `lattice` feature below).
-lattice-inference = { version = "0.6", optional = true, default-features = false, features = ["metal-gpu", "f16", "std"] }
+lattice-inference = { version = "0.6.1", optional = true, default-features = false, features = ["metal-gpu", "f16", "std"] }
 
 # Core ML bindings (macOS/iOS) - for Apple Neural Engine acceleration
 objc2 = { version = "0.6", optional = true }

--- a/npm/packages/ruvector-extensions/package.json
+++ b/npm/packages/ruvector-extensions/package.json
@@ -37,7 +37,7 @@
   "peerDependencies": {
     "openai": "^4.0.0",
     "cohere-ai": "^7.0.0",
-    "@khive-ai/lattice-embed-wasm": "^0.1.0"
+    "@khive-ai/lattice-embed-wasm": "^0.6.1"
   },
   "peerDependenciesMeta": {
     "openai": {


### PR DESCRIPTION
> _PR authored by an AI agent on behalf of @ohdearquant._

## Summary

Aligns ruvector's lattice integration with the current lattice release, **0.6.1** (published on crates.io and npm, `latest` on both). Touches both the Rust and the npm/wasm surfaces, because they were on different version lines and both were behind.

## Rust crates

- `crates/ruvector-core`: `lattice-embed` `0.6` → `0.6.1`
- `crates/ruvllm`: `lattice-inference` `0.6` → `0.6.1`
- `Cargo.lock`: refreshed via `cargo update --precise 0.6.1 -p lattice-embed -p lattice-inference`.
  - `lattice-embed`'s own `lru` dep advances `0.12` → `0.16` (its dependency, not ours).
  - The `windows-sys` entries advance to `0.61.2` as a side effect of cargo re-resolving against the current registry index. Windows-only; no effect on the Linux/macOS builds. No version **downgrades**.

The manifests previously used caret `"0.6"` (which already permitted 0.6.1), but the lockfile was pinned to `0.6.0` exactly, so `0.6.1` was never actually resolved. This makes the intent explicit and moves the lock.

0.6.1 is a patch release over 0.6.0 (wasm SIMD128 kernels in `lattice-embed`, inference-side MoE cache work, a dependency bump) with no breaking API changes.

## npm / wasm peer

- `npm/packages/ruvector-extensions`: optional peer `@khive-ai/lattice-embed-wasm` `^0.1.0` → `^0.6.1`.

The wasm package realigned its version scheme to match the Rust crate (npm now publishes `0.1.0` and `0.6.1`, with `latest` = `0.6.1`). The old caret `^0.1.0` means `>=0.1.0 <0.2.0`, so it could **never** pick up the published `0.6.1` build — the wasm embeddings were frozen a version line behind the Rust side.

Verified API-compatible before bumping (not just version-matched):

- `@khive-ai/lattice-embed-wasm@0.6.1` still exports `embed(text, model = DEFAULT_MODEL)` returning a `Float32Array` — exactly what `LatticeWasmEmbeddings.embedTexts` calls (`src/embeddings.ts`).
- It still supports the `minilm` (default) and `bge-small` models that `LATTICE_WASM_MODEL_DIMENSIONS` uses.

## Test plan

- [x] `cargo update` resolves cleanly (no transitive downgrades; only lattice + its `lru` dep + a Windows-only lockfile refresh).
- [x] Verified the wasm peer's public API (`embed(text, model)` + `minilm`/`bge-small`) is unchanged between the old and new versions by inspecting the published `0.6.1` tarball.
- Rust build with the `lattice-embeddings` / lattice `LlmBackend` features exercised by the existing feature-gated CI jobs.
