### PR TITLE
feat(spann): add an optional lattice-simd distance backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4939,6 +4939,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "lattice-embed"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3af50558cf953df225b68ec160f1ea49b0965564f10a9b8577d15ac8452542"
+dependencies = [
+ "async-trait",
+ "blake3",
+ "chrono",
+ "lru 0.16.4",
+ "parking_lot 0.12.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "lattice-inference"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9203,7 +9221,7 @@ dependencies = [
  "dashmap 6.2.1",
  "hf-hub",
  "hnsw_rs",
- "lattice-embed",
+ "lattice-embed 0.6.1",
  "memmap2",
  "mockall",
  "ndarray 0.16.1",
@@ -10603,6 +10621,9 @@ dependencies = [
 [[package]]
 name = "ruvector-spann"
 version = "0.1.0"
+dependencies = [
+ "lattice-embed 0.7.0",
+]
 
 [[package]]
 name = "ruvector-sparse-inference"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4940,9 +4940,9 @@ dependencies = [
 
 [[package]]
 name = "lattice-embed"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3af50558cf953df225b68ec160f1ea49b0965564f10a9b8577d15ac8452542"
+checksum = "3a8471670d8eb3dc5b52b7c977f1be449a4d39404ebd47bd084a1e922fa6002e"
 dependencies = [
  "async-trait",
  "blake3",
@@ -10622,7 +10622,7 @@ dependencies = [
 name = "ruvector-spann"
 version = "0.1.0"
 dependencies = [
- "lattice-embed 0.7.0",
+ "lattice-embed 0.7.1",
 ]
 
 [[package]]

--- a/crates/ruvector-spann/Cargo.toml
+++ b/crates/ruvector-spann/Cargo.toml
@@ -25,6 +25,6 @@ lattice-simd = ["dep:lattice-embed"]
 # `default-features = false` keeps this to the SIMD kernels: the model,
 # tokenizer, and download stack sit behind lattice-embed's `native` feature
 # and are not pulled in here.
-lattice-embed = { version = "0.7.0", optional = true, default-features = false }
+lattice-embed = { version = "0.7.1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/crates/ruvector-spann/Cargo.toml
+++ b/crates/ruvector-spann/Cargo.toml
@@ -10,6 +10,21 @@ repository = "https://github.com/ruvnet/ruvector"
 name = "benchmark"
 path = "src/bin/benchmark.rs"
 
+[features]
+default = []
+# Route the partition index's inner products through lattice-embed's
+# runtime-dispatched SIMD kernels instead of the scalar loops.
+#
+# Opt-in and off by default. lattice-embed requires Rust >= 1.93 (edition
+# 2024) and Cargo cannot express a per-feature `rust-version`, so enabling
+# this raises the effective MSRV for anyone who turns it on. The default
+# build keeps this crate's dependency set empty and is unaffected.
+lattice-simd = ["dep:lattice-embed"]
+
 [dependencies]
+# `default-features = false` keeps this to the SIMD kernels: the model,
+# tokenizer, and download stack sit behind lattice-embed's `native` feature
+# and are not pulled in here.
+lattice-embed = { version = "0.7.0", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/crates/ruvector-spann/src/distance.rs
+++ b/crates/ruvector-spann/src/distance.rs
@@ -1,9 +1,35 @@
 //! Distance computation for SPANN partition index.
+//!
+//! Two backends compute the same quantities. The default is the scalar code
+//! that has always been here. With the `lattice-simd` feature the inner
+//! products come from `lattice-embed`'s runtime-dispatched SIMD kernels
+//! (AVX-512 / AVX2 / NEON / wasm32 SIMD128, with its own scalar fallback).
+//!
+//! The backend split covers the inner products only. Length handling and the
+//! small-norm guard live outside it, so both backends take the same branches
+//! and differ only in how the sums are accumulated.
 
 /// Compute L2 squared distance between two f32 slices.
 #[inline]
 pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
+
+    #[cfg(feature = "lattice-simd")]
+    {
+        // Only the equal-length case is routed. lattice returns f32::MAX for a
+        // length mismatch where the scalar path below truncates to the shorter
+        // slice, so guarding here keeps the two backends from disagreeing on
+        // an input the debug assertion already calls a caller bug.
+        if a.len() == b.len() {
+            return lattice_embed::simd::squared_euclidean_distance(a, b);
+        }
+    }
+
+    l2_squared_scalar(a, b)
+}
+
+#[inline]
+fn l2_squared_scalar(a: &[f32], b: &[f32]) -> f32 {
     a.iter()
         .zip(b.iter())
         .map(|(x, y)| {
@@ -18,13 +44,37 @@ pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
 #[inline]
 pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
-    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
-    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
-    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let (dot, norm_sq_a, norm_sq_b) = inner_products(a, b);
+    let norm_a = norm_sq_a.sqrt();
+    let norm_b = norm_sq_b.sqrt();
     if norm_a < 1e-9 || norm_b < 1e-9 {
         return 1.0;
     }
     1.0 - dot / (norm_a * norm_b)
+}
+
+/// Returns `(dot(a, b), dot(a, a), dot(b, b))`.
+///
+/// `lattice_embed::simd::cosine_similarity` is deliberately not used here: it
+/// applies its own zero-norm rule, while this module's contract is a 1e-9
+/// threshold that returns 1.0. Composing the distance from three inner
+/// products keeps that threshold the single place either backend decides it.
+#[inline]
+fn inner_products(a: &[f32], b: &[f32]) -> (f32, f32, f32) {
+    #[cfg(feature = "lattice-simd")]
+    {
+        // lattice's dot_product returns 0.0 on a length mismatch, which would
+        // read as a zero norm and short-circuit to 1.0. Route equal lengths only.
+        if a.len() == b.len() {
+            use lattice_embed::simd::dot_product;
+            return (dot_product(a, b), dot_product(a, a), dot_product(b, b));
+        }
+    }
+
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let norm_sq_a: f32 = a.iter().map(|x| x * x).sum();
+    let norm_sq_b: f32 = b.iter().map(|x| x * x).sum();
+    (dot, norm_sq_a, norm_sq_b)
 }
 
 #[cfg(test)]
@@ -55,5 +105,85 @@ mod tests {
         let a = vec![1.0f32, 0.0];
         let b = vec![0.0f32, 1.0];
         assert!((cosine_distance(&a, &b) - 1.0).abs() < 1e-6);
+    }
+
+    fn reference_l2_squared(a: &[f32], b: &[f32]) -> f32 {
+        let mut acc = 0.0f64;
+        for (x, y) in a.iter().zip(b.iter()) {
+            let d = f64::from(*x) - f64::from(*y);
+            acc += d * d;
+        }
+        acc as f32
+    }
+
+    fn reference_cosine_distance(a: &[f32], b: &[f32]) -> f32 {
+        let mut dot = 0.0f64;
+        let mut na = 0.0f64;
+        let mut nb = 0.0f64;
+        for (x, y) in a.iter().zip(b.iter()) {
+            dot += f64::from(*x) * f64::from(*y);
+            na += f64::from(*x) * f64::from(*x);
+            nb += f64::from(*y) * f64::from(*y);
+        }
+        let (na, nb) = (na.sqrt() as f32, nb.sqrt() as f32);
+        if na < 1e-9 || nb < 1e-9 {
+            return 1.0;
+        }
+        1.0 - (dot as f32) / (na * nb)
+    }
+
+    fn pair(dim: usize, seed: u32) -> (Vec<f32>, Vec<f32>) {
+        let mut s = seed.wrapping_mul(2_654_435_761).wrapping_add(1);
+        let mut next = || {
+            s ^= s << 13;
+            s ^= s >> 17;
+            s ^= s << 5;
+            (s as f32 / u32::MAX as f32) * 2.0 - 1.0
+        };
+        (
+            (0..dim).map(|_| next()).collect(),
+            (0..dim).map(|_| next()).collect(),
+        )
+    }
+
+    /// Whichever backend is compiled must agree with an f64 reference.
+    ///
+    /// Dimensions straddle the 4/8/16-lane widths and the unrolled chunk sizes
+    /// a SIMD backend uses, so remainder handling is exercised rather than
+    /// assumed. Running it under both feature settings holds a default build
+    /// and a `lattice-simd` build to one reference.
+    #[test]
+    fn backend_matches_reference() {
+        for dim in [
+            1usize, 3, 4, 7, 8, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 384, 768,
+        ] {
+            for seed in 0..4u32 {
+                let (a, b) = pair(dim, seed);
+
+                let got = l2_squared(&a, &b);
+                let want = reference_l2_squared(&a, &b);
+                assert!(
+                    (got - want).abs() <= 1e-3 * want.abs().max(1.0),
+                    "l2_squared dim={dim} seed={seed}: {got} vs {want}"
+                );
+
+                let got = cosine_distance(&a, &b);
+                let want = reference_cosine_distance(&a, &b);
+                assert!(
+                    (got - want).abs() <= 1e-4,
+                    "cosine_distance dim={dim} seed={seed}: {got} vs {want}"
+                );
+            }
+        }
+    }
+
+    /// A zero vector must take the small-norm branch, not produce a NaN.
+    #[test]
+    fn cosine_zero_vector_is_not_nan() {
+        let zero = vec![0.0f32; 64];
+        let (v, _) = pair(64, 9);
+        assert_eq!(cosine_distance(&zero, &v), 1.0);
+        assert_eq!(cosine_distance(&v, &zero), 1.0);
+        assert_eq!(cosine_distance(&zero, &zero), 1.0);
     }
 }

--- a/crates/ruvector-spann/src/distance.rs
+++ b/crates/ruvector-spann/src/distance.rs
@@ -186,4 +186,39 @@ mod tests {
         assert_eq!(cosine_distance(&v, &zero), 1.0);
         assert_eq!(cosine_distance(&zero, &zero), 1.0);
     }
+
+    /// Guards against a silent reversion of the `lattice-simd` routing back
+    /// to the scalar loops. `backend_matches_reference` above cannot catch
+    /// that: it would still pass if the routed calls were replaced by the
+    /// scalar functions, since both agree with the f64 reference within
+    /// tolerance. This test instead demands the routed result differ from
+    /// the scalar result bit-for-bit, which only holds if a distinct
+    /// (SIMD-ordered) summation actually ran. If the lattice calls at the
+    /// routing sites are ever swapped back for `l2_squared_scalar` / the
+    /// inline scalar sum, `l2_squared` and the dot product become the exact
+    /// same computation as their scalar counterparts and this test fails.
+    #[cfg(feature = "lattice-simd")]
+    #[test]
+    fn lattice_backend_is_actually_selected() {
+        let (a, b) = pair(768, 7);
+
+        let l2_scalar = l2_squared_scalar(&a, &b);
+        let l2_routed = l2_squared(&a, &b);
+        assert_ne!(
+            l2_routed.to_bits(),
+            l2_scalar.to_bits(),
+            "l2_squared matched the scalar sum bit-for-bit with lattice-simd \
+             enabled; the routing at distance.rs may have reverted to scalar"
+        );
+
+        let dot_scalar: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+        let (dot_routed, _, _) = inner_products(&a, &b);
+        assert_ne!(
+            dot_routed.to_bits(),
+            dot_scalar.to_bits(),
+            "cosine's dot product matched the scalar sum bit-for-bit with \
+             lattice-simd enabled; the routing at distance.rs may have \
+             reverted to scalar"
+        );
+    }
 }

--- a/crates/ruvector-spann/src/distance.rs
+++ b/crates/ruvector-spann/src/distance.rs
@@ -9,6 +9,27 @@
 //! small-norm guard live outside it, so both backends take the same branches
 //! and differ only in how the sums are accumulated.
 
+#[cfg(all(test, feature = "lattice-simd"))]
+thread_local! {
+    static LATTICE_L2_WITNESS: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static LATTICE_DOT_WITNESS: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Routes to `lattice_embed`'s L2 kernel and records that the call returned.
+///
+/// The witness store lives inside this wrapper, not at the call site in
+/// `l2_squared`, so that reverting the call site's expression to the scalar
+/// fallback (while leaving this wrapper and its store untouched) stops the
+/// wrapper from being invoked at all and the witness cannot fire.
+#[cfg(feature = "lattice-simd")]
+#[inline]
+fn l2_lattice(a: &[f32], b: &[f32]) -> f32 {
+    let result = lattice_embed::simd::squared_euclidean_distance(a, b);
+    #[cfg(test)]
+    LATTICE_L2_WITNESS.with(|w| w.set(true));
+    result
+}
+
 /// Compute L2 squared distance between two f32 slices.
 #[inline]
 pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
@@ -21,7 +42,7 @@ pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
         // slice, so guarding here keeps the two backends from disagreeing on
         // an input the debug assertion already calls a caller bug.
         if a.len() == b.len() {
-            return lattice_embed::simd::squared_euclidean_distance(a, b);
+            return l2_lattice(a, b);
         }
     }
 
@@ -53,6 +74,20 @@ pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
     1.0 - dot / (norm_a * norm_b)
 }
 
+/// Routes to `lattice_embed`'s dot-product kernel for all three inner
+/// products and records that the calls returned. See `l2_lattice` for why
+/// the store lives in this wrapper rather than at the `inner_products` call
+/// site.
+#[cfg(feature = "lattice-simd")]
+#[inline]
+fn dot_lattice(a: &[f32], b: &[f32]) -> (f32, f32, f32) {
+    use lattice_embed::simd::dot_product;
+    let result = (dot_product(a, b), dot_product(a, a), dot_product(b, b));
+    #[cfg(test)]
+    LATTICE_DOT_WITNESS.with(|w| w.set(true));
+    result
+}
+
 /// Returns `(dot(a, b), dot(a, a), dot(b, b))`.
 ///
 /// `lattice_embed::simd::cosine_similarity` is deliberately not used here: it
@@ -66,8 +101,7 @@ fn inner_products(a: &[f32], b: &[f32]) -> (f32, f32, f32) {
         // lattice's dot_product returns 0.0 on a length mismatch, which would
         // read as a zero norm and short-circuit to 1.0. Route equal lengths only.
         if a.len() == b.len() {
-            use lattice_embed::simd::dot_product;
-            return (dot_product(a, b), dot_product(a, a), dot_product(b, b));
+            return dot_lattice(a, b);
         }
     }
 
@@ -191,34 +225,30 @@ mod tests {
     /// to the scalar loops. `backend_matches_reference` above cannot catch
     /// that: it would still pass if the routed calls were replaced by the
     /// scalar functions, since both agree with the f64 reference within
-    /// tolerance. This test instead demands the routed result differ from
-    /// the scalar result bit-for-bit, which only holds if a distinct
-    /// (SIMD-ordered) summation actually ran. If the lattice calls at the
-    /// routing sites are ever swapped back for `l2_squared_scalar` / the
-    /// inline scalar sum, `l2_squared` and the dot product become the exact
-    /// same computation as their scalar counterparts and this test fails.
+    /// tolerance, and a host without an accelerated path falls through to a
+    /// `lattice_embed` scalar loop that can equal RuVector's own scalar sum
+    /// bit-for-bit — a bit-inequality assertion would reject that valid
+    /// route. This test instead witnesses that the `lattice_embed` call
+    /// itself returned, independent of what bits it produced.
     #[cfg(feature = "lattice-simd")]
     #[test]
-    fn lattice_backend_is_actually_selected() {
+    fn lattice_backend_is_actually_called() {
+        LATTICE_L2_WITNESS.with(|w| w.set(false));
+        LATTICE_DOT_WITNESS.with(|w| w.set(false));
+
         let (a, b) = pair(768, 7);
+        let _ = l2_squared(&a, &b);
+        let _ = inner_products(&a, &b);
 
-        let l2_scalar = l2_squared_scalar(&a, &b);
-        let l2_routed = l2_squared(&a, &b);
-        assert_ne!(
-            l2_routed.to_bits(),
-            l2_scalar.to_bits(),
-            "l2_squared matched the scalar sum bit-for-bit with lattice-simd \
-             enabled; the routing at distance.rs may have reverted to scalar"
+        assert!(
+            LATTICE_L2_WITNESS.with(|w| w.get()),
+            "l2_squared did not call lattice_embed::simd::squared_euclidean_distance; \
+             the routing at distance.rs may have reverted to scalar"
         );
-
-        let dot_scalar: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
-        let (dot_routed, _, _) = inner_products(&a, &b);
-        assert_ne!(
-            dot_routed.to_bits(),
-            dot_scalar.to_bits(),
-            "cosine's dot product matched the scalar sum bit-for-bit with \
-             lattice-simd enabled; the routing at distance.rs may have \
-             reverted to scalar"
+        assert!(
+            LATTICE_DOT_WITNESS.with(|w| w.get()),
+            "inner_products did not call lattice_embed::simd::dot_product; \
+             the routing at distance.rs may have reverted to scalar"
         );
     }
 }

--- a/docs/research/nightly/2026-06-24-spann-partition-spill/README.md
+++ b/docs/research/nightly/2026-06-24-spann-partition-spill/README.md
@@ -267,7 +267,9 @@ The witness log integration path: each spill decision (vector id, primary partit
 
 ## Edge and WASM Implications
 
-`ruvector-spann` has zero external dependencies (`[dependencies]` is empty in `Cargo.toml`). Distance computation uses pure Rust scalar arithmetic. This makes it `no_std`-compatible with a static data source and suitable for WASM compilation via `wasm-pack`.
+`ruvector-spann`'s default feature configuration resolves no normal dependencies (`cargo tree -e normal` is a single node). Distance computation uses pure Rust scalar arithmetic in this configuration, making the default build `no_std`-compatible with a static data source and suitable for WASM compilation via `wasm-pack`.
+
+The optional `lattice-simd` feature adds `lattice-embed` for runtime-dispatched SIMD distance kernels and requires Rust 1.93. The edge and WASM guidance above applies to the default (scalar) feature configuration; enabling `lattice-simd` pulls in that dependency's MSRV and its own WASM SIMD128 support, and should be evaluated separately for constrained deployment targets.
 
 For Cognitum Seed edge deployment: a pre-built index (centroid matrix + serialized partition lists) can be compiled into a WASM binary at deploy time and queried in the browser or on constrained hardware without any runtime index building. Build-time spilling means the edge device never needs to re-evaluate the spill condition — the partitions are pre-computed.
 

--- a/docs/research/nightly/2026-06-24-spann-partition-spill/README.md
+++ b/docs/research/nightly/2026-06-24-spann-partition-spill/README.md
@@ -267,7 +267,7 @@ The witness log integration path: each spill decision (vector id, primary partit
 
 ## Edge and WASM Implications
 
-`ruvector-spann`'s default feature configuration resolves no normal dependencies (`cargo tree -e normal` is a single node). Distance computation uses pure Rust scalar arithmetic in this configuration, making the default build `no_std`-compatible with a static data source and suitable for WASM compilation via `wasm-pack`.
+`ruvector-spann`'s default feature configuration resolves no normal dependencies (`cargo tree -e normal` is a single node). Distance computation uses pure Rust scalar arithmetic in this configuration. The crate does not declare `#![no_std]` and uses `std::cmp::Ordering` in production code (`src/lib.rs`, `src/index.rs`), so it is not `no_std`-compatible today, and it has no tested `wasm-pack`/WASM build configuration; either would need to be added and verified before relying on them for edge deployment.
 
 The optional `lattice-simd` feature adds `lattice-embed` for runtime-dispatched SIMD distance kernels and requires Rust 1.93. The edge and WASM guidance above applies to the default (scalar) feature configuration; enabling `lattice-simd` pulls in that dependency's MSRV and its own WASM SIMD128 support, and should be evaluated separately for constrained deployment targets.
 


### PR DESCRIPTION
## What

`ruvector-spann/src/distance.rs` had four scalar iterator sums and no SIMD path.
`l2_squared` is called from eleven places across `index.rs` and `kmeans.rs`, so
it is the inner loop of partition assignment, spill selection, and search.

This adds an opt-in `lattice-simd` feature that routes the inner products
through `lattice-embed`'s runtime-dispatched SIMD kernels (AVX-512F, AVX2,
NEON, wasm32 SIMD128, each with a scalar fallback). It is the same backend
split as #762, so a reader who has seen that one already knows this shape.

**Default builds are unchanged.** With the feature off, the crate's resolved
normal dependency tree is still empty (`cargo tree -e normal` prints the single
`ruvector-spann` node); the manifest gains one optional dependency that a
default build never compiles, and the code compiled is the code that was here
before.

## What is deliberately *not* behind the feature flag

Only the accumulation moved. Length handling and the `1e-9` small-norm guard
stay outside the backend split, so both backends take identical branches and
can only differ in floating-point association.

Two specifics worth a reviewer's attention:

- `cosine_distance` is composed from three inner products rather than calling
  `lattice_embed::simd::cosine_similarity`. That function applies its own
  zero-norm rule, while this module's contract is "return 1.0 below 1e-9". Using
  `dot_product` three times keeps the threshold the single place either backend
  decides it.
- The lattice route is taken only when `a.len() == b.len()`. lattice returns
  `f32::MAX` (squared L2) or `0.0` (dot) on a mismatch, where the existing
  scalar path truncates to the shorter slice. The `debug_assert_eq!` already
  calls a mismatch a caller bug; guarding here means enabling the feature cannot
  silently change what a release build does with one.

## MSRV

`lattice-embed` requires Rust >= 1.93 (edition 2024) and Cargo cannot express a
per-feature `rust-version`, so turning `lattice-simd` on raises the effective
MSRV for whoever turns it on. This is the same trade-off `ruvector-core`
documents for `lattice-embeddings`, and the same shape as the existing
`simd-avx512` feature's documented per-feature bump (#438). Default builds are
unaffected.

The pin uses `default-features = false`, which excludes lattice-embed's model,
tokenizer, and download stack; what remains enabled is the SIMD kernel path
plus its small support dependencies, not a dependency-free graph.

## Verification

Both feature settings, `--locked`, on the same machine:

| build | result |
|-------|--------|
| `cargo test -p ruvector-spann --lib` | 12 passed, 0 failed |
| `cargo test -p ruvector-spann --lib --features lattice-simd` | 13 passed, 0 failed |

The default count includes the crate's existing k-means and index recall
acceptance tests, which exercise `l2_squared` through its real call sites
rather than directly. The feature build's extra test is a routing witness
asserting the lattice backend is actually the one called on the equal-length
path.

New `backend_matches_reference` compares whichever backend is compiled against
an f64 reference over 17 dimensions chosen to straddle the 4/8/16-lane widths
and the unrolled chunk sizes a SIMD backend uses, so remainder handling is
exercised rather than assumed. New `cosine_zero_vector_is_not_nan` pins the
small-norm branch.

**Reachability, checked rather than assumed.** A cfg-gated backend can be dead
and still let every test pass, so each arm was mutated individually and both
outcomes recorded:

| mutation | `--features lattice-simd` | default |
|----------|---------------------------|---------|
| `squared_euclidean_distance` -> `euclidean_distance` | 2 tests FAIL | 12 pass |
| `dot_product(b, b)` -> `dot_product(a, a)` in the cosine path | 1 test FAILS | 12 pass |

The failing column proves the lattice route is genuinely taken and the tests
detect it; the passing column proves each mutation stayed inside the `cfg`
block and the default path is untouched. Both were reverted; both settings are
green as pushed.

`cargo fmt --all -- --check` exits 0. `cargo clippy -p ruvector-spann
--all-targets` produces zero diagnostics attributable to `distance.rs` under
either feature setting (139 lines of clippy output on the feature build, none
naming the file).

## Cargo.lock

The lock gains the `lattice-embed 0.7.1` entry and disambiguates
`ruvector-core`'s existing `lattice-embed` edge to `0.6.1`, since two versions
now appear. Re-resolution also wanted to drift `tempfile`'s `getrandom` edge
from 0.3.4 to 0.4.3; that is unrelated to this change and was reverted, so the
diff is only the lattice entry. `cargo check --locked` passes on both feature
settings.

Both lattice-embed pins are behind off-by-default optional features, so a
default build compiles neither and the two versions only ever coexist in a
build that enables `ruvector-core/lattice-embeddings` and
`ruvector-spann/lattice-simd` at once. #758 moves the workspace pins to 0.7.1,
after which the question disappears; happy to rebase onto it if you would
rather land them in that order.

## Benchmarks

When this PR was first opened, no speed claim was made: the measurement host
was too noisy at the time to certify an A/B (ambient idle sampled at 50-63%,
under the floor the harness enforces), and the position taken was to open with
correctness evidence only. A quiet window later became available; the
Measurement section below supersedes this paragraph and records the numbers
with their conditions.



## Measurement

When this section was first written the crate had no benchmark to run — no
`[[bench]]` target, no `benches/` directory, no `criterion` dev-dependency —
and the position taken was that a harness should arrive as its own reviewable
change rather than ride under a backend flag. That harness now exists as #782.
The numbers below were produced by cherry-picking #782's commit onto this PR's
head locally; if #782 lands first, this branch measures cleanly as-is.

Apple silicon Mac mini, macOS, aarch64, rustc 1.93.0, `cargo bench -p
ruvector-spann --bench distance`, Criterion `--measurement-time 10`. This
crate's `default` feature set is empty, so the off side is the scalar path.
Same commit both phases; only the feature flag differs. CPU idle sampled every
20s inside each measured phase: off phase minimum 84%, on phase minimum 83% —
both phases quiet and symmetric, which is the cleanest window any measurement
in this PR series has had.

| benchmark | off (scalar) | on (lattice-embed) | change |
|-----------|--------------|--------------------|--------|
| `l2_squared/128` | 29.14 ns | 7.02 ns | -76.0% |
| `l2_squared/384` | 120.67 ns | 18.78 ns | -84.4% |
| `l2_squared/768` | 309.76 ns | 38.76 ns | -87.2% |
| `l2_squared/1536` | 692.15 ns | 79.58 ns | -88.5% |
| `cosine_distance/128` | 72.33 ns | 24.59 ns | -65.9% |
| `cosine_distance/384` | 349.17 ns | 54.09 ns | -84.5% |
| `cosine_distance/768` | 890.65 ns | 107.18 ns | -88.0% |
| `cosine_distance/1536` | 2.0258 us | 219.27 ns | -89.3% |

All p = 0.00. Inputs are seeded-random, not constant fills.

What this does and does not claim: these are kernel-level numbers on the two
functions this PR routes, measured through the crate's own new harness. Nothing
here measures the SPANN index end to end, and the sibling PRs show the
kernel-to-end-to-end ratio varies widely between crates. The feature is off by
default; the default build keeps the scalar path bit-for-bit.


---

**Note on this PR's CI.** `Tests (core-and-rest)` is red on every branch in this repository,
including `main`: the job is cancelled at its 240-minute cap while still compiling and never
reaches the test phase. #786 restores the exclusion list that the shard's `packages:` value loses
to a shell comment, #784 unblocks the `ruvector-filter` test target that the compiler cannot
finish, and #787 fixes a deadlock waiting behind both. That failure is not caused by this branch.

