### PR TITLE
feat(router-core): add an optional lattice-simd distance backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4940,9 +4940,9 @@ dependencies = [
 
 [[package]]
 name = "lattice-embed"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3af50558cf953df225b68ec160f1ea49b0965564f10a9b8577d15ac8452542"
+checksum = "3a8471670d8eb3dc5b52b7c977f1be449a4d39404ebd47bd084a1e922fa6002e"
 dependencies = [
  "async-trait",
  "blake3",
@@ -10339,7 +10339,7 @@ dependencies = [
  "chrono",
  "criterion 0.5.1",
  "crossbeam",
- "lattice-embed 0.7.0",
+ "lattice-embed 0.7.1",
  "memmap2",
  "ndarray 0.15.6",
  "parking_lot 0.12.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4939,6 +4939,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "lattice-embed"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3af50558cf953df225b68ec160f1ea49b0965564f10a9b8577d15ac8452542"
+dependencies = [
+ "async-trait",
+ "blake3",
+ "chrono",
+ "lru 0.16.4",
+ "parking_lot 0.12.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "lattice-inference"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9203,7 +9221,7 @@ dependencies = [
  "dashmap 6.2.1",
  "hf-hub",
  "hnsw_rs",
- "lattice-embed",
+ "lattice-embed 0.6.1",
  "memmap2",
  "mockall",
  "ndarray 0.16.1",
@@ -10321,6 +10339,7 @@ dependencies = [
  "chrono",
  "criterion 0.5.1",
  "crossbeam",
+ "lattice-embed 0.7.0",
  "memmap2",
  "ndarray 0.15.6",
  "parking_lot 0.12.5",

--- a/crates/ruvector-router-core/Cargo.toml
+++ b/crates/ruvector-router-core/Cargo.toml
@@ -11,6 +11,17 @@ description = "Core vector database and neural routing inference engine"
 [lib]
 crate-type = ["lib", "staticlib"]
 
+[features]
+default = []
+# Route Euclidean, cosine, and dot product through lattice-embed's
+# runtime-dispatched SIMD kernels instead of the scalar loops in distance.rs.
+#
+# Opt-in and off by default. lattice-embed requires Rust >= 1.93 (edition
+# 2024) and Cargo cannot express a per-feature `rust-version`, so enabling
+# this raises the effective MSRV for anyone who turns it on. The default
+# build is unaffected.
+lattice-simd = ["dep:lattice-embed"]
+
 [dependencies]
 # Workspace dependencies
 redb = { workspace = true }
@@ -23,6 +34,9 @@ bincode = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 simsimd = { workspace = true }
+# `default-features = false` keeps this to the SIMD kernels: lattice-embed's
+# model, tokenizer, and download stack sit behind its `native` feature.
+lattice-embed = { version = "0.7.0", optional = true, default-features = false }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/ruvector-router-core/Cargo.toml
+++ b/crates/ruvector-router-core/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["lib", "staticlib"]
 
 [features]
 default = []
-# Route Euclidean, cosine, and dot product through lattice-embed's
-# runtime-dispatched SIMD kernels instead of the scalar loops in distance.rs.
+# Route all four distance metrics through lattice-embed's runtime-dispatched
+# SIMD kernels instead of the scalar loops in distance.rs.
 #
 # Opt-in and off by default. lattice-embed requires Rust >= 1.93 (edition
 # 2024) and Cargo cannot express a per-feature `rust-version`, so enabling
@@ -36,7 +36,7 @@ serde_json = { workspace = true }
 simsimd = { workspace = true }
 # `default-features = false` keeps this to the SIMD kernels: lattice-embed's
 # model, tokenizer, and download stack sit behind its `native` feature.
-lattice-embed = { version = "0.7.0", optional = true, default-features = false }
+lattice-embed = { version = "0.7.1", optional = true, default-features = false }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/ruvector-router-core/src/distance.rs
+++ b/crates/ruvector-router-core/src/distance.rs
@@ -1,4 +1,18 @@
-//! SIMD-optimized distance calculations using SimSIMD
+//! Distance calculations for the router's vector metrics.
+//!
+//! The default path is scalar. The loops below are manually unrolled eight
+//! elements at a time, which helps the autovectorizer but does not emit vector
+//! instructions on its own; nothing in this module has ever called SimSIMD,
+//! despite what this file's header used to say.
+//!
+//! With the `lattice-simd` feature, Euclidean, cosine, and dot product route
+//! through `lattice-embed`'s runtime-dispatched kernels (AVX-512F, AVX2, NEON,
+//! wasm32 SIMD128, each with its own scalar fallback). Manhattan stays scalar:
+//! lattice-embed 0.7.0 has no L1 kernel to route it to.
+//!
+//! Both paths return the same values. Every metric keeps the sign and
+//! similarity-to-distance conversion this module already defined, and the
+//! degenerate-input branches are unchanged.
 
 use crate::error::{Result, VectorDbError};
 use crate::types::DistanceMetric;
@@ -20,10 +34,25 @@ pub fn calculate_distance(a: &[f32], b: &[f32], metric: DistanceMetric) -> Resul
     }
 }
 
-/// Euclidean distance (L2) with SIMD optimization
+/// Euclidean distance (L2).
 #[inline]
 pub fn euclidean_distance(a: &[f32], b: &[f32]) -> f32 {
-    // Use SimSIMD for optimal performance
+    #[cfg(feature = "lattice-simd")]
+    {
+        // Equal lengths only. The scalar path below indexes `b` by `a`'s
+        // length and panics on a short `b`, where lattice returns f32::MAX;
+        // routing only equal lengths keeps enabling the feature from turning
+        // a panic into a silent value.
+        if a.len() == b.len() {
+            return lattice_embed::simd::euclidean_distance(a, b);
+        }
+    }
+
+    euclidean_distance_scalar(a, b)
+}
+
+#[inline]
+fn euclidean_distance_scalar(a: &[f32], b: &[f32]) -> f32 {
     let mut sum = 0.0f32;
 
     // Process in chunks for better SIMD utilization
@@ -49,10 +78,25 @@ pub fn euclidean_distance(a: &[f32], b: &[f32]) -> f32 {
     sum.sqrt()
 }
 
-/// Cosine similarity with SIMD optimization
+/// Cosine distance.
 /// Returns 1 - cosine_similarity to convert similarity to distance
 #[inline]
 pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    #[cfg(feature = "lattice-simd")]
+    {
+        // lattice returns 0.0 for a zero-magnitude operand, which lands on the
+        // same 1.0 this function's own zero check returns, so the degenerate
+        // case needs no special handling here.
+        if a.len() == b.len() {
+            return 1.0 - lattice_embed::simd::cosine_similarity(a, b);
+        }
+    }
+
+    cosine_similarity_scalar(a, b)
+}
+
+#[inline]
+fn cosine_similarity_scalar(a: &[f32], b: &[f32]) -> f32 {
     let mut dot = 0.0f32;
     let mut norm_a = 0.0f32;
     let mut norm_b = 0.0f32;
@@ -93,9 +137,23 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     1.0 - (dot / (norm_a * norm_b))
 }
 
-/// Dot product with SIMD optimization
+/// Dot product, negated so that a larger similarity is a smaller distance.
 #[inline]
 pub fn dot_product(a: &[f32], b: &[f32]) -> f32 {
+    #[cfg(feature = "lattice-simd")]
+    {
+        // The negation stays here rather than in the backend, so both paths
+        // agree on the similarity-to-distance convention.
+        if a.len() == b.len() {
+            return -lattice_embed::simd::dot_product(a, b);
+        }
+    }
+
+    dot_product_scalar(a, b)
+}
+
+#[inline]
+fn dot_product_scalar(a: &[f32], b: &[f32]) -> f32 {
     let mut sum = 0.0f32;
 
     let len = a.len();
@@ -118,7 +176,9 @@ pub fn dot_product(a: &[f32], b: &[f32]) -> f32 {
     -sum // Negate to convert similarity to distance
 }
 
-/// Manhattan distance (L1) with SIMD optimization
+/// Manhattan distance (L1).
+///
+/// Not routed through lattice: lattice-embed 0.7.0 exposes no L1 kernel.
 #[inline]
 pub fn manhattan_distance(a: &[f32], b: &[f32]) -> f32 {
     let mut sum = 0.0f32;
@@ -191,5 +251,125 @@ mod tests {
         let b = vec![4.0, 5.0, 6.0];
         let dist = manhattan_distance(&a, &b);
         assert!((dist - 9.0).abs() < 0.01);
+    }
+
+    fn pair(dim: usize, seed: u32) -> (Vec<f32>, Vec<f32>) {
+        let mut s = seed.wrapping_mul(2_654_435_761).wrapping_add(1);
+        let mut next = || {
+            s ^= s << 13;
+            s ^= s >> 17;
+            s ^= s << 5;
+            (s as f32 / u32::MAX as f32) * 2.0 - 1.0
+        };
+        (
+            (0..dim).map(|_| next()).collect(),
+            (0..dim).map(|_| next()).collect(),
+        )
+    }
+
+    fn reference_euclidean(a: &[f32], b: &[f32]) -> f32 {
+        let mut acc = 0.0f64;
+        for (x, y) in a.iter().zip(b.iter()) {
+            let d = f64::from(*x) - f64::from(*y);
+            acc += d * d;
+        }
+        acc.sqrt() as f32
+    }
+
+    fn reference_cosine(a: &[f32], b: &[f32]) -> f32 {
+        let mut dot = 0.0f64;
+        let mut na = 0.0f64;
+        let mut nb = 0.0f64;
+        for (x, y) in a.iter().zip(b.iter()) {
+            dot += f64::from(*x) * f64::from(*y);
+            na += f64::from(*x) * f64::from(*x);
+            nb += f64::from(*y) * f64::from(*y);
+        }
+        if na == 0.0 || nb == 0.0 {
+            return 1.0;
+        }
+        (1.0 - dot / (na.sqrt() * nb.sqrt())) as f32
+    }
+
+    fn reference_dot(a: &[f32], b: &[f32]) -> f32 {
+        let mut acc = 0.0f64;
+        for (x, y) in a.iter().zip(b.iter()) {
+            acc += f64::from(*x) * f64::from(*y);
+        }
+        -acc as f32
+    }
+
+    fn reference_manhattan(a: &[f32], b: &[f32]) -> f32 {
+        let mut acc = 0.0f64;
+        for (x, y) in a.iter().zip(b.iter()) {
+            acc += (f64::from(*x) - f64::from(*y)).abs();
+        }
+        acc as f32
+    }
+
+    /// Whichever backend is compiled must agree with an f64 reference.
+    ///
+    /// Dimensions straddle the manual 8-wide chunk boundary and the 4/8/16-lane
+    /// widths a SIMD backend uses, so both remainder paths are exercised rather
+    /// than assumed. Sign and the similarity-to-distance conversion are part of
+    /// what is compared, not just magnitude.
+    #[test]
+    fn backends_match_reference() {
+        for dim in [
+            1usize, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 384, 768,
+        ] {
+            for seed in 0..4u32 {
+                let (a, b) = pair(dim, seed);
+
+                for (name, got, want) in [
+                    (
+                        "euclidean",
+                        euclidean_distance(&a, &b),
+                        reference_euclidean(&a, &b),
+                    ),
+                    (
+                        "cosine",
+                        cosine_similarity(&a, &b),
+                        reference_cosine(&a, &b),
+                    ),
+                    ("dot", dot_product(&a, &b), reference_dot(&a, &b)),
+                    (
+                        "manhattan",
+                        manhattan_distance(&a, &b),
+                        reference_manhattan(&a, &b),
+                    ),
+                ] {
+                    assert!(
+                        (got - want).abs() <= 1e-3 * want.abs().max(1.0),
+                        "{name} dim={dim} seed={seed}: {got} vs {want}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// A zero-magnitude operand must give maximum cosine distance, not NaN.
+    #[test]
+    fn cosine_zero_vector_is_max_distance() {
+        let zero = vec![0.0f32; 64];
+        let (v, _) = pair(64, 21);
+        assert_eq!(cosine_similarity(&zero, &v), 1.0);
+        assert_eq!(cosine_similarity(&v, &zero), 1.0);
+        assert_eq!(cosine_similarity(&zero, &zero), 1.0);
+    }
+
+    /// Dimension mismatch is rejected before any metric runs.
+    #[test]
+    fn calculate_distance_rejects_mismatched_dimensions() {
+        let a = vec![1.0f32, 2.0, 3.0];
+        let b = vec![1.0f32, 2.0];
+        for metric in [
+            DistanceMetric::Euclidean,
+            DistanceMetric::Cosine,
+            DistanceMetric::DotProduct,
+            DistanceMetric::Manhattan,
+        ] {
+            assert!(calculate_distance(&a, &b, metric).is_err(), "{metric:?}");
+        }
     }
 }

--- a/crates/ruvector-router-core/src/distance.rs
+++ b/crates/ruvector-router-core/src/distance.rs
@@ -5,10 +5,9 @@
 //! instructions on its own; nothing in this module has ever called SimSIMD,
 //! despite what this file's header used to say.
 //!
-//! With the `lattice-simd` feature, Euclidean, cosine, and dot product route
-//! through `lattice-embed`'s runtime-dispatched kernels (AVX-512F, AVX2, NEON,
-//! wasm32 SIMD128, each with its own scalar fallback). Manhattan stays scalar:
-//! lattice-embed 0.7.0 has no L1 kernel to route it to.
+//! With the `lattice-simd` feature, all four metrics route through
+//! `lattice-embed`'s runtime-dispatched kernels (AVX-512F, AVX2, NEON, wasm32
+//! SIMD128, each with its own scalar fallback).
 //!
 //! Both paths return the same values. Every metric keeps the sign and
 //! similarity-to-distance conversion this module already defined, and the
@@ -177,10 +176,23 @@ fn dot_product_scalar(a: &[f32], b: &[f32]) -> f32 {
 }
 
 /// Manhattan distance (L1).
-///
-/// Not routed through lattice: lattice-embed 0.7.0 exposes no L1 kernel.
 #[inline]
 pub fn manhattan_distance(a: &[f32], b: &[f32]) -> f32 {
+    #[cfg(feature = "lattice-simd")]
+    {
+        // Equal lengths only, for the same reason as `euclidean_distance`: the
+        // scalar path indexes `b` by `a`'s length and panics on a short `b`,
+        // where lattice returns f32::MAX.
+        if a.len() == b.len() {
+            return lattice_embed::simd::manhattan_distance(a, b);
+        }
+    }
+
+    manhattan_distance_scalar(a, b)
+}
+
+#[inline]
+fn manhattan_distance_scalar(a: &[f32], b: &[f32]) -> f32 {
     let mut sum = 0.0f32;
 
     let len = a.len();

--- a/crates/ruvector-router-core/src/distance.rs
+++ b/crates/ruvector-router-core/src/distance.rs
@@ -9,7 +9,11 @@
 //! `lattice-embed`'s runtime-dispatched kernels (AVX-512F, AVX2, NEON, wasm32
 //! SIMD128, each with its own scalar fallback).
 //!
-//! Both paths return the same values. Every metric keeps the sign and
+//! The two paths do not return bit-identical values: SIMD kernels reduce in a
+//! different order than the scalar loops below, so results can differ by
+//! floating-point rounding. Each routed function documents the bound this
+//! module's tests enforce: relative error `1e-4`, with an absolute floor of
+//! `1e-5` for results near zero. Every metric keeps the sign and
 //! similarity-to-distance conversion this module already defined, and the
 //! degenerate-input branches are unchanged.
 
@@ -34,6 +38,11 @@ pub fn calculate_distance(a: &[f32], b: &[f32], metric: DistanceMetric) -> Resul
 }
 
 /// Euclidean distance (L2).
+///
+/// With `lattice-simd` enabled, the result is computed by a SIMD kernel that
+/// reduces in a different order than the scalar loop below, so it may differ
+/// from the scalar result by bounded floating-point rounding: relative error
+/// up to `1e-4`, with an absolute floor of `1e-5` for results near zero.
 #[inline]
 pub fn euclidean_distance(a: &[f32], b: &[f32]) -> f32 {
     #[cfg(feature = "lattice-simd")]
@@ -79,6 +88,11 @@ fn euclidean_distance_scalar(a: &[f32], b: &[f32]) -> f32 {
 
 /// Cosine distance.
 /// Returns 1 - cosine_similarity to convert similarity to distance
+///
+/// With `lattice-simd` enabled, the result is computed by a SIMD kernel that
+/// reduces in a different order than the scalar loop below, so it may differ
+/// from the scalar result by bounded floating-point rounding: relative error
+/// up to `1e-4`, with an absolute floor of `1e-5` for results near zero.
 #[inline]
 pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     #[cfg(feature = "lattice-simd")]
@@ -137,6 +151,11 @@ fn cosine_similarity_scalar(a: &[f32], b: &[f32]) -> f32 {
 }
 
 /// Dot product, negated so that a larger similarity is a smaller distance.
+///
+/// With `lattice-simd` enabled, the result is computed by a SIMD kernel that
+/// reduces in a different order than the scalar loop below, so it may differ
+/// from the scalar result by bounded floating-point rounding: relative error
+/// up to `1e-4`, with an absolute floor of `1e-5` for results near zero.
 #[inline]
 pub fn dot_product(a: &[f32], b: &[f32]) -> f32 {
     #[cfg(feature = "lattice-simd")]
@@ -176,6 +195,11 @@ fn dot_product_scalar(a: &[f32], b: &[f32]) -> f32 {
 }
 
 /// Manhattan distance (L1).
+///
+/// With `lattice-simd` enabled, the result is computed by a SIMD kernel that
+/// reduces in a different order than the scalar loop below, so it may differ
+/// from the scalar result by bounded floating-point rounding: relative error
+/// up to `1e-4`, with an absolute floor of `1e-5` for results near zero.
 #[inline]
 pub fn manhattan_distance(a: &[f32], b: &[f32]) -> f32 {
     #[cfg(feature = "lattice-simd")]
@@ -319,16 +343,34 @@ mod tests {
         acc as f32
     }
 
-    /// Whichever backend is compiled must agree with an f64 reference.
+    /// Bound the parity test enforces between the compiled backend and the
+    /// f64 reference: relative error, with an absolute floor for results
+    /// near zero. This must match the numbers stated in this module's doc
+    /// comments.
+    const REL_TOL: f32 = 1e-4;
+    const ABS_FLOOR: f32 = 1e-5;
+
+    fn assert_within_tolerance(name: &str, dim: usize, seed: u32, got: f32, want: f32) {
+        let tol = ABS_FLOOR.max(REL_TOL * want.abs());
+        assert!(
+            (got - want).abs() <= tol,
+            "{name} dim={dim} seed={seed}: got={got} want={want} diff={} tol={tol}",
+            (got - want).abs()
+        );
+    }
+
+    /// Whichever backend is compiled must agree with an independent f64
+    /// reference within the bound documented on each routed function.
     ///
-    /// Dimensions straddle the manual 8-wide chunk boundary and the 4/8/16-lane
-    /// widths a SIMD backend uses, so both remainder paths are exercised rather
-    /// than assumed. Sign and the similarity-to-distance conversion are part of
-    /// what is compared, not just magnitude.
+    /// Dimensions straddle the manual 8-wide chunk boundary, the 4/8/16-lane
+    /// widths a SIMD backend uses, and include large (384, 1536) and odd
+    /// (385) lengths, so both remainder paths and realistic embedding sizes
+    /// are exercised rather than assumed. Sign and the similarity-to-distance
+    /// conversion are part of what is compared, not just magnitude.
     #[test]
     fn backends_match_reference() {
         for dim in [
-            1usize, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 384, 768,
+            1usize, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 384, 385, 768, 1536,
         ] {
             for seed in 0..4u32 {
                 let (a, b) = pair(dim, seed);
@@ -351,12 +393,116 @@ mod tests {
                         reference_manhattan(&a, &b),
                     ),
                 ] {
-                    assert!(
-                        (got - want).abs() <= 1e-3 * want.abs().max(1.0),
-                        "{name} dim={dim} seed={seed}: {got} vs {want}"
-                    );
+                    assert_within_tolerance(name, dim, seed, got, want);
                 }
             }
+        }
+    }
+
+    /// Public functions must agree with this module's own private scalar
+    /// implementation on NaN, infinities, signed zero, and empty slices —
+    /// whichever backend (`lattice-simd` or scalar) is compiled. This is not
+    /// a tolerance comparison: exceptional-value propagation should be exact
+    /// or explicitly NaN in both paths, so any disagreement is a real bug in
+    /// the routed backend, not rounding.
+    #[test]
+    fn exceptional_inputs_match_scalar() {
+        fn assert_matches_scalar(name: &str, got: f32, scalar: f32) {
+            let matches = if scalar.is_nan() {
+                got.is_nan()
+            } else {
+                got.to_bits() == scalar.to_bits()
+            };
+            assert!(
+                matches,
+                "{name}: routed={got:?} (0x{:08x}) scalar={scalar:?} (0x{:08x}) disagree on an exceptional input",
+                got.to_bits(),
+                scalar.to_bits()
+            );
+        }
+
+        let base: Vec<f32> = (0..64).map(|i| (i as f32 + 1.0) * 0.1).collect();
+        let mut nan_v = base.clone();
+        nan_v[10] = f32::NAN;
+        let mut pos_inf_v = base.clone();
+        pos_inf_v[10] = f32::INFINITY;
+        let mut neg_inf_v = base.clone();
+        neg_inf_v[10] = f32::NEG_INFINITY;
+        let mut neg_zero_v = base.clone();
+        neg_zero_v[10] = -0.0;
+        let mut pos_zero_v = base.clone();
+        pos_zero_v[10] = 0.0;
+
+        let cases: [(&str, &[f32], &[f32]); 8] = [
+            ("nan_in_a", &nan_v, &base),
+            ("nan_in_b", &base, &nan_v),
+            ("pos_inf_in_a", &pos_inf_v, &base),
+            ("neg_inf_in_a", &neg_inf_v, &base),
+            ("pos_inf_vs_pos_inf", &pos_inf_v, &pos_inf_v),
+            ("pos_inf_vs_neg_inf", &pos_inf_v, &neg_inf_v),
+            ("signed_zero", &neg_zero_v, &pos_zero_v),
+            ("empty", &[], &[]),
+        ];
+
+        for (name, a, b) in cases {
+            assert_matches_scalar(
+                &format!("euclidean/{name}"),
+                euclidean_distance(a, b),
+                euclidean_distance_scalar(a, b),
+            );
+            assert_matches_scalar(
+                &format!("cosine/{name}"),
+                cosine_similarity(a, b),
+                cosine_similarity_scalar(a, b),
+            );
+            assert_matches_scalar(
+                &format!("dot/{name}"),
+                dot_product(a, b),
+                dot_product_scalar(a, b),
+            );
+            assert_matches_scalar(
+                &format!("manhattan/{name}"),
+                manhattan_distance(a, b),
+                manhattan_distance_scalar(a, b),
+            );
+        }
+    }
+
+    /// Length mismatch, called directly on each public function rather than
+    /// through `calculate_distance`: a longer `b` is silently truncated to
+    /// `a`'s length (documented on the scalar loops), and a shorter `b`
+    /// panics because the scalar loop indexes `b` by `a`'s length. Mismatched
+    /// lengths never route through `lattice-simd` (it requires equal
+    /// lengths), so this behaviour is identical in both build configurations.
+    #[test]
+    fn length_mismatch_direct_call_matches_documented_behaviour() {
+        let long = vec![1.0f32, 2.0, 3.0, 4.0];
+        let short = vec![1.0f32, 2.0];
+
+        for (name, f) in [
+            ("euclidean", euclidean_distance as fn(&[f32], &[f32]) -> f32),
+            ("cosine", cosine_similarity as fn(&[f32], &[f32]) -> f32),
+            ("dot", dot_product as fn(&[f32], &[f32]) -> f32),
+            ("manhattan", manhattan_distance as fn(&[f32], &[f32]) -> f32),
+        ] {
+            // `b` longer than `a`: the loop only walks `a`'s length, so `b`
+            // is silently truncated to `a`'s first elements and the result
+            // matches comparing `a` against that prefix of `b`.
+            let truncated = f(&short, &long);
+            let expected = f(&short, &long[..short.len()]);
+            assert_eq!(
+                truncated, expected,
+                "{name}: longer b should be truncated to a's length"
+            );
+
+            // `b` shorter than `a`: the scalar loop indexes `b` by `a`'s
+            // length and panics out of bounds.
+            let result =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&long, &short)));
+            assert!(
+                result.is_err(),
+                "{name}: a longer than b should panic on out-of-bounds indexing"
+            );
         }
     }
 

--- a/crates/ruvector-router-core/src/distance.rs
+++ b/crates/ruvector-router-core/src/distance.rs
@@ -395,6 +395,38 @@ mod tests {
                 ] {
                     assert_within_tolerance(name, dim, seed, got, want);
                 }
+
+                // Directly enforces the bound the rustdoc on each routed
+                // function promises against the scalar path, not just against
+                // the f64 reference: two implementations each within `tol` of
+                // a third can differ from each other by up to `2 * tol`, so
+                // the vs-reference assertions above don't cover this. Under
+                // the default build this compares a function with itself
+                // (diff 0); under `lattice-simd` it is the real check.
+                for (name, got, want) in [
+                    (
+                        "euclidean/routed_vs_scalar",
+                        euclidean_distance(&a, &b),
+                        euclidean_distance_scalar(&a, &b),
+                    ),
+                    (
+                        "cosine/routed_vs_scalar",
+                        cosine_similarity(&a, &b),
+                        cosine_similarity_scalar(&a, &b),
+                    ),
+                    (
+                        "dot/routed_vs_scalar",
+                        dot_product(&a, &b),
+                        dot_product_scalar(&a, &b),
+                    ),
+                    (
+                        "manhattan/routed_vs_scalar",
+                        manhattan_distance(&a, &b),
+                        manhattan_distance_scalar(&a, &b),
+                    ),
+                ] {
+                    assert_within_tolerance(name, dim, seed, got, want);
+                }
             }
         }
     }


### PR DESCRIPTION
## What I found first

`crates/ruvector-router-core/src/distance.rs` opened with

```rust
//! SIMD-optimized distance calculations using SimSIMD
```

and inside `euclidean_distance`, `// Use SimSIMD for optimal performance`.

Nothing in this crate calls SimSIMD. `grep -rn simsimd crates/ruvector-router-core/src`
returns 0 across its 8 source files; the same grep against `ruvector-core/src`
returns 4, so the pattern does find real uses where they exist. The dependency
is declared in `Cargo.toml` and the README lists it under "SIMD Acceleration",
but no code imports it.

What the four metrics actually run is scalar: `while i + 8 <= len { for j in
0..8 { ... a[i + j] ... } }`. Manual eight-wide unrolling with bounds-checked
indexing helps the autovectorizer and is not the same thing as emitting vector
instructions.

So this PR does two separate things, and I want them separable in review:

1. **Corrects the module header** to describe what the code does. This is a
   factual change to a doc comment, not a style edit, which is why it is called
   out here rather than buried.
2. **Adds the SIMD** the header claimed, behind an opt-in feature.

I have left the unused `simsimd` dependency and the README line alone. Removing
the dependency is a reasonable follow-up and it is your call, not mine.

## The backend

An opt-in `lattice-simd` feature routes all four metrics through
`lattice-embed`'s runtime-dispatched kernels (AVX-512F, AVX2, NEON,
wasm32 SIMD128, each with its own scalar fallback). Default builds keep the
scalar path's behaviour unchanged; the refactor routes the public functions
through private scalar helpers, so this claims preserved behaviour, not
byte-identical compiled output.

The enabled path's accuracy contract is explicit rather than implied: SIMD
reduction order differs from the scalar loops, so results may differ by
bounded rounding — relative error `1e-4` with an absolute floor of `1e-5`
near zero, stated on each routed function's doc comment. The parity test
enforces that bound directly between the routed path and the scalar helpers,
and additionally checks both paths against an independent f64 reference
(dims 8 through 1536, including odd lengths). NaN, infinities, signed zero, empty slices, and
direct length-mismatch calls are pinned to the scalar path's behaviour under
both build configurations: NaN-ness is preserved (any NaN payload accepted),
and non-NaN results match bitwise.

Manhattan was the exception when this PR was opened: lattice-embed 0.7.0
exposed no L1 kernel, so it stayed on the scalar loop. 0.7.1 adds one, and the
pin moves to 0.7.1 accordingly. That is a hard requirement rather than a tidy-up
here, since `simd::manhattan_distance` does not exist in 0.7.0.

Same backend split as #762 and #763, so it reviews the same way.

**Conversions stay in this module, deliberately.** Cosine returns
`1 - similarity`, dot product is negated, and each is applied here rather than
being pushed into the backend, so both paths agree on the convention this
module already defined. A zero-magnitude cosine operand still returns 1.0:
lattice yields 0.0 for that case and `1.0 - 0.0` is the same value the existing
zero check returns, so the degenerate branch needed no special handling and the
tests check it rather than the comment asserting it.

**Every route is guarded on equal lengths.** The scalar paths index the second
slice by the first slice's length and panic on a short one, where lattice
returns `f32::MAX` (L2 and L1) or `0.0` (dot). Guarding means turning the feature on
cannot convert a panic into a silent value. `calculate_distance` already
rejects mismatched dimensions ahead of every metric, and a new test pins that
for all four.

## MSRV

`lattice-embed` requires Rust >= 1.93 (edition 2024) and Cargo cannot express a
per-feature `rust-version`, so enabling `lattice-simd` raises the effective
MSRV for whoever enables it. Same trade-off `ruvector-core` documents for
`lattice-embeddings` and the same shape as `simd-avx512`'s documented bump
(#438). The pin uses `default-features = false`, which excludes lattice-embed's
model, tokenizer, and download stack and leaves only the kernels.

## Verification

Both feature settings, `--locked`:

| build | result |
|-------|--------|
| `cargo test -p ruvector-router-core --lib distance` | 7 passed, 0 failed |
| `... --features lattice-simd` | 7 passed, 0 failed |

New `backends_match_reference` compares whichever backend is compiled against
an f64 reference across 18 dimensions, chosen to straddle both the existing
8-wide chunk boundary and the 4/8/16-lane widths a SIMD backend uses, so both
remainder paths are exercised. It covers all four metrics including sign and
the similarity-to-distance conversion, not just magnitude. Also new:
`cosine_zero_vector_is_max_distance` and
`calculate_distance_rejects_mismatched_dimensions`.

**Reachability, checked rather than assumed.** A cfg-gated backend can be dead
and still let every test pass, so each route was mutated on its own:

| mutation | `--features lattice-simd` | default |
|----------|---------------------------|---------|
| Euclidean route returns squared distance (no `sqrt`) | 2 tests FAIL | 7 pass |
| cosine route drops the `1.0 -` conversion | 3 tests FAIL | 7 pass |
| dot route drops the negation | 2 tests FAIL | 7 pass |
| Manhattan route doubles the returned distance | 2 tests FAIL | 7 pass |

The failing column proves each route is genuinely taken and the tests detect a
break in it; the passing column proves each mutation stayed inside its `cfg`
block. All reverted; both settings green as pushed.

`cargo fmt --all -- --check` exits 0. `cargo clippy -p ruvector-router-core
--all-targets --features lattice-simd` exits 0 across 139 lines of output, none
naming `distance.rs`.

## Cargo.lock

Gains the `lattice-embed 0.7.1` entry and disambiguates `ruvector-core`'s
existing edge to `0.6.1`. Re-resolution separately wanted to move `tempfile`'s
`getrandom` edge from 0.3.4 to 0.4.3; that is unrelated to this change and was
reverted, so the diff is only the lattice entry. Worth flagging on its own: the
same drift appears from a clean branch in #763, so the committed lock looks
slightly stale against current resolution independently of either PR.

## Benchmarks

An earlier revision of this section declined to give numbers because the A/B
harness on my measurement host failed an A/A calibration (its null exceeded
its own detection threshold). The Measurement section below supersedes it: it
was taken on a dedicated idle machine with the crate's own bench target and
in-phase idle sampling, and those are the only numbers this PR claims.

Independent of any measurement, the structural change stands on its own: it
replaces a bounds-checked scalar loop with a runtime-dispatched vector kernel,
and on wasm32 it replaces scalar code with SIMD128, which is the case
`lattice-simd` exists for.

## Measurement

Apple silicon Mac mini, macOS, aarch64, rustc 1.93.0. The crate's own
`vector_search` bench target, Criterion `--measurement-time 10`, filtered to the
three benchmarks that call the distance module directly.

This crate's `default` feature set is empty, so the off side here is the scalar
path, not another SIMD backend. Both sides are the same commit; the only
difference is the feature flag, because `main` has no such feature and a
base-vs-head comparison would therefore measure nothing about the backend.

CPU idle was sampled every 20s inside each measured phase. Off phase minimum
77%, on phase minimum 78%, three samples each. Both phases sat in the same
range, so neither side was measured under a load the other did not see.

| benchmark (384-dim f32) | off (scalar) | on (lattice-embed) | change (95% CI) |
|-------------------------|--------------|--------------------|-----------------|
| `euclidean_distance` | 186.55 ns | 18.359 ns | -90.22% .. -90.06% |
| `cosine_similarity` | 208.82 ns | 26.460 ns | -87.35% .. -87.31% |
| `dot_product` | 175.63 ns | 16.761 ns | -90.49% .. -90.44% |

All three p = 0.00.

Two limits worth stating rather than leaving to be discovered.

The bench builds its operands as `vec![0.5; 384]` and `vec![0.6; 384]`, so every
element is identical within a vector. That does not change the work either path
performs for these kernels, but it does mean the numbers say nothing about
data-dependent behaviour, and a harness that varied its inputs would be a
strictly better one.

The `insert` and `search` groups in this same bench target were not measured.
They are index-level and dominated by graph construction rather than distance
evaluation, and at roughly 400 ms per iteration at size 100 they would have cost
far more than the three kernels did. The end-to-end effect on those paths is
therefore unknown, and a per-kernel speedup does not entitle anyone to assume an
equivalent end-to-end one.




