### PR TITLE
feat(graph): optional lattice-embed kernels for the schema scan path, including the precomputed-norm cosine arm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4939,6 +4939,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "lattice-embed"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8471670d8eb3dc5b52b7c977f1be449a4d39404ebd47bd084a1e922fa6002e"
+dependencies = [
+ "async-trait",
+ "blake3",
+ "chrono",
+ "lru 0.16.4",
+ "parking_lot 0.12.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "lattice-inference"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9203,7 +9221,7 @@ dependencies = [
  "dashmap 6.2.1",
  "hf-hub",
  "hnsw_rs",
- "lattice-embed",
+ "lattice-embed 0.6.1",
  "memmap2",
  "mockall",
  "ndarray 0.16.1",
@@ -9636,6 +9654,7 @@ dependencies = [
  "hnsw_rs",
  "hyper 1.10.1",
  "lalrpop-util",
+ "lattice-embed 0.7.1",
  "lru 0.16.4",
  "lz4",
  "memmap2",

--- a/crates/ruvector-graph-wasm/Cargo.toml
+++ b/crates/ruvector-graph-wasm/Cargo.toml
@@ -62,7 +62,14 @@ wasm-bindgen-test = "0.3"
 
 [features]
 default = []
+# Note: on wasm32 this is effectively a no-op, because ruvector-core excludes
+# simsimd on that target and falls back to scalar.
 simd = ["ruvector-core/simd"]
+# Vectorized kernels that do reach wasm32, for both the core distance functions
+# and the graph schema scan path. Build with
+# `RUSTFLAGS="-C target-feature=+simd128"`; without that flag the kernels fall
+# back to scalar and this feature is a no-op.
+lattice-simd = ["ruvector-graph/lattice-simd"]
 
 # Ensure getrandom uses wasm_js/js features for WASM
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/ruvector-graph-wasm/Cargo.toml
+++ b/crates/ruvector-graph-wasm/Cargo.toml
@@ -62,8 +62,10 @@ wasm-bindgen-test = "0.3"
 
 [features]
 default = []
-# Note: on wasm32 this is effectively a no-op, because ruvector-core excludes
-# simsimd on that target and falls back to scalar.
+# On wasm32 this does not vectorize: ruvector-core gates its SimSIMD call sites
+# on `not(target_arch = "wasm32")` and takes the scalar arm there. Note it is the
+# call sites that are cfg'd out, not the crate — `simsimd` still resolves into
+# the wasm32 dependency graph.
 simd = ["ruvector-core/simd"]
 # Vectorized kernels that do reach wasm32, for both the core distance functions
 # and the graph schema scan path. Build with

--- a/crates/ruvector-graph/Cargo.toml
+++ b/crates/ruvector-graph/Cargo.toml
@@ -26,7 +26,7 @@ simsimd = { workspace = true, optional = true }
 # Kernels only: `default-features = false` keeps `lattice-inference` and the
 # model/tokenizer/download stack out of the tree. Unlike simsimd, these kernels
 # build for wasm32, which is what lets the schema layer stay WASM-safe.
-lattice-embed = { version = "0.7.0", optional = true, default-features = false }
+lattice-embed = { version = "0.7.1", optional = true, default-features = false }
 rayon = { workspace = true }
 crossbeam = { workspace = true }
 num_cpus = "1.16"

--- a/crates/ruvector-graph/Cargo.toml
+++ b/crates/ruvector-graph/Cargo.toml
@@ -23,6 +23,10 @@ hnsw_rs = { workspace = true, optional = true }
 
 # SIMD and performance
 simsimd = { workspace = true, optional = true }
+# Kernels only: `default-features = false` keeps `lattice-inference` and the
+# model/tokenizer/download stack out of the tree. Unlike simsimd, these kernels
+# build for wasm32, which is what lets the schema layer stay WASM-safe.
+lattice-embed = { version = "0.7.0", optional = true, default-features = false }
 rayon = { workspace = true }
 crossbeam = { workspace = true }
 num_cpus = "1.16"
@@ -111,6 +115,13 @@ full = ["simd", "storage", "async-runtime", "compression", "hnsw_rs", "ruvector-
 
 # SIMD optimizations
 simd = ["ruvector-core/simd", "simsimd"]
+
+# Explicit SIMD kernels for the schema-layer scan path, via lattice-embed.
+# Distinct from `simd` above in two ways: it reaches wasm32 (where simsimd is
+# unavailable, so `simd` leaves the scan scalar), and it carries no non-optional
+# dependency, so a no-feature build is unchanged. Raises the effective MSRV to
+# 1.93 for anyone who enables it. Off by default.
+lattice-simd = ["dep:lattice-embed"]
 
 # Storage backends
 storage = ["redb", "memmap2"]

--- a/crates/ruvector-graph/src/schema.rs
+++ b/crates/ruvector-graph/src/schema.rs
@@ -94,6 +94,13 @@ impl DistanceMetric {
                 // Single fused pass: accumulate q·c and c·c together so the
                 // candidate slice is read once (half the memory traffic of two
                 // separate `dot` calls).
+                //
+                // Deliberately left scalar even under `lattice-simd`. A kernel
+                // cosine takes only `(a, b)` and recomputes the query norm per
+                // candidate, which would discard the `query_norm` hoist this
+                // signature exists for, and would silently ignore a caller-supplied
+                // `query_norm` that differs from `‖query‖`. Vectorizing this arm
+                // needs a kernel that accepts a precomputed query norm.
                 let n = query.len().min(candidate.len());
                 let mut qc = 0.0f32;
                 let mut cc = 0.0f32;
@@ -110,6 +117,15 @@ impl DistanceMetric {
                 }
             }
             DistanceMetric::Euclidean => {
+                // Same equal-length guard as `dot`: the loop below truncates to
+                // the shorter slice, the kernel does not.
+                #[cfg(feature = "lattice-simd")]
+                {
+                    if query.len() == candidate.len() {
+                        return -lattice_embed::simd::euclidean_distance(query, candidate);
+                    }
+                }
+
                 let n = query.len().min(candidate.len());
                 let mut sum = 0.0f32;
                 for i in 0..n {
@@ -156,10 +172,24 @@ pub fn score_property(
 
 #[inline]
 fn dot(a: &[f32], b: &[f32]) -> f32 {
+    // With `lattice-simd`, use explicit kernels rather than relying on
+    // autovectorization. This stays WASM-safe and no-feature-build-safe, the two
+    // properties that kept `simsimd` out of this layer: the dependency is
+    // optional, and its kernels compile to `simd128` on wasm32 where `simsimd`
+    // is unavailable.
+    //
+    // The equal-length guard is required, not defensive. The iterator form below
+    // truncates to the shorter slice, while the kernel returns 0.0 on a length
+    // mismatch, so unequal inputs must keep taking the scalar path to preserve
+    // this function's existing behaviour.
+    #[cfg(feature = "lattice-simd")]
+    {
+        if a.len() == b.len() {
+            return lattice_embed::simd::dot_product(a, b);
+        }
+    }
+
     // Iterator form so LLVM auto-vectorizes (SSE/AVX/NEON) without bounds checks.
-    // SIMD via `simsimd`/ruvector-core is a follow-up (ADR-252 P5) but is
-    // deliberately not a hard dependency here so the schema layer stays WASM- and
-    // no-feature-build-safe.
     a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
 }
 
@@ -687,5 +717,79 @@ mod tests {
             .collect(),
         );
         assert!(s.validate_node(&n).is_ok());
+    }
+
+    /// Deterministic pseudo-random vectors, no dev-dependency needed.
+    fn vecs(dim: usize, seed: u32) -> (Vec<f32>, Vec<f32>) {
+        let mut s = seed.wrapping_mul(2_654_435_761).wrapping_add(1);
+        let mut next = || {
+            s ^= s << 13;
+            s ^= s >> 17;
+            s ^= s << 5;
+            (s as f32 / u32::MAX as f32) * 2.0 - 1.0
+        };
+        (
+            (0..dim).map(|_| next()).collect(),
+            (0..dim).map(|_| next()).collect(),
+        )
+    }
+
+    /// Whichever `dot` backend is compiled in must agree with a naive scalar sum.
+    ///
+    /// This is what catches a wrong kernel or a wrong adapter: swapping
+    /// `dot_product` for a different kernel, or dropping the negation on the
+    /// Euclidean arm, still compiles and fails here.
+    #[test]
+    fn test_score_pre_matches_scalar_reference() {
+        // Dimensions straddling 4/8/16-lane widths and their remainders.
+        for dim in [1usize, 3, 4, 7, 8, 15, 16, 17, 31, 64, 127, 384, 768] {
+            for seed in 0..4u32 {
+                let (q, c) = vecs(dim, seed);
+
+                let want_dot: f32 = q.iter().zip(&c).map(|(x, y)| x * y).sum();
+                let got_dot = DistanceMetric::DotProduct.score_pre(&q, &c, 0.0);
+                assert!(
+                    (got_dot - want_dot).abs() <= 1e-3 * want_dot.abs().max(1.0),
+                    "dot mismatch dim={dim} seed={seed}: got {got_dot}, want {want_dot}"
+                );
+
+                let want_euc =
+                    -q.iter().zip(&c).map(|(x, y)| (x - y) * (x - y)).sum::<f32>().sqrt();
+                let got_euc = DistanceMetric::Euclidean.score_pre(&q, &c, 0.0);
+                assert!(
+                    (got_euc - want_euc).abs() <= 1e-3 * want_euc.abs().max(1.0),
+                    "euclidean mismatch dim={dim} seed={seed}: got {got_euc}, want {want_euc}"
+                );
+
+                let qn = DistanceMetric::Cosine.query_norm(&q);
+                let want_qn = q.iter().map(|x| x * x).sum::<f32>().sqrt();
+                assert!(
+                    (qn - want_qn).abs() <= 1e-3 * want_qn.abs().max(1.0),
+                    "query_norm mismatch dim={dim} seed={seed}: got {qn}, want {want_qn}"
+                );
+            }
+        }
+    }
+
+    /// Unequal lengths must keep the truncating scalar behaviour. The kernels
+    /// return 0.0 on a length mismatch, so a missing guard would show up here as
+    /// a zero instead of the truncated dot product.
+    #[test]
+    fn test_unequal_lengths_truncate_not_zero() {
+        let q = vec![1.0f32, 2.0, 3.0, 4.0];
+        let c = vec![1.0f32, 1.0, 1.0];
+
+        let got = DistanceMetric::DotProduct.score_pre(&q, &c, 0.0);
+        assert!(
+            (got - 6.0).abs() < 1e-5,
+            "expected truncated dot 6.0, got {got}"
+        );
+
+        let got = DistanceMetric::Euclidean.score_pre(&q, &c, 0.0);
+        let want = -(0.0f32 + 1.0 + 4.0).sqrt();
+        assert!(
+            (got - want).abs() < 1e-5,
+            "expected truncated euclidean {want}, got {got}"
+        );
     }
 }

--- a/crates/ruvector-graph/src/schema.rs
+++ b/crates/ruvector-graph/src/schema.rs
@@ -19,6 +19,14 @@ use crate::types::PropertyValue;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Test-only witness for which cosine backend `score_pre` actually took. Lets a
+/// test assert *selection*, not just numerical agreement: a scalar reference
+/// can match the kernel's output by construction while the kernel call itself
+/// has been silently reverted to the fallback arm.
+#[cfg(all(test, feature = "lattice-simd"))]
+static COSINE_LATTICE_ROUTE_HIT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 /// Declared type of a node/edge property.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PropertyType {
@@ -101,6 +109,8 @@ impl DistanceMetric {
                 #[cfg(feature = "lattice-simd")]
                 {
                     if query.len() == candidate.len() {
+                        #[cfg(test)]
+                        COSINE_LATTICE_ROUTE_HIT.store(true, std::sync::atomic::Ordering::Relaxed);
                         return lattice_embed::simd::cosine_similarity_pre_normalized(
                             query, candidate, query_norm,
                         );
@@ -841,6 +851,30 @@ mod tests {
         assert!(
             (got - want).abs() < 1e-5,
             "expected truncated cosine {want}, got {got}"
+        );
+    }
+
+    /// Guards *selection*, not just numerical agreement: reverting the
+    /// `lattice-simd` cosine arm to the scalar fallback still produces a
+    /// correct score (that's the point of the fallback), so
+    /// `test_score_pre_matches_scalar_reference` alone would keep passing.
+    /// This test fails if the equal-length branch stops calling
+    /// `lattice_embed::simd::cosine_similarity_pre_normalized`.
+    #[cfg(feature = "lattice-simd")]
+    #[test]
+    fn test_cosine_equal_length_routes_through_lattice_backend() {
+        COSINE_LATTICE_ROUTE_HIT.store(false, std::sync::atomic::Ordering::Relaxed);
+
+        let q = vec![1.0f32, 2.0, 3.0, 4.0];
+        let c = vec![4.0f32, 3.0, 2.0, 1.0];
+        let qn = DistanceMetric::Cosine.query_norm(&q);
+        let _ = DistanceMetric::Cosine.score_pre(&q, &c, qn);
+
+        assert!(
+            COSINE_LATTICE_ROUTE_HIT.load(std::sync::atomic::Ordering::Relaxed),
+            "expected the equal-length cosine path to call \
+             lattice_embed::simd::cosine_similarity_pre_normalized; \
+             the scalar fallback ran instead"
         );
     }
 }

--- a/crates/ruvector-graph/src/schema.rs
+++ b/crates/ruvector-graph/src/schema.rs
@@ -23,9 +23,17 @@ use std::collections::HashMap;
 /// test assert *selection*, not just numerical agreement: a scalar reference
 /// can match the kernel's output by construction while the kernel call itself
 /// has been silently reverted to the fallback arm.
+///
+/// Per-thread (rather than a shared global) so that `cargo test`'s default
+/// one-thread-per-test execution can't let one test's cosine calls satisfy
+/// another test's assertion. Holds the actual value the lattice call
+/// returned (not just a flag), set only after that call returns, so the
+/// witness proves what came back rather than merely that a guarded branch
+/// was entered.
 #[cfg(all(test, feature = "lattice-simd"))]
-static COSINE_LATTICE_ROUTE_HIT: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+thread_local! {
+    static COSINE_LATTICE_ROUTE_HIT: std::cell::Cell<Option<f32>> = const { std::cell::Cell::new(None) };
+}
 
 /// Declared type of a node/edge property.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -109,11 +117,12 @@ impl DistanceMetric {
                 #[cfg(feature = "lattice-simd")]
                 {
                     if query.len() == candidate.len() {
-                        #[cfg(test)]
-                        COSINE_LATTICE_ROUTE_HIT.store(true, std::sync::atomic::Ordering::Relaxed);
-                        return lattice_embed::simd::cosine_similarity_pre_normalized(
+                        let result = lattice_embed::simd::cosine_similarity_pre_normalized(
                             query, candidate, query_norm,
                         );
+                        #[cfg(test)]
+                        COSINE_LATTICE_ROUTE_HIT.with(|hit| hit.set(Some(result)));
+                        return result;
                     }
                 }
 
@@ -858,23 +867,48 @@ mod tests {
     /// `lattice-simd` cosine arm to the scalar fallback still produces a
     /// correct score (that's the point of the fallback), so
     /// `test_score_pre_matches_scalar_reference` alone would keep passing.
-    /// This test fails if the equal-length branch stops calling
-    /// `lattice_embed::simd::cosine_similarity_pre_normalized`.
+    ///
+    /// The witness is written only after
+    /// `lattice_embed::simd::cosine_similarity_pre_normalized` returns, and
+    /// this test cross-checks the recorded value bit-for-bit against a
+    /// second, independent direct call to that same kernel function. A
+    /// reversion that swaps the call for an inline scalar computation (even
+    /// one bound to the same local and stored the same way) still shows up
+    /// here: the scalar sum's rounding practically never matches the
+    /// kernel's, so the two values diverge. Reverting the whole arm instead
+    /// leaves the witness unset, which the `.expect` below catches.
     #[cfg(feature = "lattice-simd")]
     #[test]
     fn test_cosine_equal_length_routes_through_lattice_backend() {
-        COSINE_LATTICE_ROUTE_HIT.store(false, std::sync::atomic::Ordering::Relaxed);
+        COSINE_LATTICE_ROUTE_HIT.with(|hit| hit.set(None));
 
-        let q = vec![1.0f32, 2.0, 3.0, 4.0];
-        let c = vec![4.0f32, 3.0, 2.0, 1.0];
+        // dim=17 straddles the 16-lane width with a one-element remainder,
+        // so the kernel's reduction order can't coincidentally match a
+        // sequential scalar sum.
+        let (q, c) = vecs(17, 5);
         let qn = DistanceMetric::Cosine.query_norm(&q);
-        let _ = DistanceMetric::Cosine.score_pre(&q, &c, qn);
+        let got = DistanceMetric::Cosine.score_pre(&q, &c, qn);
 
-        assert!(
-            COSINE_LATTICE_ROUTE_HIT.load(std::sync::atomic::Ordering::Relaxed),
-            "expected the equal-length cosine path to call \
-             lattice_embed::simd::cosine_similarity_pre_normalized; \
-             the scalar fallback ran instead"
+        let recorded = COSINE_LATTICE_ROUTE_HIT.with(|hit| hit.get()).expect(
+            "expected the equal-length cosine path to record a post-call \
+                 witness; the scalar fallback ran instead (or the lattice \
+                 arm never returned through the witnessed path)",
+        );
+        assert_eq!(
+            recorded.to_bits(),
+            got.to_bits(),
+            "witness value diverged from score_pre's own return value"
+        );
+
+        let direct = lattice_embed::simd::cosine_similarity_pre_normalized(&q, &c, qn);
+        assert_eq!(
+            recorded.to_bits(),
+            direct.to_bits(),
+            "expected the equal-length cosine path's witnessed value to \
+             bit-match a fresh, independent call into \
+             lattice_embed::simd::cosine_similarity_pre_normalized; got a \
+             different value, so the scan path did not actually return the \
+             kernel's result"
         );
     }
 }

--- a/crates/ruvector-graph/src/schema.rs
+++ b/crates/ruvector-graph/src/schema.rs
@@ -91,16 +91,25 @@ impl DistanceMetric {
         match self {
             DistanceMetric::DotProduct => dot(query, candidate),
             DistanceMetric::Cosine => {
+                // Takes the precomputed `query_norm` rather than recomputing
+                // `‖query‖` per candidate, so the hoist this signature exists for
+                // survives, and a caller-supplied norm that differs from `‖query‖`
+                // rescales the result exactly as the scalar arm below does.
+                //
+                // Equal-length guard for the same reason as `dot`: the fused loop
+                // truncates to the shorter slice, the kernel returns 0.0.
+                #[cfg(feature = "lattice-simd")]
+                {
+                    if query.len() == candidate.len() {
+                        return lattice_embed::simd::cosine_similarity_pre_normalized(
+                            query, candidate, query_norm,
+                        );
+                    }
+                }
+
                 // Single fused pass: accumulate q·c and c·c together so the
                 // candidate slice is read once (half the memory traffic of two
                 // separate `dot` calls).
-                //
-                // Deliberately left scalar even under `lattice-simd`. A kernel
-                // cosine takes only `(a, b)` and recomputes the query norm per
-                // candidate, which would discard the `query_norm` hoist this
-                // signature exists for, and would silently ignore a caller-supplied
-                // `query_norm` that differs from `‖query‖`. Vectorizing this arm
-                // needs a kernel that accepts a precomputed query norm.
                 let n = query.len().min(candidate.len());
                 let mut qc = 0.0f32;
                 let mut cc = 0.0f32;
@@ -175,8 +184,8 @@ fn dot(a: &[f32], b: &[f32]) -> f32 {
     // With `lattice-simd`, use explicit kernels rather than relying on
     // autovectorization. This stays WASM-safe and no-feature-build-safe, the two
     // properties that kept `simsimd` out of this layer: the dependency is
-    // optional, and its kernels compile to `simd128` on wasm32 where `simsimd`
-    // is unavailable.
+    // optional, and its kernels compile to `simd128` on wasm32 — where the
+    // SimSIMD-backed paths are cfg'd out and fall back to scalar.
     //
     // The equal-length guard is required, not defensive. The iterator form below
     // truncates to the shorter slice, while the kernel returns 0.0 on a length
@@ -753,8 +762,12 @@ mod tests {
                     "dot mismatch dim={dim} seed={seed}: got {got_dot}, want {want_dot}"
                 );
 
-                let want_euc =
-                    -q.iter().zip(&c).map(|(x, y)| (x - y) * (x - y)).sum::<f32>().sqrt();
+                let want_euc = -q
+                    .iter()
+                    .zip(&c)
+                    .map(|(x, y)| (x - y) * (x - y))
+                    .sum::<f32>()
+                    .sqrt();
                 let got_euc = DistanceMetric::Euclidean.score_pre(&q, &c, 0.0);
                 assert!(
                     (got_euc - want_euc).abs() <= 1e-3 * want_euc.abs().max(1.0),
@@ -766,6 +779,35 @@ mod tests {
                 assert!(
                     (qn - want_qn).abs() <= 1e-3 * want_qn.abs().max(1.0),
                     "query_norm mismatch dim={dim} seed={seed}: got {qn}, want {want_qn}"
+                );
+
+                // The cosine score itself, not just its hoisted norm. Reference is
+                // built from the naive sums rather than from `query_norm` above, so
+                // a norm that is wrong in the same direction on both sides cannot
+                // cancel out and pass.
+                let qc: f32 = q.iter().zip(&c).map(|(x, y)| x * y).sum();
+                let cn = c.iter().map(|y| y * y).sum::<f32>().sqrt();
+                let want_cos = if want_qn == 0.0 || cn == 0.0 {
+                    0.0
+                } else {
+                    qc / (want_qn * cn)
+                };
+                let got_cos = DistanceMetric::Cosine.score_pre(&q, &c, qn);
+                assert!(
+                    (got_cos - want_cos).abs() <= 1e-3 * want_cos.abs().max(1.0),
+                    "cosine mismatch dim={dim} seed={seed}: got {got_cos}, want {want_cos}"
+                );
+
+                // A caller-supplied norm that is not `‖query‖` must rescale the
+                // result, not be ignored. This is the property that made a plain
+                // two-argument kernel unusable for this signature, so it is
+                // asserted rather than assumed.
+                let scaled = DistanceMetric::Cosine.score_pre(&q, &c, qn * 2.0);
+                assert!(
+                    (scaled - want_cos / 2.0).abs() <= 1e-3 * (want_cos / 2.0).abs().max(1.0),
+                    "cosine ignored the supplied query_norm dim={dim} seed={seed}: \
+                     got {scaled}, want {}",
+                    want_cos / 2.0
                 );
             }
         }
@@ -790,6 +832,15 @@ mod tests {
         assert!(
             (got - want).abs() < 1e-5,
             "expected truncated euclidean {want}, got {got}"
+        );
+
+        // Cosine truncates too: q·c and ‖c‖ both over the first 3 lanes.
+        let qn = (1.0f32 + 4.0 + 9.0 + 16.0).sqrt();
+        let got = DistanceMetric::Cosine.score_pre(&q, &c, qn);
+        let want = 6.0f32 / (qn * 3.0f32.sqrt());
+        assert!(
+            (got - want).abs() < 1e-5,
+            "expected truncated cosine {want}, got {got}"
         );
     }
 }


### PR DESCRIPTION
## The gap, in your own words

`ruvector-graph`'s schema scan path scores every candidate through three hand-rolled scalar
loops. The `dot` helper carried this note:

> SIMD via `simsimd`/ruvector-core is a follow-up (ADR-252 P5) but is deliberately not a hard
> dependency here so the schema layer stays WASM- and no-feature-build-safe.

Those two constraints are the whole reason this layer is still scalar, and they are exactly what
`lattice-embed` satisfies:

- **Not a hard dependency.** It goes in `optional = true` behind an off-by-default `lattice-simd`
  feature, so a no-feature build is byte-for-byte the build you have now.
- **Reaches wasm32.** Its kernels compile to `simd128`, which is where this matters most: on
  wasm32 the `simd` feature does not vectorize this path at all.

One correction on that last point, because I found the existing note about it overstated. A
comment on `ruvector-graph-wasm`'s `simd` feature said `ruvector-core` *excludes* simsimd on
wasm32. It does not — `simsimd` is a plain optional dependency and still resolves into the wasm32
graph (`cargo tree --target wasm32-unknown-unknown` shows it, same count as the host). What is
actually gated is core's SimSIMD **call sites**, on `not(target_arch = "wasm32")`, so the feature
takes the scalar arm there. The conclusion holds, the stated mechanism did not, and this PR fixes
the comment.

## The change

All three metrics plus the query-norm hoist now route through `lattice-embed` under
`lattice-simd`, leaving the scalar bodies in place as the default and the length-mismatch path.

**The cosine arm is the interesting one.** It could not be vectorized by a conventional kernel,
and that is a design property of your API rather than an oversight: `score_pre` takes a
precomputed `query_norm` so a scan loop hoists `‖query‖` out of the per-candidate work. A
two-argument kernel cosine recomputes that norm on every candidate, which discards the hoist the
signature exists for, and silently ignores a caller-supplied norm that differs from `‖query‖`.

`lattice-embed` 0.7.1 adds `cosine_similarity_pre_normalized(query, candidate, query_norm)`, which
takes the precomputed norm and divides by it, so a supplied norm rescales the result exactly as
your scalar arm does. The pin is 0.7.1 rather than 0.7.0 because that function does not exist in
0.7.0 — a build requirement, not a tidy-up.

**Equal-length guards are required, not defensive.** Your scalar arms truncate to
`min(query.len(), candidate.len())`; the kernels return a fixed value on a length mismatch
instead. Unequal inputs keep taking the scalar path so the public behaviour of `score_pre` is
unchanged. `score_property` already rejects mismatched dimensions on both of its paths, so this
only concerns direct callers of `score_pre`.

## Verification

| arm | result |
|---|---|
| `test -p ruvector-graph --features lattice-simd --lib` | 180 passed, 0 failed, 3 ignored |
| `test -p ruvector-graph --lib` (default) | 179 passed, 0 failed, 3 ignored |
| `test -p ruvector-graph --features simd --lib` | 179 passed, 0 failed, 3 ignored |
| `clippy --features lattice-simd --all-targets -- -D warnings` | clean |
| `clippy --all-targets -- -D warnings` | clean |

The feature arm's extra test is a routing witness asserting the lattice cosine
backend is the one actually called on the equal-length scan path.

The parity test compares whichever backend compiled in against naive scalar references across
dimensions straddling 4/8/16-lane widths and their remainders, so it is backend-independent and
covers the scalar path too.

Test coverage added beyond the routing itself: the cosine **score** was previously unchecked (only
its hoisted norm was), there was no assertion that a caller-supplied norm rescales rather than
being ignored, and the truncation case covered dot and euclidean but not cosine.

Mutation-checked **per adapter**, not per patch, since mutating a patch as a unit only certifies
its best line:

| mutation | `lattice-simd` arm | default arm |
|---|---|---|
| `dot`: `dot_product(a, b)` -> `dot_product(a, a)` | fails | stays green |
| euclidean: drop the negation | fails | stays green |
| cosine: scale the result by 2 | fails | stays green |
| cosine: recompute the norm instead of using the supplied one | fails | stays green |

That last one is the reason the new assertion exists rather than being decoration: it is invisible
to every correctness check, because recomputing `‖query‖` gives the right answer whenever the
caller passed `‖query‖`. Under that mutation the plain cosine comparison stays silent and only the
rescaling assertion fires (`got 1, want 0.5`).

Each mutation leaving the default arm green is what proves it stayed inside its own `cfg` block
rather than breaking the crate outright.

## Two things worth stating

**This resolves a second copy of `lattice-embed` into the workspace.** `ruvector-core` pins
`^0.6`; this pins `^0.7`, and those cannot unify, so until the other in-flight lattice PRs land, a
build enabling both features compiles it twice. Verified with `cargo tree` rather than read off
the lockfile.

**On performance claims.** When this was first opened no measurement was attached: at the time
the host could not certify A/B deltas in the plausible range (an A/A control on byte-identical
source produced differences up to 9.97%). The Measurement section below was added later and
supersedes that position; it states explicitly what its two runs on a non-certified host do and
do not support.

## Cost

`lattice-embed` requires Rust >= 1.93, so enabling this feature raises the effective MSRV for
whoever turns it on. The default build is unaffected. That is the real price and it is why the
feature is opt-in and off by default.


## Measurement

Apple silicon Mac mini, macOS, aarch64, rustc 1.93.0, the crate's own
`typed_graph_bench` target, Criterion `--measurement-time 10`. Both phases are
the same commit and differ only by the feature flag: `main` has no such feature,
so a base-vs-head comparison would measure nothing about the backend.

Reach was established before measuring rather than assumed. The changed code is
`VectorSchema::score_pre` in `schema.rs`; `typed_graph_bench` drives the fused
`search_then_traverse` operator through `ruvector_graph::schema`, so the changed
path is on the benchmarked one.

| group | off | on | change (95% CI) | p |
|-------|-----|----|-----------------|---|
| `search_then_traverse/1000` | 119.31 us | 105.22 us | -12.36% .. -10.77% | 0.00 |
| `search_then_traverse/10000` | 658.11 us | 577.33 us | -11.96% .. -10.91% | 0.00 |
| `search_then_traverse/50000` | 4.7239 ms | 4.4194 ms | -6.64% .. -6.26% | 0.00 |
| `hash_embed_256` | 266.28 ns | 270.62 ns | -1.30% .. +2.27% | 1.00 |
| `validate_node` | 68.926 ns | 77.521 ns | +7.24% .. +13.24% | 0.00 |
| `rrf_2x1000` | 97.919 us | 97.178 us | -0.90% .. -0.41% | 0.00 |

The last three groups do not touch vector scoring, and they are the reason this
table is worth reading carefully rather than quoted for its first three rows.

`hash_embed_256` is flat at p = 1.00. That is the result a group outside the
change should give, and it says the harness did not shift uniformly between
phases.

`validate_node` moved +10%. Nothing in this diff can slow down node validation,
so that number is measuring the machine, not the code. It is a sub-100-nanosecond
benchmark, which is where ambient load shows up first.

### Conditions, and a second run

CPU idle was sampled every 20s inside each measured phase. Run 1: minimum 16%
off / 20% on. Run 2 (same commit, fresh baseline, later the same day): minimum
16% both phases. The host runs a browser whose CPU draw fluctuates and neither
run meets a quiet-machine bar; what carries the result is agreement between
the two runs, not either run's idle trace.

| group | run 1 | run 2 |
|-------|-------|-------|
| `search_then_traverse/1000` | -11.6% | -9.5% |
| `search_then_traverse/10000` | -11.4% | -15.2% |
| `search_then_traverse/50000` | -6.4% | -10.6% |
| `hash_embed_256` | +0.0% (p=1.00) | +1.5% |
| `validate_node` | +10.0% | +12.9% |
| `rrf_2x1000` | -0.7% | +3.6% |

`search_then_traverse` improves by ~9-15% in both runs at every size. That is
the changed path, and the direction and rough magnitude replicate under two
different noise profiles.

`validate_node` deserves the honest paragraph. It moved +10% and then +12.9% —
reproducing across runs, which ambient noise would not do — on a sub-100 ns
benchmark whose code this diff cannot reach. The remaining mechanism consistent
with both observations is a build-level effect: enabling the feature changes
what is compiled into the bench binary, and code layout shifts of that kind
land hardest on nanosecond-scale benchmarks. It is a real, reproducible cost of
flipping the feature on for this binary, but it is not a property of the
changed code path, and at index scale (the microsecond-and-up groups) no
corresponding penalty appears.

A certified-quiet re-run on a dedicated host is still the right ask before
these numbers are quoted as a benchmark. What two runs on a noisy host support
is: the scan path this PR touches gets a reproducible high-single to
low-double-digit improvement, the untouched microsecond-scale groups are flat,
and the one moving nanosecond group moves for build-layout reasons, not
algorithmic ones.


---

**Note on this PR's CI.** `Tests (core-and-rest)` is red on every branch in this repository,
including `main`: the job is cancelled at its 240-minute cap while still compiling and never
reaches the test phase. #786 restores the exclusion list that the shard's `packages:` value loses
to a shell comment, #784 unblocks the `ruvector-filter` test target that the compiler cannot
finish, and #787 fixes a deadlock waiting behind both. That failure is not caused by this branch.

