### PR TITLE
fix(mcp): start the MCP server when launched via `ruvector mcp start`

### DIFF
--- a/npm/packages/ruvector/bin/cli.js
+++ b/npm/packages/ruvector/bin/cli.js
@@ -8144,7 +8144,14 @@ mcpCmd.command('start')
       console.error(chalk.red('Error: MCP server not found at'), mcpServerPath);
       process.exit(1);
     }
-    require(mcpServerPath);
+    // require() alone is not enough: mcp-server.js only self-starts under
+    // `require.main === module`, which is false when it is loaded from here.
+    // Start it explicitly, or the process comes up without ever connecting a
+    // transport and never answers `initialize`.
+    require(mcpServerPath).main().catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
   });
 
 mcpCmd.command('info')

--- a/npm/packages/ruvector/bin/mcp-server.js
+++ b/npm/packages/ruvector/bin/mcp-server.js
@@ -4087,5 +4087,9 @@ async function main() {
 if (require.main === module) {
   main().catch(console.error);
 } else {
-  module.exports = { loadBrainClient, BRAIN_MISSING_DEP_RESULT };
+  // `main` is exported so a parent module can start the server explicitly.
+  // `ruvector mcp start` require()s this file, which makes require.main the
+  // CLI rather than this module — so the branch above never fires and the
+  // transport is never connected. See bin/cli.js.
+  module.exports = { main, loadBrainClient, BRAIN_MISSING_DEP_RESULT };
 }

--- a/npm/packages/ruvector/src/core/onnx/loader.js
+++ b/npm/packages/ruvector/src/core/onnx/loader.js
@@ -150,7 +150,7 @@ export class ModelLoader {
             }
         }
 
-        console.log(`Loading model: ${modelConfig.name} (${modelConfig.size})`);
+        console.error(`Loading model: ${modelConfig.name} (${modelConfig.size})`);
 
         const [modelBytes, tokenizerJson] = await Promise.all([
             this.fetchWithCache(modelConfig.model, `${modelName}-model.onnx`, 'arraybuffer'),
@@ -196,7 +196,7 @@ export class ModelLoader {
             const modelBytes = new Uint8Array(fs.readFileSync(modelPath));
             const tokenizerJson = fs.readFileSync(tokPath, 'utf8');
             if (modelBytes.length === 0 || tokenizerJson.length === 0) return null;
-            console.log(`  Disk cache hit: ${modelName}`);
+            console.error(`  Disk cache hit: ${modelName}`);
             return { modelBytes, tokenizerJson };
         } catch {
             return null;
@@ -274,7 +274,7 @@ export class ModelLoader {
                 const cache = await caches.open(this.cacheStorage);
                 const cached = await cache.match(cacheKey);
                 if (cached) {
-                    console.log(`  Cache hit: ${cacheKey}`);
+                    console.error(`  Cache hit: ${cacheKey}`);
                     return responseType === 'arraybuffer'
                         ? await cached.arrayBuffer()
                         : await cached.text();
@@ -285,7 +285,7 @@ export class ModelLoader {
         }
 
         // Fetch from network
-        console.log(`  Downloading: ${url}`);
+        console.error(`  Downloading: ${url}`);
         const response = await this.fetchWithProgress(url);
 
         if (!response.ok) {
@@ -365,7 +365,7 @@ export class ModelLoader {
     async clearCache() {
         if (typeof caches !== 'undefined') {
             await caches.delete(this.cacheStorage);
-            console.log('Model cache cleared');
+            console.error('Model cache cleared');
         }
     }
 


### PR DESCRIPTION
## Problem

`ruvector mcp start` never starts a server. A client that sends `initialize` over stdio gets **no response** — verified with a 150s probe against 0.2.35.

`bin/cli.js` loads the server with `require(mcpServerPath)`:

```js
require(mcpServerPath);
```

but `bin/mcp-server.js` only self-starts under:

```js
if (require.main === module) {
  main().catch(console.error);
}
```

Loaded from the CLI, `require.main` is `cli.js`, so that branch never fires. The process comes up, loads the ONNX model and spawns its workers, but never constructs a `StdioServerTransport`.

### Knock-on effect: leaked processes

Because no transport is connected, the client cannot shut the process down, and `process.stdin.on('end', ...)` — registered inside `main()` — never gets installed. Every session start strands a ~300MB / 19-worker process.

Measured across a 29-host fleet: **324 orphaned processes, ~101GB RSS**. One long-uptime host had accumulated **312 of them (98GB)**.

### Why `mcp test` reports success

`mcp test` checks that `mcp-server.js` exists and that tools are registered. It never performs a handshake, so it prints `All checks passed / 97 tools registered` for a server that never starts. That is worth addressing separately — it is the reason this looks healthy.

## Second defect: stdout pollution

`src/core/onnx/loader.js` logged progress via `console.log`. Stdout in a stdio MCP server must carry only newline-delimited JSON-RPC, so `  Disk cache hit: <model>` corrupts the stream. This would keep the server broken even after the launch fix, so both are in this PR. The five calls now use `console.error`, matching `mcp-server.js`, which already reports its startup line on stderr.

## Verification

Against the real installed 0.2.35 package with these patches applied:

| Check | Before | After |
|---|---|---|
| `initialize` response | none in 150s | immediate |
| `tools/list` | — | 97 tools |
| Non-JSON bytes on stdout | present | 0 |
| `claude mcp get ruvector` | timeout after 30000ms | Connected |
| Orphans after 2 health checks | +2 | 0 |

## Not verified

**I could not run `npm test` on Linux.** `npm install` fails with `EBADPLATFORM`: `@ruvector/router-darwin-arm64` is declared as a regular dependency rather than an optional/platform-gated one, so installation aborts on any non-darwin host. That is pre-existing and unrelated to this change, but it means the suite here is unrun and CI should be the gate.

Note there is no handshake test in the suite (`test/mcp-policy.js`, `test/startup-budget.js`, `test/sigterm-cleanup.js` cover adjacent ground), which is consistent with this shipping unnoticed. A test that spawns `ruvector mcp start` and asserts an `initialize` response would prevent a recurrence.

`dist/` is untracked and `build` does `cpSync('src/core/onnx' -> 'dist/core/onnx')`, so the loader change propagates on publish; no built artifact needed in this PR.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)