### PR TITLE
feat(diskann): optional lattice-embed backend for f32 distance kernels, plus a native cross-dimension parity test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4939,6 +4939,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "lattice-embed"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8471670d8eb3dc5b52b7c977f1be449a4d39404ebd47bd084a1e922fa6002e"
+dependencies = [
+ "async-trait",
+ "blake3",
+ "chrono",
+ "lru 0.16.4",
+ "parking_lot 0.12.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "lattice-inference"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9203,7 +9221,7 @@ dependencies = [
  "dashmap 6.2.1",
  "hf-hub",
  "hnsw_rs",
- "lattice-embed",
+ "lattice-embed 0.6.1",
  "memmap2",
  "mockall",
  "ndarray 0.16.1",
@@ -9407,6 +9425,7 @@ dependencies = [
  "bincode 2.0.1",
  "bytemuck",
  "getrandom 0.2.17",
+ "lattice-embed 0.7.1",
  "memmap2",
  "parking_lot 0.12.5",
  "rand 0.8.6",

--- a/crates/ruvector-diskann/Cargo.toml
+++ b/crates/ruvector-diskann/Cargo.toml
@@ -11,6 +11,10 @@ description = "DiskANN/Vamana — SSD-friendly approximate nearest neighbor sear
 default = []
 gpu = []  # Feature flag for GPU acceleration (CUDA/Metal stubs)
 simd = ["simsimd"]
+# Route the f32 distance kernels through lattice-embed rather than SimSIMD.
+# Takes precedence over `simd` and over the wasm32 SIMD128 path when both are
+# enabled, so exactly one backend compiles for any feature/target combination.
+lattice-simd = ["lattice-embed"]
 # BET 1 (ADR-200): fixed-topology reuse + periodic rebuild under metric drift.
 reuse-under-drift = []
 
@@ -24,6 +28,11 @@ thiserror = { workspace = true }
 rand = { workspace = true }
 parking_lot = "0.12"
 bytemuck = { version = "1.14", features = ["derive"] }
+# Kernels only: `native` is the feature that pulls the model stack, so with
+# default features off this is a pure-Rust SIMD dependency with no tokenizer,
+# no model loader, and no download path. Unlike `simsimd` below it is not
+# target-gated, because it compiles for wasm32 as well.
+lattice-embed = { version = "0.7.1", optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # `rand` (used by PQ k-means training) pulls getrandom 0.2 transitively, which

--- a/crates/ruvector-diskann/Cargo.toml
+++ b/crates/ruvector-diskann/Cargo.toml
@@ -13,7 +13,9 @@ gpu = []  # Feature flag for GPU acceleration (CUDA/Metal stubs)
 simd = ["simsimd"]
 # Route the f32 distance kernels through lattice-embed rather than SimSIMD.
 # Takes precedence over `simd` and over the wasm32 SIMD128 path when both are
-# enabled, so exactly one backend compiles for any feature/target combination.
+# enabled, so exactly one route is selected for any feature/target
+# combination (the other backends' helper functions still compile; only the
+# dispatch arm actually called changes).
 lattice-simd = ["lattice-embed"]
 # BET 1 (ADR-200): fixed-topology reuse + periodic rebuild under metric drift.
 reuse-under-drift = []
@@ -31,7 +33,10 @@ bytemuck = { version = "1.14", features = ["derive"] }
 # Kernels only: `native` is the feature that pulls the model stack, so with
 # default features off this is a pure-Rust SIMD dependency with no tokenizer,
 # no model loader, and no download path. Unlike `simsimd` below it is not
-# target-gated, because it compiles for wasm32 as well.
+# target-gated, because it compiles for wasm32 as well. The kernels themselves
+# are pure Rust, but that does not make the feature's dependency tree
+# C-toolchain-free: blake3 (a transitive dependency) needs a target C compiler
+# on AArch64, where its build script compiles c/blake3_neon.c.
 lattice-embed = { version = "0.7.1", optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/ruvector-diskann/src/distance.rs
+++ b/crates/ruvector-diskann/src/distance.rs
@@ -194,19 +194,35 @@ impl FlatVectors {
 pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
     assert_eq!(a.len(), b.len(), "distance vectors must have equal lengths");
 
-    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    #[cfg(feature = "lattice-simd")]
+    {
+        lattice_embed::simd::squared_euclidean_distance(a, b)
+    }
+
+    #[cfg(all(
+        not(feature = "lattice-simd"),
+        target_arch = "wasm32",
+        target_feature = "simd128"
+    ))]
     {
         wasm_simd128_l2_squared(a, b)
     }
 
-    #[cfg(all(not(target_arch = "wasm32"), feature = "simd"))]
+    #[cfg(all(
+        not(feature = "lattice-simd"),
+        not(target_arch = "wasm32"),
+        feature = "simd"
+    ))]
     {
         simd_l2_squared(a, b)
     }
 
