### PR TITLE
feat(rvf-runtime): give the compaction policy a caller

### DIFF
--- a/crates/rvf/rvf-runtime/src/compaction.rs
+++ b/crates/rvf/rvf-runtime/src/compaction.rs
@@ -197,8 +197,8 @@ mod tests {
     // evaluate_triggers, so they lock the WIRING -- the part that was missing -- and
     // not just the arithmetic, which the tests above already cover.
 
-    use crate::store::RvfStore;
     use crate::options::DistanceMetric;
+    use crate::store::RvfStore;
     use crate::RvfOptions;
     use tempfile::TempDir;
 
@@ -238,7 +238,10 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let store = store_with(&dir, "dirty.rvf", 10, 6);
 
-        assert!(store.status().dead_space_ratio > 0.20, "precondition: real dead space");
+        assert!(
+            store.status().dead_space_ratio > 0.20,
+            "precondition: real dead space"
+        );
         assert_eq!(store.should_compact(), CompactionDecision::Normal);
     }
 
@@ -278,7 +281,10 @@ mod tests {
             min_interval_secs: 0,
             emergency_ratio: 0.70,
         };
-        assert_eq!(store.should_compact_with(&eager), CompactionDecision::Normal);
+        assert_eq!(
+            store.should_compact_with(&eager),
+            CompactionDecision::Normal
+        );
     }
 
     #[test]

--- a/crates/rvf/rvf-runtime/src/compaction.rs
+++ b/crates/rvf/rvf-runtime/src/compaction.rs
@@ -13,8 +13,7 @@
 //! 4. Cold OVERLAY_SEGs
 
 /// Compaction trigger thresholds.
