### PR TITLE
fix(rvf-runtime): clear the deletion bit when an id is re-ingested

### DIFF
--- a/crates/rvf/rvf-runtime/src/store.rs
+++ b/crates/rvf/rvf-runtime/src/store.rs
@@ -403,6 +403,12 @@ impl RvfStore {
             self.vectors.insert_slice(vec_id, vec_data);
         }
 
+        // Re-inserting an id resurrects it. A deletion tombstones the payload that
+        // was there, it does not retire the identifier, so the bit must not outlive
+        // the vector it condemned. Left set, it hides the new vector from every
+        // query, and compact() reads it as dead and physically drops it.
+        self.deletion_bitmap.clear_ids(&valid_ids);
+
         // Keep the in-memory HNSW index in sync with the new vectors.
         {
             let mut guard = self.index.lock().unwrap_or_else(|e| e.into_inner());
@@ -3378,6 +3384,79 @@ mod tests {
         let results = store.query(&query, 10, &QueryOptions::default()).unwrap();
         assert_eq!(results.len(), 2);
         assert!(results.iter().all(|r| r.id != 2));
+
+        store.close().unwrap();
+    }
+
+    #[test]
+    fn reingest_after_delete_makes_the_id_visible_again() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("reingest.rvf");
+
+        let options = RvfOptions {
+            dimension: 2,
+            metric: DistanceMetric::L2,
+            ..Default::default()
+        };
+        let mut store = RvfStore::create(&path, options).unwrap();
+
+        let original = vec![1.0f32, 0.0];
+        store.ingest_batch(&[&original[..]], &[42], None).unwrap();
+        assert_eq!(store.delete(&[42]).unwrap().deleted, 1);
+
+        // Re-inserting the same id must resurrect it: a deletion is a statement
+        // about the old payload, not a permanent ban on the identifier.
+        let replacement = vec![0.0f32, 1.0];
+        store
+            .ingest_batch(&[&replacement[..]], &[42], None)
+            .unwrap();
+
+        let hits = store
+            .query(&[0.0, 1.0], 1, &QueryOptions::default())
+            .unwrap();
+        assert!(
+            hits.iter().any(|r| r.id == 42),
+            "id 42 stayed soft-deleted after re-ingest, so the new payload is unreachable"
+        );
+
+        store.close().unwrap();
+    }
+
+    #[test]
+    fn compact_keeps_a_vector_reingested_after_delete() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("reingest_compact.rvf");
+
+        let options = RvfOptions {
+            dimension: 2,
+            metric: DistanceMetric::L2,
+            ..Default::default()
+        };
+        let mut store = RvfStore::create(&path, options).unwrap();
+
+        let keep = vec![1.0f32, 0.0];
+        let original = vec![0.0f32, 1.0];
+        store
+            .ingest_batch(&[&keep[..], &original[..]], &[1, 42], None)
+            .unwrap();
+        store.delete(&[42]).unwrap();
+
+        let replacement = vec![0.5f32, 0.5];
+        store
+            .ingest_batch(&[&replacement[..]], &[42], None)
+            .unwrap();
+
+        // Compaction physically drops whatever the bitmap still calls dead, so a
+        // stale bit here destroys live data rather than merely hiding it.
+        store.compact().unwrap();
+
+        let hits = store
+            .query(&[0.5, 0.5], 10, &QueryOptions::default())
+            .unwrap();
+        assert!(
+            hits.iter().any(|r| r.id == 42),
+            "compaction dropped a vector that had been re-ingested after deletion"
+        );
 
         store.close().unwrap();
     }

--- a/crates/rvf/rvf-runtime/src/store.rs
+++ b/crates/rvf/rvf-runtime/src/store.rs
@@ -3462,6 +3462,57 @@ mod tests {
     }
 
     #[test]
