### PR TITLE
perf(maxsim): compute each query token's norm once per document

### DIFF
--- a/crates/ruvector-maxsim/src/score.rs
+++ b/crates/ruvector-maxsim/src/score.rs
@@ -16,7 +16,20 @@ use crate::types::Embedding;
 #[inline]
 pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len(), "dimension mismatch in cosine");
-    cosine_with_lhs_norm(a, b, norm(a))
+    let mut dot = 0.0_f32;
+    let mut na = 0.0_f32;
+    let mut nb = 0.0_f32;
+    for (&ai, &bi) in a.iter().zip(b.iter()) {
+        dot += ai * bi;
+        na += ai * ai;
+        nb += bi * bi;
+    }
+    let denom = na.sqrt() * nb.sqrt();
+    if denom < f32::EPSILON {
+        0.0
+    } else {
+        dot / denom
+    }
 }
 
 /// L2 norm of a vector.
@@ -134,35 +147,22 @@ mod tests {
         assert!((s - 2.0).abs() < 1e-5, "expected ~2.0, got {s}");
     }
 
-    /// The pre-hoist cosine, kept verbatim: one fused loop, three
-    /// accumulators, the query norm recomputed for every pair.
+    /// MaxSim recomputed with the naive, un-hoisted formulation: every
+    /// pairwise score goes through the public [`cosine`], recomputing the
+    /// query token's norm on each call instead of once per query token.
     ///
