### PR TITLE
test: verify live MCP handshake and tools/list

### DIFF
--- a/npm/packages/ruvector/bin/cli.js
+++ b/npm/packages/ruvector/bin/cli.js
@@ -8390,7 +8390,7 @@ mcpCmd.command('tools')
 
 mcpCmd.command('test')
   .description('Test MCP server setup and tool registration')
-  .action(() => {
+  .action(async () => {
     console.log(chalk.bold.cyan('\nMCP Server Test Results'));
     console.log(chalk.dim('-'.repeat(40)));
 
@@ -8455,6 +8455,87 @@ mcpCmd.command('test')
         console.log(`  ${match ? chalk.green('PASS') : chalk.yellow('WARN')} Server version: ${verMatch[1]}${match ? '' : ` (package: ${pkg.version})`}`);
       }
     } catch {}
+
+    // Test 6: live handshake.
+    //
+    // Every check above is static — the file parses, the SDK resolves, the
+    // TOOLS array greps to N entries. All of them passed against a server that
+    // never started, because nothing here launched it. This spawns the real
+    // `mcp start` path and speaks the protocol, which is the only check that
+    // can tell a working server from a dead one.
+    const handshake = await new Promise((resolve) => {
+      const { spawn } = require('child_process');
+      const child = spawn(process.execPath, [__filename, 'mcp', 'start'], {
+        stdio: ['pipe', 'pipe', 'ignore'],
+      });
+
+      let buf = '';
+      const noise = [];
+      let settled = false;
+      let draining = false;
+      const finish = (r) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        try { child.stdin.end(); } catch {}
+        try { child.kill('SIGTERM'); } catch {}
+        resolve(r);
+      };
+      const timer = setTimeout(
+        () => finish({ ok: false, reason: 'no response within 45s (transport never connected?)' }),
+        45000
+      );
+
+      child.stdout.on('data', (chunk) => {
+        buf += chunk.toString();
+        const lines = buf.split('\n');
+        buf = lines.pop();
+        for (const raw of lines) {
+          const line = raw.trim();
+          if (!line) continue;
+          if (!line.startsWith('{')) { noise.push(line); continue; }
+          try {
+            const msg = JSON.parse(line);
+            if (msg.id === 1 && msg.error) {
+              return finish({ ok: false, reason: JSON.stringify(msg.error), noise });
+            }
+            if (msg.id === 1 && msg.result && !draining) {
+              // Drain before settling: the loader's stdout chatter is written
+              // *after* the initialize reply, so returning here immediately
+              // would race past the very noise this check exists to catch.
+              draining = true;
+              const info = msg.result.serverInfo;
+              setTimeout(() => finish({ ok: true, info, noise }), 3000);
+            }
+          } catch { noise.push(line); }
+        }
+      });
+      child.on('error', (e) => finish({ ok: false, reason: e.message }));
+      child.on('exit', (code) => finish({ ok: false, reason: `server exited early (code ${code})` }));
+
+      child.stdin.write(JSON.stringify({
+        jsonrpc: '2.0', id: 1, method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18', capabilities: {},
+          clientInfo: { name: 'ruvector-mcp-test', version: '1.0.0' },
+        },
+      }) + '\n');
+    });
+
+    if (!handshake.ok) {
+      console.log(`  ${chalk.red('FAIL')} live handshake: ${handshake.reason}`);
+      console.log(chalk.bold.red('\n  Checks failed — the server does not answer MCP requests.\n'));
+      process.exit(1);
+    }
+    console.log(`  ${chalk.green('PASS')} live handshake (server: ${handshake.info && handshake.info.name})`);
+
+    if (handshake.noise && handshake.noise.length) {
+      // stdio MCP requires stdout to carry only newline-delimited JSON-RPC.
+      console.log(`  ${chalk.red('FAIL')} stdout carries non-JSON output: ${JSON.stringify(handshake.noise.slice(0, 2))}`);
+      console.log(chalk.bold.red('\n  Checks failed — stdout noise corrupts the JSON-RPC stream.\n'));
+      process.exit(1);
+    }
+    console.log(`  ${chalk.green('PASS')} stdout carries only JSON-RPC`);
 
     console.log(chalk.bold.green('\n  All checks passed.\n'));
     console.log(chalk.dim('  Setup: claude mcp add ruvector npx ruvector mcp start\n'));

