### PR TITLE
fix(ruvllm): back embeddings with a real pretrained model (lattice-embed, feature-gated) (#655)

### DIFF
--- a/examples/ruvLLM/Cargo.lock
+++ b/examples/ruvLLM/Cargo.lock
@@ -143,6 +143,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,7 +195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -192,13 +204,46 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -225,6 +270,25 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
@@ -321,6 +385,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +411,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -397,6 +484,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,33 +502,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ccf5ee3532e66868516d9b315f73aec9f34ea1a37ae98514534d458915dbf1"
 dependencies = [
  "byteorder",
- "candle-metal-kernels",
  "gemm 0.17.1",
  "half",
  "memmap2",
- "metal 0.27.0",
  "num-traits",
  "num_cpus",
  "rand 0.9.2",
  "rand_distr 0.5.1",
  "rayon",
- "safetensors",
+ "safetensors 0.4.5",
  "thiserror 1.0.69",
- "ug",
- "ug-metal",
+ "ug 0.1.0",
  "yoke 0.7.5",
- "zip",
+ "zip 1.1.4",
+]
+
+[[package]]
+name = "candle-core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15b675b80d994b2eadb20a4bbe434eabeb454eac3ee5e2b4cf6f147ee9be091"
+dependencies = [
+ "byteorder",
+ "candle-metal-kernels",
+ "candle-ug",
+ "float8",
+ "gemm 0.19.0",
+ "half",
+ "libm",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "objc2-foundation",
+ "objc2-metal",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
+ "rayon",
+ "safetensors 0.7.0",
+ "thiserror 2.0.18",
+ "yoke 0.8.1",
+ "zip 7.2.0",
 ]
 
 [[package]]
 name = "candle-metal-kernels"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c85c21827c28db94e7112e364abe7e0cf8d2b022c014edf08642be6b94f21e"
+checksum = "2fdfe9d06de16ce49961e49084e5b79a75a9bdf157246e7c7b6328e87a7aa25d"
 dependencies = [
- "metal 0.27.0",
+ "half",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
  "once_cell",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -445,15 +565,31 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1160c3b63f47d40d91110a3e1e1e566ae38edddbbf492a60b40ffc3bc1ff38"
 dependencies = [
- "candle-core",
- "candle-metal-kernels",
+ "candle-core 0.8.4",
  "half",
- "metal 0.27.0",
  "num-traits",
  "rayon",
- "safetensors",
+ "safetensors 0.4.5",
  "serde",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "candle-nn"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3045fa9e7aef8567d209a27d56b692f60b96f4d0569f4c3011f8ca6715c65e03"
+dependencies = [
+ "candle-core 0.9.2",
+ "candle-metal-kernels",
+ "half",
+ "libc",
+ "num-traits",
+ "objc2-metal",
+ "rayon",
+ "safetensors 0.7.0",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -463,9 +599,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94a0900d49f8605e0e7e6693a1f560e6271279de98e5fa369e7abf3aac245020"
 dependencies = [
  "byteorder",
- "candle-core",
- "candle-nn",
- "fancy-regex",
+ "candle-core 0.8.4",
+ "candle-nn 0.8.4",
+ "fancy-regex 0.13.0",
  "num-traits",
  "rand 0.9.2",
  "rayon",
@@ -473,6 +609,35 @@ dependencies = [
  "serde_json",
  "serde_plain",
  "tracing",
+]
+
+[[package]]
+name = "candle-transformers"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b538ec4aa807c416a2ddd3621044888f188827862e2a6fcacba4738e89795d01"
+dependencies = [
+ "byteorder",
+ "candle-core 0.9.2",
+ "candle-nn 0.9.2",
+ "fancy-regex 0.17.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rayon",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "tracing",
+]
+
+[[package]]
+name = "candle-ug"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d62be69068bf58987a45f690612739d8d2ea1bf508c1b87dc6815a019575d"
+dependencies = [
+ "ug 0.5.0",
+ "ug-metal",
 ]
 
 [[package]]
@@ -547,6 +712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -555,8 +721,22 @@ version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -602,6 +782,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -654,6 +840,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -910,6 +1105,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,10 +1265,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1085,6 +1310,18 @@ checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float8"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
+dependencies = [
+ "half",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
 ]
 
 [[package]]
@@ -1286,6 +1523,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "gemm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-c32 0.19.0",
+ "gemm-c64 0.19.0",
+ "gemm-common 0.19.0",
+ "gemm-f16 0.19.0",
+ "gemm-f32 0.19.0",
+ "gemm-f64 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.6.0",
+ "seq-macro",
+]
+
+[[package]]
 name = "gemm-c32"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1573,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "gemm-c32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.6.0",
+ "seq-macro",
+]
+
+[[package]]
 name = "gemm-c64"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,6 +1610,21 @@ checksum = "dfcad8a3d35a43758330b635d02edad980c1e143dc2f21e6fd25f9e4eada8edf"
 dependencies = [
  "dyn-stack 0.13.2",
  "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.6.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common 0.19.0",
  "num-complex",
  "num-traits",
  "paste",
@@ -1387,6 +1674,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "gemm-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+dependencies = [
+ "bytemuck",
+ "dyn-stack 0.13.2",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp 0.22.3",
+ "raw-cpuid 11.6.0",
+ "rayon",
+ "seq-macro",
+ "sysctl 0.6.0",
+]
+
+[[package]]
 name = "gemm-f16"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +1721,24 @@ dependencies = [
  "dyn-stack 0.13.2",
  "gemm-common 0.18.2",
  "gemm-f32 0.18.2",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.6.0",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common 0.19.0",
+ "gemm-f32 0.19.0",
  "half",
  "num-complex",
  "num-traits",
@@ -1453,6 +1779,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "gemm-f32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.6.0",
+ "seq-macro",
+]
+
+[[package]]
 name = "gemm-f64"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1816,21 @@ checksum = "35b2a4f76ce4b8b16eadc11ccf2e083252d8237c1b589558a49b0183545015bd"
 dependencies = [
  "dyn-stack 0.13.2",
  "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.6.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common 0.19.0",
  "num-complex",
  "num-traits",
  "paste",
@@ -1578,6 +1934,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1912,6 +2270,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,6 +2405,49 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "lattice-embed"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "188e4627dabd63544da5a57daabfe3105bf4d4970840f2e5a5c7f01123835ecb"
+dependencies = [
+ "async-trait",
+ "blake3",
+ "chrono",
+ "lattice-inference",
+ "lru",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "lattice-inference"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b113852e4c522b6607cd8e01842b5dff7de307d4cc9223dfd798b0136e2aa62b"
+dependencies = [
+ "axum 0.8.9",
+ "clap",
+ "futures",
+ "half",
+ "image",
+ "indexmap",
+ "memmap2",
+ "rayon",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "ureq",
 ]
 
 [[package]]
@@ -2177,6 +2593,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,21 +2637,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "metal"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
-dependencies = [
- "bitflags 2.10.0",
- "block",
- "core-graphics-types",
- "foreign-types 0.5.0",
- "log",
- "objc",
- "paste",
 ]
 
 [[package]]
@@ -2340,6 +2747,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "munge"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,6 +2861,22 @@ dependencies = [
  "portable-atomic-util",
  "rawpointer",
  "rayon",
+ "serde",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
  "serde",
 ]
 
@@ -2610,16 +3043,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
 ]
 
 [[package]]
-name = "objc_exception"
-version = "0.1.2"
+name = "objc2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
- "cc",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2852,6 +3328,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,6 +3476,35 @@ dependencies = [
  "reborrow",
  "version_check",
 ]
+
+[[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid 11.6.0",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
@@ -3329,6 +3847,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3405,7 +3929,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-attention"
-version = "0.1.31"
+version = "2.3.0"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -3415,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-core"
-version = "2.0.3"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3423,8 +3947,9 @@ dependencies = [
  "crossbeam",
  "dashmap",
  "hnsw_rs",
+ "lattice-embed",
  "memmap2",
- "ndarray",
+ "ndarray 0.16.1",
  "once_cell",
  "parking_lot",
  "rand 0.8.5",
@@ -3436,18 +3961,19 @@ dependencies = [
  "serde_json",
  "simsimd",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "ruvector-gnn"
-version = "2.0.3"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "dashmap",
  "libc",
- "ndarray",
+ "ndarray 0.17.2",
  "parking_lot",
  "rand 0.8.5",
  "rand_distr 0.4.3",
@@ -3460,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-graph"
-version = "2.0.3"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3473,7 +3999,7 @@ dependencies = [
  "lz4",
  "memmap2",
  "moka",
- "ndarray",
+ "ndarray 0.16.1",
  "nom",
  "nom_locate",
  "num_cpus",
@@ -3501,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "ruvector-sona"
-version = "0.1.5"
+version = "0.2.1"
 dependencies = [
  "crossbeam",
  "getrandom 0.2.17",
@@ -3518,12 +4044,12 @@ dependencies = [
  "ahash",
  "anyhow",
  "approx",
- "axum",
+ "axum 0.7.9",
  "bincode 2.0.1",
  "byteorder",
- "candle-core",
- "candle-nn",
- "candle-transformers",
+ "candle-core 0.8.4",
+ "candle-nn 0.8.4",
+ "candle-transformers 0.8.4",
  "chrono",
  "criterion",
  "crossbeam",
@@ -3536,7 +4062,7 @@ dependencies = [
  "memmap2",
  "napi",
  "napi-derive",
- "ndarray",
+ "ndarray 0.16.1",
  "once_cell",
  "parking_lot",
  "prometheus",
@@ -3549,7 +4075,7 @@ dependencies = [
  "ruvector-gnn",
  "ruvector-graph",
  "ruvector-sona",
- "ruvllm 2.0.3",
+ "ruvllm 2.3.0",
  "serde",
  "serde_json",
  "simsimd",
@@ -3568,22 +4094,21 @@ dependencies = [
 
 [[package]]
 name = "ruvllm"
-version = "2.0.3"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "bincode 2.0.1",
- "candle-core",
- "candle-nn",
- "candle-transformers",
+ "candle-core 0.9.2",
+ "candle-nn 0.9.2",
+ "candle-transformers 0.9.2",
  "chrono",
  "dashmap",
  "dirs",
  "futures-core",
  "half",
- "hf-hub",
  "md5",
- "ndarray",
+ "ndarray 0.16.1",
  "once_cell",
  "parking_lot",
  "rand 0.8.5",
@@ -3615,6 +4140,17 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
 dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
  "serde",
  "serde_json",
 ]
@@ -3769,7 +4305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3787,6 +4323,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -4098,7 +4644,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -4356,6 +4904,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4381,7 +4935,28 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "rayon",
- "safetensors",
+ "safetensors 0.4.5",
+ "serde",
+ "thiserror 1.0.69",
+ "tracing",
+ "yoke 0.7.5",
+]
+
+[[package]]
+name = "ug"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76b761acf8af3494640d826a8609e2265e19778fb43306c7f15379c78c9b05b0"
+dependencies = [
+ "gemm 0.18.2",
+ "half",
+ "libloading",
+ "memmap2",
+ "num",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+ "safetensors 0.4.5",
  "serde",
  "thiserror 1.0.69",
  "tracing",
@@ -4390,16 +4965,16 @@ dependencies = [
 
 [[package]]
 name = "ug-metal"
-version = "0.1.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a02ddc17bf32f7dcaaf016b6735f7198082b82f122df7b3ca15d8ead5911ccef"
+checksum = "9f7adf545a99a086d362efc739e7cf4317c18cbeda22706000fd434d70ea3d95"
 dependencies = [
  "half",
- "metal 0.29.0",
+ "metal",
  "objc",
  "serde",
  "thiserror 1.0.69",
- "ug",
+ "ug 0.5.0",
 ]
 
 [[package]]
@@ -5182,6 +5757,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+ "memchr",
+ "typed-path",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5213,4 +5800,19 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/examples/ruvLLM/Cargo.toml
+++ b/examples/ruvLLM/Cargo.toml
@@ -100,6 +100,12 @@ server = ["axum", "tower", "tower-http"]
 real-inference = ["candle-core", "candle-nn", "candle-transformers", "hf-hub", "tokenizers", "memmap2", "byteorder", "half", "dirs"]
 # HuggingFace export for learned patterns and LoRA weights
 hf-export = ["ruvector-sona"]
+# Real pretrained sentence embeddings via lattice-embed (through ruvector-core).
+# Opt-in: enabling this raises the effective MSRV to Rust >= 1.93 (lattice-embed 0.6,
+# edition 2024) and makes a pretrained model a runtime dependency. Off by default so the
+# base package keeps its current build/footprint; the embedder backend is selected at
+# runtime when this feature is compiled in.
+lattice-embeddings = ["ruvector-core/lattice-embeddings"]
 # N-API bindings for Node.js
 napi = ["dep:napi", "dep:napi-derive"]
 # Multi-threaded GEMM/GEMV with rayon (4-6x speedup)

--- a/examples/ruvLLM/src/embedding.rs
+++ b/examples/ruvLLM/src/embedding.rs
@@ -1,14 +1,35 @@
 //! Embedding service with tokenization and caching
 //!
 //! Provides text-to-vector conversion with LRU caching for efficiency.
+//!
+//! Two backends are available:
+//! - **Random** (default): a random-init character-level matrix + sinusoidal
+//!   positions + mean-pooling. Fast, requires no download, but **not
+//!   semantic** — it does not discriminate between related and unrelated
+//!   text (see `EmbeddingBackend::Random`'s docs below).
+//! - **Lattice** (feature `lattice-embeddings`, opt-in): real pretrained
+//!   sentence embeddings via [`ruvector_core::embeddings::LatticeEmbedding`],
+//!   a pure-Rust native embedder (no ONNX Runtime, no C++ FFI). Selected at
+//!   runtime by requesting a model id (see [`EmbeddingService::new`]); a
+//!   pretrained model is a ~90-130MB download on first use, so this backend
+//!   is never enabled implicitly.
 
 use crate::config::EmbeddingConfig;
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 use ahash::AHashMap;
 use lru::LruCache;
 use parking_lot::Mutex;
 use std::num::NonZeroUsize;
+
+#[cfg(feature = "lattice-embeddings")]
+use ruvector_core::embeddings::{EmbeddingProvider, LatticeEmbedding};
+
+/// Environment variable used to request a pretrained model id for the
+/// `lattice-embeddings` backend (e.g. `"minilm"`, `"bge-small-en-v1.5"`).
+/// Only consulted when the `lattice-embeddings` feature is compiled in; the
+/// default build never reads it.
+pub const RUVLLM_EMBED_MODEL_ENV: &str = "RUVLLM_EMBED_MODEL";
 
 /// Result of embedding a text
 #[derive(Debug, Clone)]
@@ -131,34 +152,26 @@ impl Tokenizer {
     }
 }
 
-/// Service for text embedding with caching
-pub struct EmbeddingService {
-    /// Embedding dimension
+/// Random-init character-level embedder: matrix + sinusoidal positions +
+/// pooling. This is the original (and default) `EmbeddingService` behavior,
+/// moved verbatim into its own type so it can sit behind
+/// [`EmbeddingBackend::Random`].
+///
+/// ⚠️ **Not semantic.** The embedding matrix is initialized from uniform
+/// random noise and never trained or loaded from a checkpoint, so cosine
+/// similarity between texts does not track meaning — unrelated pairs can
+/// score higher than genuine paraphrases. Use the `lattice-embeddings`
+/// feature (see [`EmbeddingBackend::Lattice`]) for real semantic embeddings.
+struct RandomEmbedder {
     dimension: usize,
-    /// Maximum tokens
     max_tokens: usize,
-    /// Tokenizer
     tokenizer: Tokenizer,
-    /// LRU cache for embeddings
-    cache: Mutex<LruCache<u64, Embedding>>,
-    /// Embedding matrix (token_id -> embedding)
     embedding_matrix: Vec<Vec<f32>>,
-    /// Position embeddings
     position_embeddings: Vec<Vec<f32>>,
-    /// Statistics
-    stats: EmbeddingStats,
 }
 
-/// Embedding service statistics
-struct EmbeddingStats {
-    cache_hits: std::sync::atomic::AtomicU64,
-    cache_misses: std::sync::atomic::AtomicU64,
-    total_tokens: std::sync::atomic::AtomicU64,
-}
-
-impl EmbeddingService {
-    /// Create a new embedding service
-    pub fn new(config: &EmbeddingConfig) -> Result<Self> {
+impl RandomEmbedder {
+    fn new(config: &EmbeddingConfig) -> Self {
         let tokenizer = Tokenizer::new(10000);
         let vocab_size = tokenizer.vocab_size();
 
@@ -197,78 +210,34 @@ impl EmbeddingService {
             })
             .collect();
 
-        let cache_size = NonZeroUsize::new(10000).unwrap();
-
-        Ok(Self {
+        Self {
             dimension: config.dimension,
             max_tokens: config.max_tokens,
             tokenizer,
-            cache: Mutex::new(LruCache::new(cache_size)),
             embedding_matrix,
             position_embeddings,
-            stats: EmbeddingStats {
-                cache_hits: std::sync::atomic::AtomicU64::new(0),
-                cache_misses: std::sync::atomic::AtomicU64::new(0),
-                total_tokens: std::sync::atomic::AtomicU64::new(0),
-            },
-        })
+        }
     }
 
-    /// Embed a text string
-    pub fn embed(&self, text: &str) -> Result<Embedding> {
-        // Check cache
-        let hash = self.hash_text(text);
-        {
-            let mut cache = self.cache.lock();
-            if let Some(cached) = cache.get(&hash) {
-                self.stats
-                    .cache_hits
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                let mut result = cached.clone();
-                result.from_cache = true;
-                return Ok(result);
-            }
-        }
-        self.stats
-            .cache_misses
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
-        // Tokenize
+    /// Tokenize, truncate, mean-pool, and wrap into a fully-formed
+    /// `Embedding` (token/truncation bookkeeping matches this backend's own
+    /// character-level tokenizer).
+    fn embed(&self, text: &str) -> Embedding {
         let tokens = self.tokenizer.tokenize(text);
-        let token_count = tokens.len();
-        let truncated = token_count > self.max_tokens;
+        let truncated = tokens.len() > self.max_tokens;
         let tokens: Vec<u32> = tokens.into_iter().take(self.max_tokens).collect();
 
-        self.stats
-            .total_tokens
-            .fetch_add(tokens.len() as u64, std::sync::atomic::Ordering::Relaxed);
-
-        // Compute embedding
         let vector = self.compute_embedding(&tokens);
 
-        let embedding = Embedding {
+        Embedding {
             vector,
             token_count: tokens.len(),
             truncated,
             from_cache: false,
-        };
-
-        // Cache result
-        {
-            let mut cache = self.cache.lock();
-            cache.put(hash, embedding.clone());
         }
-
-        Ok(embedding)
     }
 
-    /// Embed multiple texts (batched for efficiency)
-    pub fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Embedding>> {
-        texts.iter().map(|t| self.embed(t)).collect()
-    }
-
-    /// Embed with specific pooling strategy
-    pub fn embed_with_pooling(&self, text: &str, pooling: PoolingStrategy) -> Result<Embedding> {
+    fn embed_with_pooling(&self, text: &str, pooling: PoolingStrategy) -> Embedding {
         let tokens = self.tokenizer.tokenize(text);
         let tokens: Vec<u32> = tokens.into_iter().take(self.max_tokens).collect();
 
@@ -279,45 +248,12 @@ impl EmbeddingService {
             PoolingStrategy::LastToken => self.last_token_pooling(&tokens),
         };
 
-        Ok(Embedding {
+        Embedding {
             vector,
             token_count: tokens.len(),
             truncated: tokens.len() >= self.max_tokens,
             from_cache: false,
-        })
-    }
-
-    /// Get embedding statistics
-    pub fn get_stats(&self) -> EmbeddingServiceStats {
-        EmbeddingServiceStats {
-            cache_hits: self
-                .stats
-                .cache_hits
-                .load(std::sync::atomic::Ordering::Relaxed),
-            cache_misses: self
-                .stats
-                .cache_misses
-                .load(std::sync::atomic::Ordering::Relaxed),
-            total_tokens: self
-                .stats
-                .total_tokens
-                .load(std::sync::atomic::Ordering::Relaxed),
-            cache_size: self.cache.lock().len(),
         }
-    }
-
-    /// Clear the embedding cache
-    pub fn clear_cache(&self) {
-        self.cache.lock().clear();
-    }
-
-    fn hash_text(&self, text: &str) -> u64 {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-
-        let mut hasher = DefaultHasher::new();
-        text.hash(&mut hasher);
-        hasher.finish()
     }
 
     fn compute_embedding(&self, tokens: &[u32]) -> Vec<f32> {
@@ -433,6 +369,248 @@ impl EmbeddingService {
     }
 }
 
+/// The backend actually used to compute embedding vectors.
+enum EmbeddingBackend {
+    /// Random-init character-level matrix (default; not semantic — see
+    /// [`RandomEmbedder`]'s docs).
+    Random(RandomEmbedder),
+    /// Real pretrained sentence embeddings via `lattice-embed`, through
+    /// [`ruvector_core::embeddings::LatticeEmbedding`]. Selected at runtime
+    /// when a model id is requested (config field or
+    /// [`RUVLLM_EMBED_MODEL_ENV`]); never enabled implicitly.
+    #[cfg(feature = "lattice-embeddings")]
+    Lattice(LatticeEmbedding),
+}
+
+impl EmbeddingBackend {
+    /// Human-readable backend label for [`EmbeddingServiceStats::backend`]
+    /// (e.g. `"random-charlevel"` / `"lattice:bge-small-en-v1.5"`).
+    fn label(&self) -> String {
+        match self {
+            EmbeddingBackend::Random(_) => "random-charlevel".to_string(),
+            #[cfg(feature = "lattice-embeddings")]
+            EmbeddingBackend::Lattice(l) => format!("lattice:{}", l.name()),
+        }
+    }
+
+    fn is_pretrained(&self) -> bool {
+        match self {
+            EmbeddingBackend::Random(_) => false,
+            #[cfg(feature = "lattice-embeddings")]
+            EmbeddingBackend::Lattice(_) => true,
+        }
+    }
+}
+
+/// Service for text embedding with caching
+pub struct EmbeddingService {
+    /// Embedding dimension actually produced by the active backend (may
+    /// differ from `config.dimension` when a pretrained model is loaded —
+    /// e.g. bge-small is 384D regardless of what `config.dimension` requested).
+    dimension: usize,
+    /// LRU cache for embeddings
+    cache: Mutex<LruCache<u64, Embedding>>,
+    /// Active embedding backend
+    backend: EmbeddingBackend,
+    /// Statistics
+    stats: EmbeddingStats,
+}
+
+/// Embedding service statistics
+struct EmbeddingStats {
+    cache_hits: std::sync::atomic::AtomicU64,
+    cache_misses: std::sync::atomic::AtomicU64,
+    total_tokens: std::sync::atomic::AtomicU64,
+}
+
+impl EmbeddingService {
+    /// Create a new embedding service.
+    ///
+    /// By default this builds the random-init character-level backend
+    /// (`EmbeddingBackend::Random`) — fast, no download, but not semantic.
+    ///
+    /// A real pretrained backend can be selected at runtime by requesting a
+    /// model id via the `RUVLLM_EMBED_MODEL` environment variable (e.g.
+    /// `"minilm"`, `"bge-small-en-v1.5"`) **and** compiling with the
+    /// `lattice-embeddings` feature. If a model is requested but the feature
+    /// is not compiled in, or the feature is compiled in but the requested
+    /// model fails to load (bad id, network/download failure), this returns
+    /// an error rather than silently falling back to the random backend — an
+    /// explicitly-requested pretrained model that can't load is a real
+    /// failure.
+    pub fn new(config: &EmbeddingConfig) -> Result<Self> {
+        let requested_model = std::env::var(RUVLLM_EMBED_MODEL_ENV).ok();
+
+        let backend = match requested_model {
+            Some(model_id) if !model_id.trim().is_empty() => {
+                Self::load_lattice_backend(&model_id)?
+            }
+            _ => EmbeddingBackend::Random(RandomEmbedder::new(config)),
+        };
+
+        let dimension = match &backend {
+            EmbeddingBackend::Random(_) => config.dimension,
+            #[cfg(feature = "lattice-embeddings")]
+            EmbeddingBackend::Lattice(l) => l.dimensions(),
+        };
+
+        let cache_size = NonZeroUsize::new(10000).unwrap();
+
+        Ok(Self {
+            dimension,
+            cache: Mutex::new(LruCache::new(cache_size)),
+            backend,
+            stats: EmbeddingStats {
+                cache_hits: std::sync::atomic::AtomicU64::new(0),
+                cache_misses: std::sync::atomic::AtomicU64::new(0),
+                total_tokens: std::sync::atomic::AtomicU64::new(0),
+            },
+        })
+    }
+
+    #[cfg(feature = "lattice-embeddings")]
+    fn load_lattice_backend(model_id: &str) -> Result<EmbeddingBackend> {
+        let provider = LatticeEmbedding::from_pretrained(model_id).map_err(|e| {
+            Error::Embedding(format!(
+                "requested pretrained model '{model_id}' via {RUVLLM_EMBED_MODEL_ENV} \
+                 failed to load: {e}"
+            ))
+        })?;
+        Ok(EmbeddingBackend::Lattice(provider))
+    }
+
+    #[cfg(not(feature = "lattice-embeddings"))]
+    fn load_lattice_backend(model_id: &str) -> Result<EmbeddingBackend> {
+        Err(Error::Embedding(format!(
+            "pretrained model '{model_id}' requested via {RUVLLM_EMBED_MODEL_ENV}, but this \
+             build was compiled without the `lattice-embeddings` feature. Rebuild with \
+             `--features lattice-embeddings` to use a pretrained backend, or unset \
+             {RUVLLM_EMBED_MODEL_ENV} to use the default random backend."
+        )))
+    }
+
+    /// Embed a text string
+    pub fn embed(&self, text: &str) -> Result<Embedding> {
+        // Check cache
+        let hash = self.hash_text(text);
+        {
+            let mut cache = self.cache.lock();
+            if let Some(cached) = cache.get(&hash) {
+                self.stats
+                    .cache_hits
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let mut result = cached.clone();
+                result.from_cache = true;
+                return Ok(result);
+            }
+        }
+        self.stats
+            .cache_misses
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let embedding = match &self.backend {
+            EmbeddingBackend::Random(random) => random.embed(text),
+            #[cfg(feature = "lattice-embeddings")]
+            EmbeddingBackend::Lattice(lattice) => {
+                // Symmetric STS/similarity usage: always the passage side.
+                // `EmbeddingProvider::embed` never applies a query
+                // instruction (see `LatticeEmbedding`'s docs) — callers that
+                // need asymmetric query/passage retrieval should use
+                // `LatticeEmbedding::embed_query` directly, which this napi
+                // surface does not expose.
+                let vector = lattice
+                    .embed(text)
+                    .map_err(|e| Error::Embedding(format!("lattice-embed inference failed: {e}")))?;
+                Embedding {
+                    vector,
+                    // Informational only: the pretrained backend uses its
+                    // own subword tokenizer internally, not the char-level
+                    // `Tokenizer` above.
+                    token_count: text.split_whitespace().count(),
+                    truncated: false,
+                    from_cache: false,
+                }
+            }
+        };
+
+        self.stats
+            .total_tokens
+            .fetch_add(embedding.token_count as u64, std::sync::atomic::Ordering::Relaxed);
+
+        // Cache result
+        {
+            let mut cache = self.cache.lock();
+            cache.put(hash, embedding.clone());
+        }
+
+        Ok(embedding)
+    }
+
+    /// Embed multiple texts (batched for efficiency)
+    pub fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Embedding>> {
+        texts.iter().map(|t| self.embed(t)).collect()
+    }
+
+    /// Embed with specific pooling strategy.
+    ///
+    /// Pooling strategies (mean/max/CLS/last-token) are a property of the
+    /// `Random` backend's own token+position matrices. The `Lattice` backend
+    /// performs its own pooling internally (mean-pooling over the
+    /// transformer's hidden states, L2-normalized) and has no separate
+    /// per-strategy output, so on that backend this ignores `pooling` and
+    /// returns the same vector as [`EmbeddingService::embed`].
+    pub fn embed_with_pooling(&self, text: &str, pooling: PoolingStrategy) -> Result<Embedding> {
+        match &self.backend {
+            EmbeddingBackend::Random(random) => Ok(random.embed_with_pooling(text, pooling)),
+            #[cfg(feature = "lattice-embeddings")]
+            EmbeddingBackend::Lattice(_) => self.embed(text),
+        }
+    }
+
+    /// Effective embedding dimension of the active backend. Matches
+    /// `config.dimension` on the default random backend; may differ from it
+    /// on the `lattice-embeddings` backend, where the loaded pretrained
+    /// model's own dimensionality wins (e.g. bge-small is always 384D).
+    pub fn dimension(&self) -> usize {
+        self.dimension
+    }
+
+    /// Get embedding statistics
+    pub fn get_stats(&self) -> EmbeddingServiceStats {
+        EmbeddingServiceStats {
+            cache_hits: self
+                .stats
+                .cache_hits
+                .load(std::sync::atomic::Ordering::Relaxed),
+            cache_misses: self
+                .stats
+                .cache_misses
+                .load(std::sync::atomic::Ordering::Relaxed),
+            total_tokens: self
+                .stats
+                .total_tokens
+                .load(std::sync::atomic::Ordering::Relaxed),
+            cache_size: self.cache.lock().len(),
+            backend: self.backend.label(),
+            pretrained: self.backend.is_pretrained(),
+        }
+    }
+
+    /// Clear the embedding cache
+    pub fn clear_cache(&self) {
+        self.cache.lock().clear();
+    }
+
+    fn hash_text(&self, text: &str) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let mut hasher = DefaultHasher::new();
+        text.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
 /// Pooling strategy for embeddings
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PoolingStrategy {
@@ -457,6 +635,13 @@ pub struct EmbeddingServiceStats {
     pub total_tokens: u64,
     /// Current cache size
     pub cache_size: usize,
+    /// Active backend label, e.g. `"random-charlevel"` or
+    /// `"lattice:bge-small-en-v1.5"`. Lets a caller distinguish the
+    /// non-semantic default from a loaded pretrained model.
+    pub backend: String,
+    /// Whether the active backend is a real pretrained model (`true`) or
+    /// the random-init default (`false`).
+    pub pretrained: bool,
 }
 
 #[cfg(test)]
@@ -584,6 +769,8 @@ mod tests {
         let stats = service.get_stats();
         assert_eq!(stats.cache_hits, 1);
         assert_eq!(stats.cache_misses, 2);
+        assert_eq!(stats.backend, "random-charlevel");
+        assert!(!stats.pretrained);
     }
 
     #[test]
@@ -608,5 +795,145 @@ mod tests {
 
         service.clear_cache();
         assert_eq!(service.get_stats().cache_size, 0);
+    }
+
+}
+
+/// Discrimination regression test (issue #655, ask #2): asserts that every
+/// paraphrase pair scores a higher cosine similarity than every unrelated
+/// pair.
+///
+/// Gated `#[ignore]` unconditionally: it downloads a pretrained model over
+/// the network on first run, so it must never fire from a plain `cargo
+/// test`. Compiles in both the default and `lattice-embeddings` builds (it
+/// only touches the public `EmbeddingService` API), but can only actually
+/// pass in the `lattice-embeddings` build — without that feature,
+/// `EmbeddingService::new` fails fast (see
+/// `EmbeddingService::load_lattice_backend`) because a model was
+/// explicitly requested. This is the mutation-sensitivity property required
+/// by #655 ask #2: the assertion fails against the random backend (verified
+/// manually against `RandomEmbedder` during development — see the PR
+/// description for the observed before/after cosine tables) and passes only
+/// once real pretrained embeddings are wired in.
+///
+/// Run with: `RUVLLM_EMBED_MODEL=minilm cargo test --features
+/// lattice-embeddings -- --ignored discriminat`
+#[cfg(test)]
+mod discrimination {
+    use super::*;
+
+    fn cosine(a: &[f32], b: &[f32]) -> f32 {
+        let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+        let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm_a == 0.0 || norm_b == 0.0 {
+            0.0
+        } else {
+            dot / (norm_a * norm_b)
+        }
+    }
+
+    #[test]
+    #[ignore = "needs the lattice-embeddings feature and downloads a model over the \
+                network; run: RUVLLM_EMBED_MODEL=minilm cargo test --features \
+                lattice-embeddings -- --ignored discriminat"]
+    fn lattice_embeddings_discriminate() {
+        let model_id =
+            std::env::var(RUVLLM_EMBED_MODEL_ENV).unwrap_or_else(|_| "minilm".to_string());
+        // SAFETY: single-threaded test process (this test is `--ignored`,
+        // always run in isolation), no concurrent env access.
+        unsafe {
+            std::env::set_var(RUVLLM_EMBED_MODEL_ENV, &model_id);
+        }
+
+        let config = EmbeddingConfig::default();
+        let service = EmbeddingService::new(&config)
+            .unwrap_or_else(|e| panic!("failed to load pretrained model '{model_id}': {e}"));
+        assert!(
+            service.get_stats().pretrained,
+            "service must report pretrained=true once a real model is loaded"
+        );
+
+        // (text, paraphrase, unrelated)
+        let corpus: [(&str, &str, &str); 6] = [
+            (
+                "The cat sat on the mat.",
+                "A cat was sitting on the rug.",
+                "The stock market crashed yesterday.",
+            ),
+            (
+                "How do I reset my password?",
+                "What is the process to change my login password?",
+                "The recipe calls for two cups of flour.",
+            ),
+            (
+                "The weather today is sunny and warm.",
+                "It's a bright, warm day outside.",
+                "The quarterly earnings report was released.",
+            ),
+            (
+                "She enjoys playing the piano in the evening.",
+                "In the evenings she likes to play piano.",
+                "The bridge was constructed in 1932.",
+            ),
+            (
+                "The car broke down on the highway.",
+                "The vehicle stalled on the freeway.",
+                "He studied biology at the university.",
+            ),
+            (
+                "Machine learning models require large datasets.",
+                "Training ML models needs a lot of data.",
+                "The garden was full of blooming roses.",
+            ),
+        ];
+
+        let mut paraphrase_scores = Vec::with_capacity(corpus.len());
+        let mut unrelated_scores = Vec::with_capacity(corpus.len());
+        let mut table = String::new();
+        table.push_str("text | paraphrase_sim | unrelated_sim\n");
+
+        for (text, paraphrase, unrelated) in corpus {
+            let e_text = service.embed(text).unwrap();
+            let e_paraphrase = service.embed(paraphrase).unwrap();
+            let e_unrelated = service.embed(unrelated).unwrap();
+
+            let sim_paraphrase = cosine(&e_text.vector, &e_paraphrase.vector);
+            let sim_unrelated = cosine(&e_text.vector, &e_unrelated.vector);
+
+            table.push_str(&format!(
+                "{text:?} | {sim_paraphrase:.4} | {sim_unrelated:.4}\n"
+            ));
+
+            paraphrase_scores.push(sim_paraphrase);
+            unrelated_scores.push(sim_unrelated);
+        }
+
+        println!("model={model_id}\n{table}");
+
+        let min_paraphrase = paraphrase_scores
+            .iter()
+            .copied()
+            .fold(f32::INFINITY, f32::min);
+        let max_unrelated = unrelated_scores
+            .iter()
+            .copied()
+            .fold(f32::NEG_INFINITY, f32::max);
+
+        println!(
+            "min(paraphrase_sim)={min_paraphrase:.4} max(unrelated_sim)={max_unrelated:.4}"
+        );
+
+        for (i, (&p, &u)) in paraphrase_scores.iter().zip(unrelated_scores.iter()).enumerate() {
+            assert!(
+                p > u,
+                "pair {i}: paraphrase similarity ({p:.4}) must exceed unrelated similarity ({u:.4})"
+            );
+        }
+
+        assert!(
+            min_paraphrase > max_unrelated,
+            "min(paraphrase_sim)={min_paraphrase:.4} must exceed max(unrelated_sim)={max_unrelated:.4}"
+        );
     }
 }


### PR DESCRIPTION
> _PR authored by an AI agent on behalf of @ohdearquant._

Fixes #655. Design decision for the default: #694.

## Problem

`@ruvector/ruvllm`'s `embed()`/`similarity` are non-discriminative — `EmbeddingService`
(`examples/ruvLLM/src/embedding.rs`) builds a **random-init character-level** matrix, never
loaded from any checkpoint, so unrelated pairs frequently out-score paraphrases (all values
collapse into a ~0.91–1.0 band).

## Fix

Back `EmbeddingService` with a **real pretrained** embedder — `ruvector_core::embeddings::LatticeEmbedding`
(already in `ruvector-core` behind the `lattice-embeddings` feature) — via an internal backend enum,
selected at runtime. Public method signatures and the `Embedding` struct are unchanged, so `napi.rs`
is untouched.

```rust
enum EmbeddingBackend {
    Random(RandomEmbedder),                 // existing logic, lifted verbatim into its own type
    #[cfg(feature = "lattice-embeddings")]
    Lattice(LatticeEmbedding),
}
```

- **Default is unchanged.** Without the `lattice-embeddings` feature, the build, footprint, and
  behavior are exactly as before (random backend). Whether the pretrained embedder should become
  the *default* — and carry a ~90–130 MB model download into the published package — is a
  distribution decision for the maintainer, raised in **#694**. This PR wires option B (opt-in);
  flipping to default-on is a small follow-up once #694 is decided.
- **No silent fallback.** When the feature is compiled in and `RUVLLM_EMBED_MODEL` selects a model,
  a load failure is a hard error, never a quiet drop back to random.
- **Visibility (issue ask #3).** `EmbeddingServiceStats` gains `backend: String`
  (`"random-charlevel"` / `"lattice:BAAI/bge-small-en-v1.5"`) and `pretrained: bool`, so the
  random-vs-pretrained state is inspectable rather than silent. (Left on the Rust stats struct;
  `get_stats()` has no current napi caller to extend without adding new napi surface.)

## Discrimination proof (real model, real numbers)

Methodology: model = MiniLM (`RUVLLM_EMBED_MODEL=minilm`), passage-side `embed()` for both texts of
each pair, cosine similarity; fixed 6-item corpus (each item: one paraphrase pair + one unrelated
pair). Reproduce:

```
RUVLLM_EMBED_MODEL=minilm cargo test --features lattice-embeddings -- --ignored --nocapture discriminat
```

| text | paraphrase_sim | unrelated_sim |
|---|---:|---:|
| "The cat sat on the mat." | 0.7396 | 0.1104 |
| "How do I reset my password?" | 0.7213 | 0.0625 |
| "The weather today is sunny and warm." | 0.7594 | −0.0239 |
| "She enjoys playing the piano in the evening." | 0.8673 | −0.0611 |
| "The car broke down on the highway." | 0.5833 | 0.0133 |
| "Machine learning models require large datasets." | 0.7965 | 0.0545 |

`min(paraphrase)=0.5833 > max(unrelated)=0.1104` — every paraphrase beats every unrelated pair,
with a wide margin. Contrast the **random** backend on the identical corpus (measured, not
asserted): values collapse into a 0.96–1.0 band and at least one pair inverts
(`paraphrase_sim=0.9641 < unrelated_sim=0.9821`) — the exact failure #655 describes.

## Regression test

`lattice_embeddings_discriminate` (in `embedding.rs`) asserts `min(paraphrase) > max(unrelated)`
across the corpus. `#[ignore]`d by default because it downloads a model and needs the
`lattice-embeddings` feature; run it with the command above.

## Test plan

- [x] Discrimination proof above (real MiniLM run).
- [x] Default build (`cargo build` / `cargo test --lib`, no feature): unchanged, all existing
      embedding tests pass, `Embedding`/napi shapes intact.
- [x] `cargo clippy --features lattice-embeddings -- -D warnings` clean (one pre-existing
      `SpecialTokens.pad` dead-code finding predates this change).
- [ ] Maintainer decision on #694 (default-on vs opt-in, model choice, bundle-vs-lazy-download).