-    /// Written out rather than delegating to [`cosine`] so that the oracle
-    /// shares no code with what it checks. Delegating would make a bug in the
-    /// shared helper cancel on both sides and the comparison pass anyway.
-    fn cosine_pre_hoist(a: &[f32], b: &[f32]) -> f32 {
-        let mut dot = 0.0_f32;
-        let mut na = 0.0_f32;
-        let mut nb = 0.0_f32;
-        for (&ai, &bi) in a.iter().zip(b.iter()) {
-            dot += ai * bi;
-            na += ai * ai;
-            nb += bi * bi;
-        }
-        let denom = na.sqrt() * nb.sqrt();
-        if denom < f32::EPSILON {
-            0.0
-        } else {
-            dot / denom
-        }
-    }
-
-    /// The pre-hoist formulation, kept verbatim as the oracle.
+    /// This is the property that matters after `cosine` went back to a
+    /// single fused pass: [`maxsim`]'s hoist (`norm(q)` once, then
+    /// [`cosine_with_lhs_norm`] per document token) must still agree with
+    /// calling the real `cosine` per pair. The two sides run genuinely
+    /// different code — one composes `norm` + `cosine_with_lhs_norm`, the
+    /// other calls fused `cosine` — so the comparison still guards a real
+    /// invariant instead of comparing a function with a hand-copy of itself.
     fn maxsim_recomputing_query_norm(q: &[Embedding], d: &[Embedding]) -> f32 {
         q.iter()
             .map(|qv| {
                 d.iter()
-                    .map(|dv| cosine_pre_hoist(qv, dv))
+                    .map(|dv| cosine(qv, dv))
                     .fold(f32::NEG_INFINITY, f32::max)
             })
             .sum()

--- a/crates/ruvector-maxsim/src/score.rs
+++ b/crates/ruvector-maxsim/src/score.rs
@@ -58,7 +58,11 @@ fn norm(v: &[f32]) -> f32 {
 ///
 /// Accumulates in the same order as [`cosine`] and combines the same two
 /// factors into the same denominator, so a caller that passes `norm(a)` gets
-/// bit-identical results to calling [`cosine`] directly.
+/// bit-identical results to calling [`cosine`] directly — but only when `a`
+/// and `b` have equal length: `norm_a` was computed over the full `a`, so a
+/// truncated zip over `a` and `b` here would combine a full-length norm with
+/// a truncated dot product. Callers with mismatched lengths must use
+/// [`cosine`] (or [`cosine_truncating`]) instead.
 #[inline]
 fn cosine_with_lhs_norm(a: &[f32], b: &[f32], norm_a: f32) -> f32 {
     debug_assert_eq!(a.len(), b.len(), "dimension mismatch in cosine");
@@ -76,13 +80,42 @@ fn cosine_with_lhs_norm(a: &[f32], b: &[f32], norm_a: f32) -> f32 {
     }
 }
 
+/// Fused cosine without [`cosine`]'s equal-length precondition: both norms
+/// and the dot product accumulate inside the same `zip`, so mismatched
+/// lengths truncate to the shorter vector rather than panicking in debug
+/// builds. This is [`maxsim`]'s fallback for query/document token pairs of
+/// differing dimension, where the hoisted `norm(q)` (taken over the full
+/// query) would otherwise be combined with a dot product truncated to the
+/// document's length.
+#[inline]
+fn cosine_truncating(a: &[f32], b: &[f32]) -> f32 {
+    let mut dot = 0.0_f32;
+    let mut na = 0.0_f32;
+    let mut nb = 0.0_f32;
+    for (&ai, &bi) in a.iter().zip(b.iter()) {
+        dot += ai * bi;
+        na += ai * ai;
+        nb += bi * bi;
+    }
+    let denom = na.sqrt() * nb.sqrt();
+    if denom < f32::EPSILON {
+        0.0
+    } else {
+        dot / denom
+    }
+}
+
 /// MaxSim score between a multi-vector query and a multi-vector document.
 ///
 /// Time: O(|query_vecs| * |doc_vecs| * D).
 ///
 /// Each query token's norm is computed once and reused across every document
-/// token, rather than being recomputed inside each pairwise cosine. The inner
-/// loop therefore does two multiply-adds per dimension instead of three.
+/// token of matching dimension, rather than being recomputed inside each
+/// pairwise cosine. The inner loop therefore does two multiply-adds per
+/// dimension instead of three. Pairs whose query and document tokens have
+/// different lengths fall back to [`cosine_truncating`], since the hoisted
+/// query norm is only bit-identical to per-pair cosine when both operands
+/// are the same length.
 pub fn maxsim(query_vecs: &[Embedding], doc_vecs: &[Embedding]) -> f32 {
     query_vecs
         .iter()
@@ -90,7 +123,13 @@ pub fn maxsim(query_vecs: &[Embedding], doc_vecs: &[Embedding]) -> f32 {
             let norm_q = norm(q);
             doc_vecs
                 .iter()
-                .map(|d| cosine_with_lhs_norm(q, d, norm_q))
+                .map(|d| {
+                    if q.len() == d.len() {
+                        cosine_with_lhs_norm(q, d, norm_q)
+                    } else {
+                        cosine_truncating(q, d)
+                    }
+                })
                 .fold(f32::NEG_INFINITY, f32::max)
         })
         .sum()
@@ -282,5 +321,32 @@ mod tests {
         assert_eq!(got, 0.0);
         assert!(got.is_finite());
         assert_eq!(got, maxsim_recomputing_query_norm(&q, &d));
+    }
+
+    /// A query token longer than the document token it is scored against
+    /// must fall back to the pre-hoist, truncating-zip cosine rather than
+    /// combining a norm taken over the full query with a dot product
+    /// truncated to the document's length. q=[3,4,12] vs d=[3,4]: the
+    /// truncating base semantics give dot=25, na=25 (truncated to 2 terms),
+    /// nb=25, so 25/(5*5)=1.0 exactly. The hoisted fast path would instead
+    /// divide by norm(q)=13, giving 25/(13*5)=0.3846....
+    #[test]
+    fn mismatched_query_longer_scores_via_truncating_fallback() {
+        let q = vec![vec![3.0_f32, 4.0, 12.0]];
+        let d = vec![vec![3.0_f32, 4.0]];
+        let got = maxsim(&q, &d);
+        assert_eq!(got, 1.0, "expected exact 1.0, got {got}");
+    }
+
+    /// The opposite mismatch direction — document token longer than the
+    /// query token — must also route through the truncating fallback and
+    /// agree with calling it directly on the same pair.
+    #[test]
+    fn mismatched_document_longer_matches_truncating_cosine() {
+        let q = vec![vec![3.0_f32, 4.0]];
+        let d = vec![vec![3.0_f32, 4.0, 12.0]];
+        let got = maxsim(&q, &d);
+        let want = cosine_truncating(&q[0], &d[0]);
+        assert_eq!(got, want);
     }
 }

--- a/crates/ruvector-maxsim/src/score.rs
+++ b/crates/ruvector-maxsim/src/score.rs
@@ -16,15 +16,34 @@ use crate::types::Embedding;
 #[inline]
 pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len(), "dimension mismatch in cosine");