-#[allow(dead_code)]
-pub(crate) struct CompactionThresholds {
+pub struct CompactionThresholds {
     /// Minimum dead space ratio to trigger compaction.
     pub dead_space_ratio: f64,
     /// Maximum segment count before compaction.
@@ -38,8 +37,7 @@ impl Default for CompactionThresholds {
 
 /// Compaction decision.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[allow(dead_code)]
-pub(crate) enum CompactionDecision {
+pub enum CompactionDecision {
     /// No compaction needed.
     None,
     /// Normal compaction should run.
@@ -49,8 +47,7 @@ pub(crate) enum CompactionDecision {
 }
 
 /// Evaluate whether compaction should run.
-#[allow(dead_code)]
-pub(crate) fn evaluate_triggers(
+pub fn evaluate_triggers(
     dead_space_ratio: f64,
     segment_count: u32,
     secs_since_last: u64,
@@ -190,6 +187,98 @@ mod tests {
         // Even though dead_space and segment_count exceed thresholds,
         // interval hasn't passed.
         assert_eq!(decision, CompactionDecision::None);
+    }
+
+    // --- the policy is now REACHABLE from the store, not just from these tests ---
+    //
+    // Every input evaluate_triggers needs was already tracked on RvfStore
+    // (dead_space_ratio and total_segments via status(), last_compaction_time stamped
+    // by compact()). These drive a REAL store rather than passing numbers straight to
+    // evaluate_triggers, so they lock the WIRING -- the part that was missing -- and
+    // not just the arithmetic, which the tests above already cover.
+
+    use crate::store::RvfStore;
+    use crate::options::DistanceMetric;
+    use crate::RvfOptions;
+    use tempfile::TempDir;
+
+    fn store_with(dir: &TempDir, name: &str, count: u64, delete: u64) -> RvfStore {
+        let options = RvfOptions {
+            dimension: 4,
+            metric: DistanceMetric::L2,
+            ..Default::default()
+        };
+        let mut store = RvfStore::create(&dir.path().join(name), options).unwrap();
+        if count > 0 {
+            let vecs: Vec<Vec<f32>> = (0..count).map(|i| vec![i as f32, 1.0, 0.0, 0.0]).collect();
+            let refs: Vec<&[f32]> = vecs.iter().map(|v| v.as_slice()).collect();
+            let ids: Vec<u64> = (0..count).collect();
+            store.ingest_batch(&refs, &ids, None).unwrap();
+        }
+        if delete > 0 {
+            let doomed: Vec<u64> = (0..delete).collect();
+            store.delete(&doomed).unwrap();
+        }
+        store
+    }
+
+    #[test]
+    fn a_store_with_no_dead_space_is_not_due() {
+        let dir = TempDir::new().unwrap();
+        let store = store_with(&dir, "clean.rvf", 10, 0);
+
+        assert_eq!(store.should_compact(), CompactionDecision::None);
+    }
+
+    #[test]
+    fn dead_space_over_the_threshold_is_read_from_LIVE_state() {
+        // 6 of 10 deleted = 0.60: over the 0.20 normal trigger, under the 0.70 emergency.
+        // This is the case that could not be reached before, because nothing called the
+        // policy with the store's real numbers.
+        let dir = TempDir::new().unwrap();
+        let store = store_with(&dir, "dirty.rvf", 10, 6);
+
+        assert!(store.status().dead_space_ratio > 0.20, "precondition: real dead space");
+        assert_eq!(store.should_compact(), CompactionDecision::Normal);
+    }
+
+    #[test]
+    fn dead_space_over_the_emergency_ratio_escalates() {
+        // 8 of 10 deleted = 0.80, above the 0.70 emergency ratio.
+        let dir = TempDir::new().unwrap();
+        let store = store_with(&dir, "emergency.rvf", 10, 8);
+
+        assert_eq!(store.should_compact(), CompactionDecision::Emergency);
+    }
+
+    #[test]
+    fn compact_if_needed_distinguishes_not_needed_from_ran_and_found_nothing() {
+        let dir = TempDir::new().unwrap();
+        let mut clean = store_with(&dir, "skip.rvf", 10, 0);
+        let mut dirty = store_with(&dir, "run.rvf", 10, 6);
+
+        // None => the policy declined. That must NOT look like a compaction that ran and
+        // reclaimed zero, which is Some(result) -- the distinction is why this returns an
+        // Option rather than a bare CompactionResult.
+        assert!(clean.compact_if_needed().unwrap().is_none());
+        assert!(dirty.compact_if_needed().unwrap().is_some());
+    }
+
+    #[test]
+    fn custom_thresholds_are_honoured() {
+        let dir = TempDir::new().unwrap();
+        let store = store_with(&dir, "custom.rvf", 10, 0);
+
+        // A store the default policy declines must flip under a stricter threshold,
+        // which proves should_compact_with reads live state rather than a constant.
+        assert_eq!(store.should_compact(), CompactionDecision::None);
+        let eager = CompactionThresholds {
+            dead_space_ratio: 0.20,
+            max_segment_count: 0,
+            min_interval_secs: 0,
+            emergency_ratio: 0.70,
+        };
+        assert_eq!(store.should_compact_with(&eager), CompactionDecision::Normal);
     }
 
     #[test]

--- a/crates/rvf/rvf-runtime/src/store.rs
+++ b/crates/rvf/rvf-runtime/src/store.rs
@@ -1346,9 +1346,7 @@ impl RvfStore {
     pub fn compact_if_needed(&mut self) -> Result<Option<CompactionResult>, RvfError> {
         match self.should_compact() {
             CompactionDecision::None => Ok(None),
-            CompactionDecision::Normal | CompactionDecision::Emergency => {
-                self.compact().map(Some)
-            }
+            CompactionDecision::Normal | CompactionDecision::Emergency => self.compact().map(Some),
         }
     }
 

--- a/crates/rvf/rvf-runtime/src/store.rs
+++ b/crates/rvf/rvf-runtime/src/store.rs
@@ -22,6 +22,7 @@ use rvf_types::{
     SEGMENT_MAGIC,
 };
 
+use crate::compaction::{evaluate_triggers, CompactionDecision, CompactionThresholds};
 use crate::cow::{CowEngine, CowStats};
 use crate::cow_map::CowMap;
 use crate::deletion::DeletionBitmap;
@@ -1305,7 +1306,56 @@ impl RvfStore {
         }
     }
 
+    /// Evaluate the documented compaction triggers against this store's live state.
+    ///
+    /// Spec 10 §7 defines when compaction *should* run — dead space > 20%, segment
+    /// count > 32, at least 60s since the last run, with an emergency path above 70%.
+    /// [`crate::compaction::evaluate_triggers`] implements exactly that and was unit
+    /// tested, but had no caller outside its own tests, so the policy could not affect
+    /// anything. Every input it needs was already tracked here: `dead_space_ratio` and
+    /// `total_segments` are computed by [`Self::status`], and `last_compaction_time` is
+    /// stamped at the end of [`Self::compact`].
+    ///
+    /// This is a read-only query — it never compacts. Use it to decide, or call
+    /// [`Self::compact_if_needed`] to decide and act in one step.
+    pub fn should_compact(&self) -> CompactionDecision {
+        self.should_compact_with(&CompactionThresholds::default())
+    }
+
+    /// [`Self::should_compact`] against caller-supplied thresholds.
+    pub fn should_compact_with(&self, thresholds: &CompactionThresholds) -> CompactionDecision {
+        let status = self.status();
+        // Saturating: a clock that moved backwards must not wrap into a huge interval
+        // and make an over-eager compaction look policy-approved.
+        let secs_since_last = now_secs().saturating_sub(self.last_compaction_time);
+        evaluate_triggers(
+            status.dead_space_ratio,
+            status.total_segments,
+            secs_since_last,
+            thresholds,
+        )
+    }
+
+    /// Compact only if [`Self::should_compact`] says the policy is met.
+    ///
+    /// Returns `Ok(None)` when no compaction was needed — distinct from
+    /// `Ok(Some(result))` with zero reclaimed, which means compaction ran and found
+    /// nothing. Callers that want to compact regardless should call [`Self::compact`]
+    /// directly; that remains unconditional, because an explicit request is not a
+    /// policy decision.
+    pub fn compact_if_needed(&mut self) -> Result<Option<CompactionResult>, RvfError> {
+        match self.should_compact() {
+            CompactionDecision::None => Ok(None),
+            CompactionDecision::Normal | CompactionDecision::Emergency => {
+                self.compact().map(Some)
+            }
+        }
+    }
+
     /// Run compaction to reclaim dead space.
+    ///
+    /// Unconditional by design: this is an explicit request, not a scheduling
+    /// decision. For the documented policy, see [`Self::compact_if_needed`].
     ///
     /// Preserves all non-Vec, non-Manifest, non-Journal segments byte-for-byte
     /// to maintain forward compatibility with segment types this version does


### PR DESCRIPTION
Fixes the third defect in #753. Separate from #754 on purpose — that one is confined to the npm package, this one adds API to `rvf-runtime`.

## The policy was implemented, tested, and unreachable

`crates/rvf/rvf-runtime/src/compaction.rs` implements spec 10 §7 in full — `CompactionThresholds` (dead space 0.20, 32 segments, 60s interval, 0.70 emergency), `evaluate_triggers`, `CompactionDecision` — with passing unit tests. Every item was `#[allow(dead_code)]`, and the only callers were its own tests:

```
$ grep -rn "evaluate_triggers" --include='*.rs' . | grep -v /target/
compaction.rs:53                     <- definition
compaction.rs:165,171,177,183,189    <- tests only
```

`select_segments` is the same. So the documented triggers gated nothing, `RvfStore::compact()` compacts whenever asked, and a consumer with no signal for *when* to compact ends up calling it unconditionally on a timer.

## No new state was needed — three tracked values were simply never wired

That is the part worth highlighting. Everything `evaluate_triggers` takes already existed on the store:

| input | already available as |
|---|---|
| `dead_space_ratio` | computed in `RvfStore::status()` |
| `segment_count` | `segment_dir.len()`, also in `status()` |
| `secs_since_last` | `last_compaction_time`, stamped at the end of `compact()` |

## What this adds

```rust
pub fn should_compact(&self) -> CompactionDecision            // read-only, never compacts
pub fn should_compact_with(&self, &CompactionThresholds) -> CompactionDecision
pub fn compact_if_needed(&mut self) -> Result<Option<CompactionResult>, RvfError>
```

**`compact()` is unchanged and stays unconditional** — an explicit request is not a scheduling decision. Nothing existing changes behaviour; this is purely additive.

`compact_if_needed()` returns `Ok(None)` when the policy declines, which is deliberately distinct from `Ok(Some(result))` with zero reclaimed. *"We did not run"* must not read like *"we ran and found nothing"*.

`secs_since_last` uses `saturating_sub`, so a clock that moved backwards cannot wrap into a huge interval and make an over-eager compaction look policy-approved.

## Scoped to the trigger policy

`CompactionPlan` and `select_segments` stay `pub(crate)` + `dead_code`. They describe **segment-level** compaction that `RvfStore::compact()` does not currently perform, so wiring them would be a behaviour change rather than a wiring fix — worth its own look, not this PR.

## Tests

The five new tests drive a **real store** rather than passing numbers straight to `evaluate_triggers`. The arithmetic was already covered by the existing tests; the *wiring* was what was missing, so that is what these lock:

- no dead space → `None`
- 6/10 deleted → `Normal` (asserts the precondition that `status().dead_space_ratio > 0.20` first)
- 8/10 deleted → `Emergency`
- `compact_if_needed` → `None` vs `Some`, on two stores in the same test
- custom thresholds flipping a verdict the default declines — proving live state is read, not a constant

```
cargo test -p rvf-runtime --lib    248 passed, 0 failed
cargo clippy --lib                 clean
```

## Open question for you

If compaction is *meant* to be caller-scheduled and the policy is vestigial, the alternative is to delete it rather than wire it — an implemented, tested policy that nothing consults reads as enforced when it is not, and that is the state I hit as a consumer. I have wired it because the thresholds match the spec and the inputs were all present, but I am happy to invert this PR into a removal if that matches your intent.