+    fn reingest_after_delete_survives_reopen() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("reingest_reopen.rvf");
+
+        let options = RvfOptions {
+            dimension: 2,
+            metric: DistanceMetric::L2,
+            ..Default::default()
+        };
+
+        {
+            let mut store = RvfStore::create(&path, options).unwrap();
+
+            let original = vec![1.0f32, 0.0];
+            store.ingest_batch(&[&original[..]], &[42], None).unwrap();
+            assert_eq!(store.delete(&[42]).unwrap().deleted, 1);
+
+            let replacement = vec![0.0f32, 1.0];
+            store
+                .ingest_batch(&[&replacement[..]], &[42], None)
+                .unwrap();
+
+            store.close().unwrap();
+        }
+
+        // Reopen from the same directory: the deletion bit that was cleared
+        // in memory must also be cleared in the persisted manifest, or boot
+        // reconstructs id 42 as deleted again and buries the replacement.
+        {
+            let store = RvfStore::open(&path).unwrap();
+
+            let hits = store
+                .query(&[0.0, 1.0], 1, &QueryOptions::default())
+                .unwrap();
+            assert_eq!(
+                hits.len(),
+                1,
+                "id 42 came back soft-deleted after reopen, so the persisted \
+                 tombstone clear did not survive"
+            );
+            assert_eq!(hits[0].id, 42);
+            assert!(
+                hits[0].distance < f32::EPSILON,
+                "id 42 resolved to a vector other than the post-reingest replacement"
+            );
+
+            store.close().unwrap();
+        }
+    }
+
+    #[test]
     fn filter_query() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("filter.rvf");


### PR DESCRIPTION
Fixes #748.

`delete(ids)` sets bits in the deletion bitmap. `ingest_batch` never cleared them, so re-inserting a
deleted id left the bit set. Two consequences, and the second is data loss:

1. `query()` skips the id, so the newly ingested vector is unreachable even though it is stored.
2. `compact()` treats the id as dead and **physically removes it**, destroying a payload that was
   written after the deletion.

`DeletionBitmap::clear_ids` already existed for exactly this; its only caller was its own unit test.

## The fix

One line, placed immediately after the loop that inserts the vectors, which is the point where the
id becomes live again:

```rust
self.deletion_bitmap.clear_ids(&valid_ids);
```

## Verified at `main`, not inherited from the report

The issue confirms 0.2.0 and says the interaction is "present in 0.3.0". I reproduced it at `main`
rather than taking that forward, because the same crate had a separate issue that was already fixed
by the time it was filed. Both halves reproduce:

| test | without the fix | with the fix |
|---|---|---|
| `reingest_after_delete_makes_the_id_visible_again` | FAILED — *"id 42 stayed soft-deleted after re-ingest, so the new payload is unreachable"* | ok |
| `compact_keeps_a_vector_reingested_after_delete` | FAILED — *"compaction dropped a vector that had been re-ingested after deletion"* | ok |

Both are in the PR. They were written before the fix and observed failing first, then observed
passing, and the failure was re-confirmed afterwards by removing the added line and watching exactly
those two go red while the other 243 stayed green. A regression test that passes with the fix
reverted would not be guarding anything.

Full suite at the current head: **328 passed, 0 failed** across the rvf-runtime library (246) plus integration and doc targets. `cargo fmt --all --check` clean.

## One thing I checked and deliberately did not change

`delete()` also drops the id from a COW child's `membership_filter`, so my first version of this
patch re-added it there for symmetry. That turned out to be unnecessary: re-ingesting makes the
vector child-owned, and the query paths find it through `self.vectors` without consulting membership.
I confirmed it by writing a COW branch/delete/re-ingest/query test and watching it pass both with and
without that block, which means the block was doing nothing. It is not in this PR, and neither is
that test — it passes on unmodified `main`, so shipping it alongside the two real ones would have
made it look like a regression guard when it characterises behaviour that was already correct.

Mentioning it because "does this need the same treatment for COW children" is the first question a
reviewer should ask about this fix, and the answer is no, measured rather than assumed.

## Note on lint

`cargo clippy` on this crate reports three pre-existing errors, all in `rvf-types` (`impl can be
derived` ×2, missing `Default` for `Sha256`). They are untouched by this PR. Worth knowing why they
survive: `rvf-runtime` is not a workspace member, so `cargo clippy --workspace` and
`cargo test --workspace` never reach it or its path deps. Happy to open that separately if useful.


---

**Note on this PR's CI.** `Tests (core-and-rest)` is red on every branch in this repository,
including `main`: the job is cancelled at its 240-minute cap while still compiling and never
reaches the test phase. #786 restores the exclusion list that the shard's `packages:` value loses
to a shell comment, #784 unblocks the `ruvector-filter` test target that the compiler cannot
finish, and #787 fixes a deadlock waiting behind both. That failure is not caused by this branch.