+    cosine_with_lhs_norm(a, b, norm(a))
+}
+
+/// L2 norm of a vector.
+#[inline]
+fn norm(v: &[f32]) -> f32 {
+    let mut acc = 0.0_f32;
+    for &x in v.iter() {
+        acc += x * x;
+    }
+    acc.sqrt()
+}
+
+/// Cosine similarity with the left vector's norm supplied by the caller.
+///
+/// Accumulates in the same order as [`cosine`] and combines the same two
+/// factors into the same denominator, so a caller that passes `norm(a)` gets
+/// bit-identical results to calling [`cosine`] directly.
+#[inline]
+fn cosine_with_lhs_norm(a: &[f32], b: &[f32], norm_a: f32) -> f32 {
+    debug_assert_eq!(a.len(), b.len(), "dimension mismatch in cosine");
     let mut dot = 0.0_f32;
-    let mut na = 0.0_f32;
     let mut nb = 0.0_f32;
     for (&ai, &bi) in a.iter().zip(b.iter()) {
         dot += ai * bi;
-        na += ai * ai;
         nb += bi * bi;
     }
-    let denom = na.sqrt() * nb.sqrt();
+    let denom = norm_a * nb.sqrt();
     if denom < f32::EPSILON {
         0.0
     } else {
@@ -35,13 +54,18 @@ pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
 /// MaxSim score between a multi-vector query and a multi-vector document.
 ///
 /// Time: O(|query_vecs| * |doc_vecs| * D).
+///
+/// Each query token's norm is computed once and reused across every document
+/// token, rather than being recomputed inside each pairwise cosine. The inner
+/// loop therefore does two multiply-adds per dimension instead of three.
 pub fn maxsim(query_vecs: &[Embedding], doc_vecs: &[Embedding]) -> f32 {
     query_vecs
         .iter()
         .map(|q| {
+            let norm_q = norm(q);
             doc_vecs
                 .iter()
-                .map(|d| cosine(q, d))
+                .map(|d| cosine_with_lhs_norm(q, d, norm_q))
                 .fold(f32::NEG_INFINITY, f32::max)
         })
         .sum()
@@ -108,5 +132,95 @@ mod tests {
         let s = maxsim(&q, &d);
         // Each query token matches exactly one doc token → sum = 2.0
         assert!((s - 2.0).abs() < 1e-5, "expected ~2.0, got {s}");
+    }
+
+    /// The pre-hoist cosine, kept verbatim: one fused loop, three
+    /// accumulators, the query norm recomputed for every pair.
+    ///
+    /// Written out rather than delegating to [`cosine`] so that the oracle
+    /// shares no code with what it checks. Delegating would make a bug in the
+    /// shared helper cancel on both sides and the comparison pass anyway.
+    fn cosine_pre_hoist(a: &[f32], b: &[f32]) -> f32 {
+        let mut dot = 0.0_f32;
+        let mut na = 0.0_f32;
+        let mut nb = 0.0_f32;
+        for (&ai, &bi) in a.iter().zip(b.iter()) {
+            dot += ai * bi;
+            na += ai * ai;
+            nb += bi * bi;
+        }
+        let denom = na.sqrt() * nb.sqrt();
+        if denom < f32::EPSILON {
+            0.0
+        } else {
+            dot / denom
+        }
+    }
+
+    /// The pre-hoist formulation, kept verbatim as the oracle.
+    fn maxsim_recomputing_query_norm(q: &[Embedding], d: &[Embedding]) -> f32 {
+        q.iter()
+            .map(|qv| {
+                d.iter()
+                    .map(|dv| cosine_pre_hoist(qv, dv))
+                    .fold(f32::NEG_INFINITY, f32::max)
+            })
+            .sum()
+    }
+
+    fn vecs(count: usize, dim: usize, seed: u32) -> Vec<Embedding> {
+        let mut s = seed.wrapping_mul(2_654_435_761).wrapping_add(1);
+        let mut next = || {
+            s ^= s << 13;
+            s ^= s >> 17;
+            s ^= s << 5;
+            (s as f32 / u32::MAX as f32) * 2.0 - 1.0
+        };
+        (0..count)
+            .map(|_| (0..dim).map(|_| next()).collect())
+            .collect()
+    }
+
+    /// Hoisting the query norm must be exact, not merely close.
+    ///
+    /// The norm is accumulated in the same order and multiplied into the same
+    /// denominator either way, so any difference at all would mean the
+    /// refactor changed the arithmetic. Compared bitwise for that reason.
+    #[test]
+    fn hoisting_query_norm_is_bit_exact() {
+        for dim in [1usize, 3, 8, 16, 33, 128, 384] {
+            for (nq, nd) in [(1usize, 1usize), (1, 7), (5, 1), (4, 9)] {
+                let q = vecs(nq, dim, dim as u32);
+                let d = vecs(nd, dim, dim as u32 + 17);
+                let got = maxsim(&q, &d);
+                let want = maxsim_recomputing_query_norm(&q, &d);
+                assert_eq!(
+                    got.to_bits(),
+                    want.to_bits(),
+                    "dim={dim} nq={nq} nd={nd}: {got} vs {want}"
+                );
+            }
+        }
+    }
+
+    /// A zero-magnitude query token must still take the degenerate branch.
+    #[test]
+    fn zero_query_token_scores_zero() {
+        let q = vec![vec![0.0_f32; 8]];
+        let d = vecs(4, 8, 3);
+        assert_eq!(maxsim(&q, &d), 0.0);
+        assert_eq!(maxsim(&q, &d), maxsim_recomputing_query_norm(&q, &d));
+    }
+
+    /// A zero-magnitude document token must not poison the max.
+    #[test]
+    fn zero_doc_token_does_not_poison_max() {
+        let q = vecs(2, 8, 5);
+        let mut d = vecs(3, 8, 11);
+        d.push(vec![0.0_f32; 8]);
+        assert_eq!(
+            maxsim(&q, &d).to_bits(),
+            maxsim_recomputing_query_norm(&q, &d).to_bits()
+        );
     }
 }

--- a/crates/ruvector-maxsim/src/score.rs
+++ b/crates/ruvector-maxsim/src/score.rs
@@ -32,9 +32,21 @@ pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
     }
 }
 