-    #[cfg(any(
-        all(target_arch = "wasm32", not(target_feature = "simd128")),
-        all(not(target_arch = "wasm32"), not(feature = "simd"))
+    #[cfg(all(
+        not(feature = "lattice-simd"),
+        any(
+            all(target_arch = "wasm32", not(target_feature = "simd128")),
+            all(not(target_arch = "wasm32"), not(feature = "simd"))
+        )
     ))]
     {
         scalar_l2_squared(a, b)
@@ -313,27 +329,51 @@ pub fn wasm_simd128_l2_squared(a: &[f32], b: &[f32]) -> f32 {
 pub fn inner_product(a: &[f32], b: &[f32]) -> f32 {
     assert_eq!(a.len(), b.len(), "distance vectors must have equal lengths");
 
-    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    #[cfg(feature = "lattice-simd")]
+    {
+        // Negated to match the other backends: this returns a distance for a
+        // min-heap, not a similarity. `SpatialSimilarity::inner` is a plain
+        // alias for `dot`, so both sides negate the same raw dot product.
+        -lattice_embed::simd::dot_product(a, b)
+    }
+
+    #[cfg(all(
+        not(feature = "lattice-simd"),
+        target_arch = "wasm32",
+        target_feature = "simd128"
+    ))]
     {
         wasm_simd128_inner_product(a, b)
     }
 
-    #[cfg(all(not(target_arch = "wasm32"), feature = "simd"))]
+    #[cfg(all(
+        not(feature = "lattice-simd"),
+        not(target_arch = "wasm32"),
+        feature = "simd"
+    ))]
     {
         simsimd::SpatialSimilarity::inner(a, b)
             .map(|d| -(d as f32))
             .unwrap_or_else(|| scalar_inner_product(a, b))
     }
 
-    #[cfg(any(
-        all(target_arch = "wasm32", not(target_feature = "simd128")),
-        all(not(target_arch = "wasm32"), not(feature = "simd"))
+    #[cfg(all(
+        not(feature = "lattice-simd"),
+        any(
+            all(target_arch = "wasm32", not(target_feature = "simd128")),
+            all(not(target_arch = "wasm32"), not(feature = "simd"))
+        )
     ))]
     {
         scalar_inner_product(a, b)
     }
 }
 
