### PR TITLE
Document the LatticeEmbedding provider in the embeddings guide

### DIFF
--- a/crates/ruvector-core/docs/EMBEDDINGS.md
+++ b/crates/ruvector-core/docs/EMBEDDINGS.md
@@ -151,6 +151,67 @@ model.save_pretrained("./onnx-model")
 tokenizer.save_pretrained("./onnx-model")
 ```
 
+## Native Pure-Rust (Local, No API Costs, No Export Step)
+
+`LatticeEmbedding` runs BERT-family embedding models in-process with no Python, no ONNX
+export step, and no network calls after the first model download. It is already in this
+crate behind the `lattice-embeddings` feature.
+
+```toml
+[dependencies]
+ruvector-core = { version = "2.3", features = ["lattice-embeddings"] }
+```
+
+```rust
+use ruvector_core::{AgenticDB, embeddings::LatticeEmbedding, types::DbOptions};
+use std::sync::Arc;
+
+let provider = Arc::new(LatticeEmbedding::from_pretrained("bge-small-en-v1.5")?);
+
+let mut options = DbOptions::default();
+options.dimensions = 384; // bge-small-en-v1.5
+options.storage_path = "agenticdb.db".to_string();
+
+let db = AgenticDB::with_embedding_provider(options, provider)?;
+```
+
+BERT-family models (BGE, E5, MiniLM) download from HuggingFace into `~/.lattice/models`
+on first use. Vectors are L2-normalized, so a dot-product index works as well as cosine.
+
+A runnable example is in `crates/ruvector-core/examples/lattice_embedding_example.rs`.
+
+**Requires Rust 1.93.** `lattice-embed` 0.6.1 declares `rust-version = 1.93` (edition 2024),
+and cargo enforces that before compiling, so enabling this feature raises the toolchain
+floor for the whole build. That is why it is opt-in rather than a default.
+
+### Asymmetric models and query embedding
+
+This is worth knowing before choosing a model, because it is invisible from the call site.
+
+BGE, E5, and Qwen3-Embedding are *asymmetric* retrievers: the query side is prefixed with a
+retrieval instruction, the document side is not. `LatticeEmbedding` follows that —
+`EmbeddingProvider::embed` is the passage side, and the inherent `LatticeEmbedding::embed_query`
+applies the query instruction.
+
+`AgenticDB` reaches its provider through the `EmbeddingProvider` trait, which has one
+role-neutral `embed`. Its search entry points (`retrieve_similar_episodes`, `search_skills`,
+`find_relevant_turns`, `search`) call the same method its indexing paths call, so queries
+issued through `AgenticDB` are embedded with the **passage** side and the query instruction
+is not applied.
+
+What that means in practice:
+
+- **MiniLM is unaffected.** It is genuinely symmetric — contrastive training on raw text, no
+  prefix — so its query and passage sides are equivalent and nothing is lost.
+- **On BGE, E5, or Qwen3-Embedding**, retrieval quality through `AgenticDB` will be lower than
+  the same model scores in a harness that embeds queries with `embed_query`. Stored documents
+  are correct either way; it is the query side that differs.
+
+If you want asymmetric retrieval at full strength today, embed queries yourself with
+`LatticeEmbedding::embed_query` and query the vector index directly rather than through
+`AgenticDB`'s text-search helpers. Whether `AgenticDB` should offer a query-side path is a
+design question for this project, not something this provider can decide from underneath.
+
 ## Feature Flags
 
 ### `real-embeddings` (Optional)
@@ -235,6 +296,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - **Cons**: Model storage (~100MB), setup complexity
 - **Best for**: Edge deployment, high-volume apps
 
+### Native Pure-Rust (`LatticeEmbedding`)
+- **Pros**: No API costs, offline after first download, no ONNX export step, no Python
+- **Cons**: Model storage (~130MB for bge-small), raises the build's Rust floor to 1.93
+- **Best for**: Local and offline deployments that would rather not maintain an export pipeline
+
 ### Hash-based (Default)
 - **Pros**: Zero dependencies, instant, no setup
 - **Cons**: Not semantic, only for testing
@@ -244,7 +310,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 1. **Development/Testing**: Use hash-based (default)
 2. **Production (Cloud)**: Use `ApiEmbedding::openai()`
-3. **Production (Edge/Offline)**: Implement ONNX provider
+3. **Production (Edge/Offline)**: Use `LatticeEmbedding` (no export step), or implement an ONNX provider
 4. **Custom Models**: Implement `EmbeddingProvider` trait
 
 ## Migration Path


### PR DESCRIPTION
`LatticeEmbedding` is already in `ruvector-core` behind the `lattice-embeddings` feature —
struct in `src/embeddings.rs`, re-exported from `src/lib.rs`, with a runnable example under
`examples/`. Its rustdoc covers the model set, asymmetric query/passage semantics, normalization,
and the threading model.

`docs/EMBEDDINGS.md` does not mention it. That guide exists to help a reader choose a provider,
and it currently lists hash, three API providers, a `todo!()` ONNX sketch, and a stub Candle
type, while its Recommendations send the edge/offline reader to the ONNX stub. This adds the
provider to the guide in the same shape as the existing entries, and updates the two places
that enumerate the options.

It also documents one interaction that is not visible from either side alone.
`AgenticDB::generate_text_embedding` calls `EmbeddingProvider::embed`, which is the passage
side, and every text-search entry point routes through it — the same call the indexing paths
make. On a symmetric model (MiniLM) that is a no-op. On an asymmetric one (BGE, E5,
Qwen3-Embedding) it means the query instruction is not applied to queries issued through
`AgenticDB`, so retrieval quality is lower than the same model reaches when queries go through
`embed_query`. Both pieces are individually correct, so this is written as behaviour a reader
should know before picking a model, not as a defect report. Whether `AgenticDB` should grow a
query-side path is yours to decide; nothing here presumes an answer.

No code changes. Docs only.

This is the concrete form of an offer made in issue #694 in this repo, where the underlying
retrieval comparison and its method are written up. If you would rather not carry this in the
guide, closing is completely fine — no follow-up needed and nothing depends on it.