+#[cfg(test)]
+thread_local! {
+    /// Test-only seam counting calls to [`norm`], which `maxsim` uses
+    /// exclusively for the hoisted per-query-token norm. Thread-local (not a
+    /// shared atomic) so parallel test threads never pollute each other's
+    /// count; a given test's `maxsim` call runs synchronously on its own
+    /// thread, so this is race-free without any lock.
+    static QUERY_NORM_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 /// L2 norm of a vector.
 #[inline]
 fn norm(v: &[f32]) -> f32 {
+    #[cfg(test)]
+    QUERY_NORM_CALLS.with(|c| c.set(c.get() + 1));
     let mut acc = 0.0_f32;
     for &x in v.iter() {
         acc += x * x;
@@ -222,5 +234,53 @@ mod tests {
             maxsim(&q, &d).to_bits(),
             maxsim_recomputing_query_norm(&q, &d).to_bits()
         );
+    }
+
+    /// The hoist must retain its shape, not just its output: `maxsim` must
+    /// compute each query token's norm exactly once, no matter how many
+    /// document tokens it is scored against. More than one document token is
+    /// used deliberately — a formulation that recomputes the query norm once
+    /// per document token would tie with the hoisted one when `nd == 1`.
+    #[test]
+    fn hoist_computes_query_norm_once_per_token_regardless_of_doc_count() {
+        let q = vecs(3, 8, 51);
+        let d = vecs(5, 8, 59);
+        QUERY_NORM_CALLS.with(|c| c.set(0));
+        let _ = maxsim(&q, &d);
+        let calls = QUERY_NORM_CALLS.with(|c| c.get());
+        assert_eq!(
+            calls,
+            q.len(),
+            "expected exactly one query-norm computation per query token \
+             regardless of document count, got {calls} for {} query tokens \
+             against {} document tokens",
+            q.len(),
+            d.len()
+        );
+    }
+
+    /// A document containing ONLY a zero-magnitude token must score 0.0 and
+    /// finite, not NaN silently masked by the max-fold's NaN-ignoring
+    /// semantics.
+    #[test]
+    fn zero_only_document_scores_zero_and_finite() {
+        let q = vecs(2, 8, 41);
+        let d = vec![vec![0.0_f32; 8]];
+        let got = maxsim(&q, &d);
+        assert_eq!(got, 0.0);
+        assert!(got.is_finite());
+        assert_eq!(got, maxsim_recomputing_query_norm(&q, &d));
+    }
+
+    /// Every document token being zero-magnitude (not just one among
+    /// otherwise-normal tokens) must still resolve to 0.0 and finite.
+    #[test]
+    fn all_zero_document_tokens_score_zero_and_finite() {
+        let q = vecs(2, 8, 43);
+        let d = vec![vec![0.0_f32; 8]; 4];
+        let got = maxsim(&q, &d);
+        assert_eq!(got, 0.0);
+        assert!(got.is_finite());
+        assert_eq!(got, maxsim_recomputing_query_norm(&q, &d));
     }
 }


### PR DESCRIPTION
## What

`maxsim` calls `cosine` once for every (query token, document token) pair, and
`cosine` recomputed the *query* token's norm inside each of those calls. For a
document of `m` tokens, the same `Σ q_i²` was accumulated `m` times.

This hoists it: each query token's norm is computed once and reused across the
whole document.

## Arithmetic

Counted by reading the loop, not measured:

| | multiplies per dimension, per pair | adds |
|---|---|---|
| before | 3 (`ai*bi`, `ai*ai`, `bi*bi`) | 3 |
| after | 2 (`ai*bi`, `bi*bi`) | 2 |

plus one `Σ q_i²` per query token, amortised over the whole document. For
documents of any realistic length the inner loop does two thirds of the work it
used to.

An earlier revision of this description attached no wall-clock figure because the
measurement host at the time could not certify one. Measurements were subsequently
taken under sampled idle conditions; see the Measurement section below.

## Correctness: bit-identical, and checked as such

The norm is accumulated in the same order and multiplied into the same
denominator either way, so this refactor should not move the result by a single
ULP. `hoisting_query_norm_is_bit_exact` asserts exactly that, comparing
`f32::to_bits()` rather than an epsilon, across 7 dimensions and 4
query/document shapes. An epsilon comparison would have hidden a real change in
the arithmetic behind a tolerance.

At the current head the comparison oracle is the shipping fused `cosine` itself:
since the second commit restored `cosine` to its own single-pass body, the hoisted
helper and `cosine` share no accumulation code, so a bug in either side cannot
cancel against the other. An earlier revision of this text described the oracle as
an independently written-out copy; that stopped being the implementation when
`cosine` was restored, and the claim is corrected here.

Two more tests pin the degenerate branches the `f32::EPSILON` denominator guard
exists for: `zero_query_token_scores_zero` and
`zero_doc_token_does_not_poison_max` (a zero-magnitude document token must
score 0.0 and lose the `max`, not become `NaN` and win it). Direct coverage of the
zero/NaN branch itself — single- and multi-token all-zero documents asserted exactly
0.0, finite, and equal to the per-pair oracle — was added in a later commit.

## Verification

`cargo test -p ruvector-maxsim --lib`: 31 passed, 0 failed at the current head
(26 when this section was first written; later commits added the call-count
witness, the direct zero-branch tests, and the mismatched-dimension regression
tests). That includes the
crate's existing flat / graph / bucket / hnsw index tests, which reach `maxsim`
through its four real call sites.

Mutation-sensitivity, each part mutated separately rather than the patch as a
whole:

| mutation | result |
|----------|--------|
| `norm()` returns the sum of squares without the `sqrt` | 2 tests fail |
| `cosine_with_lhs_norm` accumulates `ai*ai` into `nb` instead of `bi*bi` | 2 tests fail |

The second one is the important arm: it lives in the helper both the new and
old paths would share if the oracle delegated, so it is the mutation an
insufficiently independent test would have missed.

Both reverted. `cargo fmt --all -- --check` exits 0. `cargo clippy -p
ruvector-maxsim --all-targets` emits 175 lines and none of them name
`score.rs`.

### Mismatched-dimension semantics (current head)

Hoisting the query norm changed release-mode scores for mismatched-length
query/document pairs: the base fused loop truncated both norms to the shorter
length, while the hoisted path computed the full query norm. Flat and Bucket do
not validate query dimensions and HNSW validates documents only, so such inputs
are externally reachable. The current head routes equal-length pairs through the
hoisted path and mismatched-length pairs through a private fused truncating
cosine that reproduces the base accumulation exactly, restoring pre-hoist
semantics for every input. Two regression tests pin this; removing the branch in
a release build reproduces the predicted 25/(13*5) = 0.3846 counterexample.
Rejecting mismatched dimensions outright at the index boundary (as Graph already
does, and as the trait documentation promises) would be the stricter long-term
answer, but that is an API-contract change proposed separately rather than
smuggled into a perf PR.

## Scope

One file, no dependency change, no `Cargo.lock` change, no public API change:
`cosine` keeps its signature and (since the second commit) its original fused
single-pass body; the hoisted helper is private to `maxsim`.


## Measurement

Apple silicon Mac mini, macOS, aarch64, rustc 1.93.0, the crate's own
`maxsim_bench` target. Base is always the merge-base with `main`. Criterion
`--measurement-time 15`, baseline saved on the base phase. CPU idle sampled
every 20s inside each measured phase; per-phase minima are stated with each
run because the host also runs a browser with fluctuating load, and a figure
that hides its conditions is indistinguishable from one taken on a quiet
machine.

### Round 1 — hoist only (first head), and a regression it exposed

Idle minima: base 72%, head 87%. That asymmetry favours the head, which makes
the one regression below more credible, not less.

| group | change |
|-------|--------|
| FlatMaxSim/500 | -19.4% |
| FlatMaxSim/2000 | -20.1% |
| BucketMaxSim/500 | -3.4% |
| BucketMaxSim/2000 | **+2.9% regression** |
| HnswMaxSim/500 | within noise |
| HnswMaxSim/2000 | +2.4%, within noise |

The pattern maps exactly onto call structure. `FlatMaxSim::search` reaches this
module only through `maxsim`, which got the hoist: it improves. `BucketMaxSim`
and `HnswMaxSim` additionally call the public `cosine` directly (centroid
scoring, graph traversal), and the first version of this patch had made
`cosine` delegate to `norm(a)` + `cosine_with_lhs_norm` — two traversals of
`a` where the original fused loop did one. Callers that hold the query fixed
across many documents gained; callers invoking `cosine` once per pair paid.

### The fix

The second commit restores `cosine` to its original single fused pass (three
accumulators, one traversal) and keeps the hoisted path private to `maxsim`.
Direct `cosine` callers are byte-for-byte back on the pre-patch code path.

### Round 2 — at the current head

Idle minima: base 50%, head 62%. Below the bar I would call certified, and this
time the asymmetry runs against the base, which flatters the head; the reason
to believe the table anyway is agreement with round 1 on the untouched groups
(FlatMaxSim within a point across four independent runs) and the elimination
of a regression that the noisier base phase would tend to exaggerate, not hide.

| group | change |
|-------|--------|
| FlatMaxSim/500 | -20.7% |
| FlatMaxSim/2000 | -20.6% |
| BucketMaxSim/500 | -7.8% |
| BucketMaxSim/2000 | no change (p = 0.41) |
| HnswMaxSim/500 | -2.5%, within noise |
| HnswMaxSim/2000 | -5.7% |

The +2.9% Bucket regression is gone, Bucket/500 improves further (its Phase-2
`maxsim` still benefits while its Phase-1 centroid `cosine` no longer pays),
and no group is left worse than base. An earlier 5s-measurement run had shown
Bucket/2000 at +9.8%; Criterion warned it could not fit its sample count at
that size, and the 15s runs do not reproduce it, so it is discarded as
underpowered rather than averaged in.


---

**Note on this PR's CI.** `Tests (core-and-rest)` is red on every branch in this repository,
including `main`: the job is cancelled at its 240-minute cap while still compiling and never
reaches the test phase. #786 restores the exclusion list that the shard's `packages:` value loses
to a shell comment, #784 unblocks the `ruvector-filter` test target that the compiler cannot
finish, and #787 fixes a deadlock waiting behind both. That failure is not caused by this branch.