+/// Retained under `lattice-simd` as the reference implementation the parity
+/// test checks the compiled backend against, and as the fallback the other
+/// backends still call. `scalar_l2_squared` is `pub` and so needs no such
+/// annotation.
+#[cfg_attr(feature = "lattice-simd", allow(dead_code))]
 #[inline]
 fn scalar_inner_product(a: &[f32], b: &[f32]) -> f32 {
     let mut s0 = 0.0f32;
@@ -577,6 +617,66 @@ mod tests {
         let a = vec![1.0, 2.0, 3.0];
         let b = vec![4.0, 5.0, 6.0];
         assert!((inner_product(&a, &b) - (-32.0)).abs() < 1e-6);
+    }
+
+    /// Checks whichever backend compiled in against naive scalar references,
+    /// across dimensions chosen to straddle 4/8/16-lane widths **and their
+    /// remainders** so tail handling is exercised. The references are naive
+    /// single-pass loops rather than `scalar_l2_squared` / `scalar_inner_product`,
+    /// which are themselves 4-accumulator implementations, so a reduction-order
+    /// bug in the shared shape cannot hide.
+    ///
+    /// Backend-independent by construction: it covers the SimSIMD path, the
+    /// lattice path, and the plain scalar path. The cross-dimension parity
+    /// tests that existed before this were gated on
+    /// `all(target_arch = "wasm32", target_feature = "simd128")`, so no native
+    /// backend was checked at any dimension wider than 3.
+    #[test]
+    fn backend_matches_scalar_reference() {
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        fn naive_l2_squared(a: &[f32], b: &[f32]) -> f32 {
+            a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum()
+        }
+
+        fn naive_inner_product(a: &[f32], b: &[f32]) -> f32 {
+            -a.iter().zip(b).map(|(x, y)| x * y).sum::<f32>()
+        }
+
+        const DIMS: &[usize] = &[
+            0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 384, 768, 1000, 1023, 1024,
+        ];
+
+        // Combined absolute+relative tolerance, numpy `allclose`-style. A flat
+        // absolute bound is not achievable: each backend uses a different
+        // reduction tree, f32 addition is not associative, so reordering shifts
+        // rounding by a few ULPs and that drift grows with accumulated
+        // magnitude. A real bug (wrong lane math, dropped remainder) produces
+        // relative error orders of magnitude above machine epsilon.
+        const ATOL: f32 = 1e-5;
+        const RTOL: f32 = 1e-5;
+
+        let mut rng = StdRng::seed_from_u64(42);
+        for &dim in DIMS {
+            let a: Vec<f32> = (0..dim).map(|_| rng.gen_range(-10.0f32..10.0)).collect();
+            let b: Vec<f32> = (0..dim).map(|_| rng.gen_range(-10.0f32..10.0)).collect();
+
+            for (op, got, want) in [
+                ("l2_squared", l2_squared(&a, &b), naive_l2_squared(&a, &b)),
+                (
+                    "inner_product",
+                    inner_product(&a, &b),
+                    naive_inner_product(&a, &b),
+                ),
+            ] {
+                let bound = ATOL + RTOL * got.abs().max(want.abs());
+                assert!(
+                    (got - want).abs() <= bound,
+                    "{op} dim={dim}: got={got} want={want} bound={bound}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/ruvector-diskann/src/distance.rs
+++ b/crates/ruvector-diskann/src/distance.rs
@@ -1,23 +1,11 @@
 //! Distance computations with SIMD acceleration and optional GPU offload
 //!
-//! Dispatch priority: GPU (if `gpu` feature) → SimSIMD (if `simd` feature, native
-//! NEON/AVX2/AVX-512) → WASM SIMD128 (`wasm32` target with `simd128`
-//! target-feature) → scalar
+//! Dispatch priority: GPU (if `gpu` feature) → lattice-embed (if `lattice-simd`
+//! feature) → SimSIMD (if `simd` feature, native NEON/AVX2/AVX-512) → WASM
+//! SIMD128 (`wasm32` target with `simd128` target-feature) → scalar
 
 use crate::error::{DiskAnnError, Result};
 use memmap2::Mmap;
-
-/// Set from inside the `lattice-simd` dispatch arms, immediately alongside
-/// the real kernel call, so that swapping the arm's body for a scalar/native
-/// fallback (rather than genuinely calling `lattice_embed`) removes the
-/// `store` along with it. Compiled only for `lattice-simd` test builds — zero
-/// footprint elsewhere. See `lattice_backend_is_actually_invoked` below.
-#[cfg(all(test, feature = "lattice-simd"))]
-static LATTICE_L2_INVOKED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-#[cfg(all(test, feature = "lattice-simd"))]
-static LATTICE_INNER_INVOKED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
 
 /// Backing storage for the flat vector slab.
 ///
@@ -201,6 +189,46 @@ impl FlatVectors {
 // Distance functions — auto-dispatch based on features
 // ============================================================================
 
+/// Set from inside [`l2_lattice`]/[`inner_lattice`] below, only after the
+/// real kernel call returns — so a dispatch arm that swaps the wrapper call
+/// for a scalar/native fallback bypasses the flag along with the kernel.
+/// Thread-local (not a shared global) so a sibling test running on another
+/// thread can't set the flag between this test's reset and its assert.
+/// Compiled only for `lattice-simd` test builds — zero footprint elsewhere.
+/// See `lattice_backend_is_actually_invoked` below.
+#[cfg(all(test, feature = "lattice-simd"))]
+thread_local! {
+    static LATTICE_L2_INVOKED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static LATTICE_INNER_INVOKED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Sole caller of the `lattice-embed` L2 kernel — the dispatch arm in
+/// [`l2_squared`] can only reach the kernel through this wrapper, so
+/// replacing the arm's call expression with a fallback also removes the
+/// witness store.
+#[cfg(feature = "lattice-simd")]
+#[inline]
+fn l2_lattice(a: &[f32], b: &[f32]) -> f32 {
+    let result = lattice_embed::simd::squared_euclidean_distance(a, b);
+    #[cfg(test)]
+    LATTICE_L2_INVOKED.with(|invoked| invoked.set(true));
+    result
+}
+
+/// Sole caller of the `lattice-embed` dot-product kernel — see
+/// [`l2_lattice`] for why the store lives here rather than inline in the
+/// dispatch arm. Negated to match the other backends: this returns a
+/// distance for a min-heap, not a similarity. `SpatialSimilarity::inner` is a
+/// plain alias for `dot`, so both sides negate the same raw dot product.
+#[cfg(feature = "lattice-simd")]
+#[inline]
+fn inner_lattice(a: &[f32], b: &[f32]) -> f32 {
+    let result = -lattice_embed::simd::dot_product(a, b);
+    #[cfg(test)]
+    LATTICE_INNER_INVOKED.with(|invoked| invoked.set(true));
+    result
+}
+
 /// L2 squared distance — dispatches to best available implementation
 #[inline]
 pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
@@ -208,9 +236,7 @@ pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
 
     #[cfg(feature = "lattice-simd")]
     {
-        #[cfg(test)]
-        LATTICE_L2_INVOKED.store(true, std::sync::atomic::Ordering::Relaxed);
-        lattice_embed::simd::squared_euclidean_distance(a, b)
+        l2_lattice(a, b)
     }
 
     #[cfg(all(
@@ -345,12 +371,7 @@ pub fn inner_product(a: &[f32], b: &[f32]) -> f32 {
 
     #[cfg(feature = "lattice-simd")]
     {
-        // Negated to match the other backends: this returns a distance for a
-        // min-heap, not a similarity. `SpatialSimilarity::inner` is a plain
-        // alias for `dot`, so both sides negate the same raw dot product.
-        #[cfg(test)]
-        LATTICE_INNER_INVOKED.store(true, std::sync::atomic::Ordering::Relaxed);
-        -lattice_embed::simd::dot_product(a, b)
+        inner_lattice(a, b)
     }
 
     #[cfg(all(
@@ -385,10 +406,10 @@ pub fn inner_product(a: &[f32], b: &[f32]) -> f32 {
     }
 }
 
-/// Retained under `lattice-simd` as the reference implementation the parity
-/// test checks the compiled backend against, and as the fallback the other
-/// backends still call. `scalar_l2_squared` is `pub` and so needs no such
-/// annotation.
+/// Retained under `lattice-simd` as the fallback the `simd` backend still
+/// calls if SimSIMD returns `None`. The parity test's reference is the local
+/// `naive_inner_product`, not this function. `scalar_l2_squared` is `pub` and
+/// so needs no such annotation.
 #[cfg_attr(feature = "lattice-simd", allow(dead_code))]
 #[inline]
 fn scalar_inner_product(a: &[f32], b: &[f32]) -> f32 {
@@ -699,17 +720,17 @@ mod tests {
     /// against a naive oracle; scalar and lattice implement the same
     /// arithmetic, so a `lattice-simd` build that silently fell back to the
     /// scalar/native kernel would still pass it. This pins actual backend
-    /// *selection*: it fails if either dispatch arm's lattice call is
-    /// replaced by a fallback route while the feature stays declared, since
-    /// `LATTICE_L2_INVOKED` / `LATTICE_INNER_INVOKED` are only set from
-    /// inside those exact arms, right next to the real call.
+    /// *selection*: it fails if either dispatch arm's call to
+    /// [`l2_lattice`]/[`inner_lattice`] is replaced by a fallback route while
+    /// the feature stays declared, since the witness flags are only set
+    /// inside those wrappers, after the real kernel call returns. Thread-local
+    /// storage means a sibling test running concurrently on another thread
+    /// can't set these flags between this test's reset and its assert.
     #[test]
     #[cfg(feature = "lattice-simd")]
     fn lattice_backend_is_actually_invoked() {
-        use std::sync::atomic::Ordering;
-
-        LATTICE_L2_INVOKED.store(false, Ordering::Relaxed);
-        LATTICE_INNER_INVOKED.store(false, Ordering::Relaxed);
+        LATTICE_L2_INVOKED.with(|invoked| invoked.set(false));
+        LATTICE_INNER_INVOKED.with(|invoked| invoked.set(false));
 
         let a = vec![1.0f32, 2.0, 3.0, 4.0, 5.0];
         let b = vec![6.0f32, 7.0, 8.0, 9.0, 10.0];
@@ -717,11 +738,11 @@ mod tests {
         let _ = inner_product(&a, &b);
 
         assert!(
-            LATTICE_L2_INVOKED.load(Ordering::Relaxed),
+            LATTICE_L2_INVOKED.with(|invoked| invoked.get()),
             "l2_squared did not route through the lattice-embed kernel"
         );
         assert!(
-            LATTICE_INNER_INVOKED.load(Ordering::Relaxed),
+            LATTICE_INNER_INVOKED.with(|invoked| invoked.get()),
             "inner_product did not route through the lattice-embed kernel"
         );
     }

--- a/crates/ruvector-diskann/src/distance.rs
+++ b/crates/ruvector-diskann/src/distance.rs
@@ -7,6 +7,18 @@
 use crate::error::{DiskAnnError, Result};
 use memmap2::Mmap;
 
+/// Set from inside the `lattice-simd` dispatch arms, immediately alongside
+/// the real kernel call, so that swapping the arm's body for a scalar/native
+/// fallback (rather than genuinely calling `lattice_embed`) removes the
+/// `store` along with it. Compiled only for `lattice-simd` test builds — zero
+/// footprint elsewhere. See `lattice_backend_is_actually_invoked` below.
+#[cfg(all(test, feature = "lattice-simd"))]
+static LATTICE_L2_INVOKED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+#[cfg(all(test, feature = "lattice-simd"))]
+static LATTICE_INNER_INVOKED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 /// Backing storage for the flat vector slab.
 ///
 /// `Owned` is heap-resident — used while inserting/building, and by
@@ -196,6 +208,8 @@ pub fn l2_squared(a: &[f32], b: &[f32]) -> f32 {
 
     #[cfg(feature = "lattice-simd")]
     {
+        #[cfg(test)]
+        LATTICE_L2_INVOKED.store(true, std::sync::atomic::Ordering::Relaxed);
         lattice_embed::simd::squared_euclidean_distance(a, b)
     }
 
@@ -334,6 +348,8 @@ pub fn inner_product(a: &[f32], b: &[f32]) -> f32 {
         // Negated to match the other backends: this returns a distance for a
         // min-heap, not a similarity. `SpatialSimilarity::inner` is a plain
         // alias for `dot`, so both sides negate the same raw dot product.
+        #[cfg(test)]
+        LATTICE_INNER_INVOKED.store(true, std::sync::atomic::Ordering::Relaxed);
         -lattice_embed::simd::dot_product(a, b)
     }
 
@@ -677,6 +693,37 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// `backend_matches_scalar_reference` above only checks numerical parity
+    /// against a naive oracle; scalar and lattice implement the same
+    /// arithmetic, so a `lattice-simd` build that silently fell back to the
+    /// scalar/native kernel would still pass it. This pins actual backend
+    /// *selection*: it fails if either dispatch arm's lattice call is
+    /// replaced by a fallback route while the feature stays declared, since
+    /// `LATTICE_L2_INVOKED` / `LATTICE_INNER_INVOKED` are only set from
+    /// inside those exact arms, right next to the real call.
+    #[test]
+    #[cfg(feature = "lattice-simd")]
+    fn lattice_backend_is_actually_invoked() {
+        use std::sync::atomic::Ordering;
+
+        LATTICE_L2_INVOKED.store(false, Ordering::Relaxed);
+        LATTICE_INNER_INVOKED.store(false, Ordering::Relaxed);
+
+        let a = vec![1.0f32, 2.0, 3.0, 4.0, 5.0];
+        let b = vec![6.0f32, 7.0, 8.0, 9.0, 10.0];
+        let _ = l2_squared(&a, &b);
+        let _ = inner_product(&a, &b);
+
+        assert!(
+            LATTICE_L2_INVOKED.load(Ordering::Relaxed),
+            "l2_squared did not route through the lattice-embed kernel"
+        );
+        assert!(
+            LATTICE_INNER_INVOKED.load(Ordering::Relaxed),
+            "inner_product did not route through the lattice-embed kernel"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What this is, stated plainly

A fourth backend for `ruvector-diskann`'s two f32 distance kernels, behind an off-by-default
`lattice-simd` feature.

**This one is a substitution, not a gap-fill, and the difference is worth being clear about.**
The wasm argument that motivates the same feature in `ruvector-core` does not transfer here:
`ruvector-diskann` already has hand-written `simd128` kernels for both metrics, so wasm is covered
and lattice is not filling a hole. On native, SimSIMD already vectorizes. This is one SIMD
implementation swapped for another, and it should be judged on what the swap buys rather than on a
speed claim.

## What the swap buys

**A pure-Rust dependency in place of a C one.** `simsimd` builds its kernels through `build.rs` ->
`cc::Build` -> `c/lib.c`, so enabling `simd` here needs a working C toolchain at build time.
`lattice-embed`'s kernels are Rust `std::arch` intrinsics with runtime dispatch and no build
script of their own. One honesty note on the toolchain claim: this does not make the enabled
build C-free, because `lattice-embed`'s mandatory `blake3` dependency compiles a C NEON source
through its build script on aarch64 targets, so cross-compiling with `lattice-simd` enabled
still needs a target C compiler there. The swap removes the C dependency from the distance
kernels themselves, not from the feature's whole dependency tree.

**One dependency entry rather than a target-gated one.** `simsimd` is declared under
`[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` because it does not build for wasm32.
`lattice-embed` does, so it is a plain dependency.

**One kernel set across the workspace.** If `ruvector-core` routes through lattice, leaving
`diskann` on a different SIMD library means two implementations of the same arithmetic, with
independent rounding behaviour, inside one search path.

**On performance claims.** When this was first opened, no measurement was attached: at the time
the host could not certify A/B deltas in the plausible range (an A/A control on byte-identical
source produced differences up to 9.97%). The measurement section added later, below, supersedes
this position and states its own conditions and limits.

## The change

`l2_squared` and `inner_product` each gain a `lattice-simd` arm ahead of the existing three. The
arms stay mutually exclusive and exhaustive, so exactly one route is selected for any
feature/target combination (the other backends' helper functions still compile; only the
dispatch arm actually called changes):

| condition | backend |
|---|---|
| `lattice-simd` | `lattice_embed::simd` |
| else, wasm32 + `simd128` | existing `wasm_simd128_*` |
| else, non-wasm32 + `simd` | existing SimSIMD |
| else | existing scalar |

Default builds (`default = []`) are untouched and use the scalar path; `simd` (SimSIMD)
is opt-in.

`SpatialSimilarity::inner` is a plain alias for `dot` — it forwards directly, with no `1 - x`
transform — so the negation both paths apply is over the same raw dot product. I checked that at
the SimSIMD source rather than inferring it from the method name, because had the two differed by
a constant, the scalar fallback sitting beside it would already disagree with the SimSIMD path
today.

`scalar_inner_product` becomes unreachable in a `lattice-simd` build. It is annotated
`#[cfg_attr(feature = "lattice-simd", allow(dead_code))]` rather than deleted or made `pub`: it is
still the fallback the `simd` backend calls when SimSIMD returns `None`. (The parity test's
oracle is a separate local `naive_inner_product`, not this function.)

## A test gap this turned up, independent of lattice

The cross-dimension parity tests in this file are gated on
`#[cfg(all(test, target_arch = "wasm32", target_feature = "simd128"))]`. They are good tests: a
14-dimension grid straddling lane widths and remainders, with a documented tolerance. They only
ever run for wasm32.

The native backends' fixed-value checks all sat at dim 3 — below every lane width in play, so
they exercise a remainder loop and nothing else. (An identical-vectors check did run at dim 128,
but identical inputs cannot catch a wrong-value bug; no prior non-identical, reference-checked
native test exercised dimensions above 3.)

I did not want to assert the consequence of that without measuring it, so I injected a
dropped-remainder bug — truncating the distance computation to the first 3 lanes, which is exactly
correct at dim <= 3 and wrong above it — and ran the pre-existing suite against it:

| arm | pre-existing tests (new one excluded) | wall time |
|---|---|---|
| unmutated | 34 passed, 0 failed | 253.07s |
| dropped-remainder bug injected | **34 passed, 0 failed** | 2.66s |

The load-bearing result there is the pass/fail column, not the clock: the suite does not catch the
bug. On the wall times, one scope note — those two runs were sequential on a machine I did not
hold exclusively, so treat them as an order-of-magnitude observation rather than a controlled
timing measurement. The ratio is far too large to be contention, but I would rather bound the
claim than have it read as a benchmark.

That collapse is still the interesting part: those tests build indexes and drive the
wide-dimension distance path constantly, they simply never compare a value against a reference,
so an incorrect result above dim 3 has nothing asserting against it.

`backend_matches_scalar_reference` closes that, and fails on that same injected bug. It is
backend-independent by construction, so it covers the SimSIMD path shipping today, the scalar
path, and the lattice path alike, and it keeps its value in this file whether or not you take the
rest of this PR. Its references are naive single-pass loops rather than the crate's own `scalar_*`
functions, which are themselves 4-accumulator implementations — using those as the reference would
let a shared reduction-order bug pass.

## Verification

| arm | result |
|---|---|
| `test --features lattice-simd --lib` | 36 passed, 0 failed, 1 ignored |
| `test --features simd --lib` (SimSIMD, opt-in) | 35 passed, 0 failed, 1 ignored |
| `test --lib` (scalar, the default) | 35 passed, 0 failed, 1 ignored |
| `clippy --features lattice-simd --all-targets -- -D warnings` | clean |
| `clippy --all-targets -- -D warnings` | clean |

The scalar-oracle parity test runs in every configuration (named in each arm's output), which is
what shows it is backend-independent rather than compiled into one configuration; the
`lattice-simd` arm's one extra test is the cfg-gated routing witness.

Mutation-checked **per adapter**, not per patch, since mutating a patch as a unit only certifies
its best line:

| mutation | `lattice-simd` arm | default arm |
|---|---|---|
| l2 adapter: `squared_euclidean_distance` -> `euclidean_distance` | fails | stays green |
| inner adapter: drop the negation | fails | stays green |
| dropped-remainder bug (above) | fails | n/a, lattice arm only |

Each mutation leaving the default arm green is what proves it stayed inside its own `cfg` block
instead of breaking the crate outright.

## Two consequences worth stating

**This resolves a second copy of `lattice-embed` into the workspace.** `ruvector-core` pins
`0.6.1`; this pins `0.7.1`, which is the version the other in-flight lattice PRs move to. `^0.6`
and `^0.7` cannot unify, so until those land, a build enabling both `ruvector-core/lattice-embeddings`
and `ruvector-diskann/lattice-simd` compiles `lattice-embed` twice. Verified with `cargo tree`
rather than read off the lockfile. Whichever of these PRs lands second will want a lockfile
rebase.

**Debug-profile test time differed noticeably between arms** (the lattice arm ran longer than the
SimSIMD arm). I am deliberately not putting numbers on that: the arms ran sequentially on a shared
machine under varying load, it is a debug profile, and I have not controlled it. Flagging it only
so it is not a surprise, and it is worth a release-profile check before adoption.

## Cost

`lattice-embed` requires Rust >= 1.93. Enabling this feature raises the effective MSRV for whoever
turns it on. The default build is unaffected and stays on the workspace MSRV. That is the real
price and it is why the feature is opt-in.


## Measurement

When this section was first written the crate had no benchmark to run, and the
position taken was that the harness should be its own reviewable change. That
harness is now #783; the numbers below come from cherry-picking #783's commit
onto this PR's head locally (clean pick). If #783 lands first, this branch
measures as-is.

Apple silicon Mac mini, macOS, aarch64, rustc 1.93.0, `cargo bench -p
ruvector-diskann --bench distance`, Criterion `--measurement-time 10`. Same
commit both phases, only the feature flag differs. This crate's `default` is
empty, so off is the scalar path. CPU idle sampled every 20s inside each
measured phase: off minimum 85%, on minimum 78% — both phases quiet.

| benchmark | off | on (lattice-embed) | change |
|-----------|-----|--------------------|--------|
| `l2_squared/384` | 115.47 ns | 18.85 ns | -83.6% |
| `l2_squared/1536` | 459.15 ns | 79.57 ns | -82.7% |
| `inner_product/384` | 67.62 ns | 19.89 ns | -70.6% |
| `inner_product/1536` | 268.71 ns | 73.83 ns | -72.5% |
| `scalar_l2_squared/1536` | 460.23 ns | 446.40 ns | -3.1% |
| `pq_asymmetric_distance/1536` | 822.77 ns | 829.73 ns | +0.7% |

(128/768 dims behave the same as their neighbours; all p = 0.00; seeded-random
inputs.)

The last two rows are the table's own controls, and they are why the first
four are believable. `scalar_l2_squared` is deliberately not routed by this
feature and moves only ~3%; `pq_asymmetric_distance` is untouched and moves
under 1%. If the harness or the machine had shifted between phases, those two
rows are where it would show.

Kernel-level numbers only: nothing here measures DiskANN search end to end,
and the sibling PRs show the kernel-to-end-to-end ratio varies widely by
crate. The feature stays off by default.


---

**Note on this PR's CI.** `Tests (core-and-rest)` is red on every branch in this repository,
including `main`: the job is cancelled at its 240-minute cap while still compiling and never
reaches the test phase. #786 restores the exclusion list that the shard's `packages:` value loses
to a shell comment, #784 unblocks the `ruvector-filter` test target that the compiler cannot
finish, and #787 fixes a deadlock waiting behind both. That failure is not caused by this branch.