--- a/npm/packages/ruvector/package.json
+++ b/npm/packages/ruvector/package.json
@@ -12,7 +12,7 @@
     "verify-dist": "node scripts/verify-dist.js",
     "prepack": "npm run build && npm run verify-dist",
     "prepublishOnly": "npm run build && npm run verify-dist",
-    "test": "node test/integration.js && node test/cli-commands.js && node test/db-workflow.js && node test/mcp-stdio.js && node test/sigterm-cleanup.js && node test/mcp-policy.js && node test/startup-budget.js"
+    "test": "node test/integration.js && node test/cli-commands.js && node test/db-workflow.js && node test/mcp-stdio.js && node test/sigterm-cleanup.js && node test/mcp-policy.js && node test/mcp-handshake.js && node test/startup-budget.js"
   },
   "keywords": [
     "vector",

--- a/npm/packages/ruvector/test/mcp-handshake.js
+++ b/npm/packages/ruvector/test/mcp-handshake.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * MCP handshake regression test.
+ *
+ * The static checks in `ruvector mcp test` (file exists, syntax parses, SDK
+ * resolves, TOOLS array greps to N entries) all passed against a server that
+ * never started: `bin/cli.js` loaded it with `require(mcpServerPath)`, so
+ * `require.main === module` was false and `main()` never ran. Nothing
+ * constructed a transport and `initialize` went unanswered.
+ *
+ * This test spawns the CLI exactly as a client does — `ruvector mcp start` —
+ * and asserts the protocol actually works. It deliberately does NOT invoke
+ * bin/mcp-server.js directly: run as main, that file always worked, so a
+ * direct probe would have passed throughout the outage.
+ */
+
+const { spawn } = require('child_process');
+const path = require('path');
+const assert = require('assert');
+
+const CLI = path.join(__dirname, '..', 'bin', 'cli.js');
+const TIMEOUT_MS = Number(process.env.RUVECTOR_MCP_TEST_TIMEOUT || 45000);
+// Grace window after the last expected reply, to catch stdout written *after*
+// the handshake (model-loading chatter arrives late and would otherwise be missed).
+const DRAIN_MS = Number(process.env.RUVECTOR_MCP_TEST_DRAIN || 3000);
+
+const INIT = {
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2025-06-18',
+    capabilities: {},
+    clientInfo: { name: 'ruvector-handshake-test', version: '1.0.0' },
+  },
+};
+const LIST = { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} };
+
+/**
+ * Drive a full handshake against `ruvector mcp start`.
+ * Resolves { init, tools, stdoutNoise } — never rejects on protocol failure,
+ * so the assertions below produce readable diagnostics instead of a stack.
+ */
+function handshake() {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [CLI, 'mcp', 'start'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let buf = '';
+    const noise = [];
+    const seen = new Map();
+    let settled = false;
+    let draining = false;
+
+    const finish = (extra = {}) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      // The server exits on stdin close once a transport is connected; kill is
+      // a backstop so a regression cannot leak a worker-heavy process here.
+      try { child.stdin.end(); } catch { /* already closed */ }
+      try { child.kill('SIGTERM'); } catch { /* already gone */ }
+      resolve({
+        init: seen.get(1) || null,
+        tools: seen.get(2) || null,
+        stdoutNoise: noise,
+        ...extra,
+      });
+    };
+
+    const timer = setTimeout(() => finish({ timedOut: true }), TIMEOUT_MS);
+
+    child.stdout.on('data', (chunk) => {
+      buf += chunk.toString();
+      const lines = buf.split('\n');
+      buf = lines.pop();
+      for (const raw of lines) {
+        const line = raw.trim();
+        if (!line) continue;
+        if (!line.startsWith('{')) {
+          // stdio MCP requires stdout to carry ONLY newline-delimited
+          // JSON-RPC. Anything else corrupts the stream for a real client.
+          noise.push(line);
+          continue;
+        }
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id != null) seen.set(msg.id, msg);
+        } catch {
+          noise.push(line);
+        }
+      }
+      // Do NOT finish the moment both responses land. The stdout noise this
+      // test exists to catch (e.g. the ONNX loader's cache messages) is
+      // emitted *after* the initialize reply, so returning immediately races
+      // past it and the noise assertion silently passes. Drain briefly first.
+      if (seen.has(1) && seen.has(2) && !draining) {
+        draining = true;
+        setTimeout(() => finish(), DRAIN_MS);
+      }
+    });
+
+    child.on('error', (err) => finish({ spawnError: err.message }));
+    child.on('exit', (code) => finish({ exitedEarly: true, exitCode: code }));
+
+    child.stdin.write(JSON.stringify(INIT) + '\n');
+    child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+    child.stdin.write(JSON.stringify(LIST) + '\n');
+  });
+}
+
+async function main() {
+  console.log('\nMCP Handshake Test');
+  console.log('-'.repeat(40));
+
+  const r = await handshake();
+  let failed = 0;
+  const check = (name, fn) => {
+    try {
+      fn();
+      console.log(`  PASS  ${name}`);
+    } catch (e) {
+      failed++;
+      console.log(`  FAIL  ${name}\n        ${e.message}`);
+    }
+  };
+
+  check('`ruvector mcp start` answers initialize', () => {
+    assert.ok(!r.spawnError, `spawn failed: ${r.spawnError}`);
+    assert.ok(
+      !r.timedOut || r.init,
+      `no initialize response within ${TIMEOUT_MS}ms — the server started but ` +
+      'never connected a transport (see bin/cli.js `mcp start`)'
+    );
+    assert.ok(r.init, 'no initialize response received');
+    assert.ok(r.init.result, `initialize returned an error: ${JSON.stringify(r.init.error)}`);
+  });
+
+  check('initialize reports a protocol version and serverInfo', () => {
+    assert.ok(r.init && r.init.result, 'no initialize result to inspect');
+    assert.ok(r.init.result.protocolVersion, 'missing protocolVersion');
+    assert.strictEqual(r.init.result.serverInfo.name, 'ruvector');
+  });
+
+  check('tools/list returns a non-empty tool set', () => {
+    assert.ok(r.tools, 'no tools/list response received');
+    assert.ok(r.tools.result, `tools/list returned an error: ${JSON.stringify(r.tools.error)}`);
+    const tools = r.tools.result.tools || [];
+    assert.ok(tools.length > 0, 'tools/list returned zero tools');
+    assert.ok(tools.every((t) => t.name), 'a tool is missing its name');
+  });
+
+  check('stdout carries only JSON-RPC (no diagnostic noise)', () => {
+    assert.strictEqual(
+      r.stdoutNoise.length,
+      0,
+      `non-JSON line(s) on stdout would corrupt the stream for a real client: ` +
+      JSON.stringify(r.stdoutNoise.slice(0, 3))
+    );
+  });
+
+  const total = 4;
+  console.log(`\nResults: ${total - failed} passed, ${failed} failed`);
+  if (failed) {
+    console.log('MCP HANDSHAKE TEST FAILED');
+    process.exit(1);
+  }
+  console.log('ALL TESTS PASSED');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- run the real `ruvector mcp start` path from `mcp test`
- validate `initialize` and a non-empty `tools/list` response
- drain stdout after replies to detect late non-JSON diagnostic noise
- retain the existing stdio regression test from #724

This cleanly salvages the unique contribution from #722 on top of current `main`, preserving original authorship for Mark Tenenholtz.

## Validation

- `node --check bin/cli.js`
- `node --check test/mcp-handshake.js`
- `node test/mcp-handshake.js` — 4 passed
- `node bin/cli.js mcp test` — all checks passed
