### PR TITLE
feat(tiny-dancer-core): make the cosine backend selectable, with a lattice-simd option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4939,6 +4939,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "lattice-embed"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8471670d8eb3dc5b52b7c977f1be449a4d39404ebd47bd084a1e922fa6002e"
+dependencies = [
+ "async-trait",
+ "blake3",
+ "chrono",
+ "lru 0.16.4",
+ "parking_lot 0.12.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "lattice-inference"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9203,7 +9221,7 @@ dependencies = [
  "dashmap 6.2.1",
  "hf-hub",
  "hnsw_rs",
- "lattice-embed",
+ "lattice-embed 0.6.1",
  "memmap2",
  "mockall",
  "ndarray 0.16.1",
@@ -10698,6 +10716,7 @@ dependencies = [
  "criterion 0.5.1",
  "crossbeam",
  "dashmap 6.2.1",
+ "lattice-embed 0.7.1",
  "memmap2",
  "ndarray 0.16.1",
  "once_cell",

--- a/crates/ruvector-tiny-dancer-core/Cargo.toml
+++ b/crates/ruvector-tiny-dancer-core/Cargo.toml
@@ -11,6 +11,14 @@ description = "Production-grade AI agent routing system with FastGRNN neural inf
 [lib]
 crate-type = ["lib", "staticlib"]
 
+[features]
+# The cosine kernel behind candidate scoring. Exactly one backend compiles;
+# `lattice-simd` wins if both are on. `--no-default-features` leaves the scalar
+# path, which is also the reference the parity test checks the others against.
+default = ["simd-simsimd"]
+simd-simsimd = ["dep:simsimd"]
+lattice-simd = ["dep:lattice-embed"]
+
 [dependencies]
 # Workspace dependencies
 redb = { workspace = true }
@@ -20,7 +28,15 @@ crossbeam = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-simsimd = { workspace = true }
+simsimd = { workspace = true, optional = true }
+# Pure-Rust SIMD kernels with runtime dispatch, and the only one of the three
+# backends that compiles for wasm32. `default-features = false` keeps this to
+# the kernels: the model, tokenizer and download stack stay out of the graph.
+#
+# NOTE: lattice-embed requires Rust >= 1.93. Cargo cannot express a per-feature
+# `rust-version`, so enabling `lattice-simd` raises the effective MSRV for
+# whoever turns it on. The default build is unaffected.
+lattice-embed = { version = "0.7.1", optional = true, default-features = false }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/ruvector-tiny-dancer-core/README.md
+++ b/crates/ruvector-tiny-dancer-core/README.md
@@ -322,9 +322,31 @@ let scores = model.forward_batch(&inputs)?;
 
 ### SIMD Acceleration
 
-Feature extraction uses `simsimd` for hardware-accelerated similarity:
-- Cosine similarity: **144ns** (384-dim vectors)
+Feature extraction's cosine similarity kernel is selected by Cargo feature:
+
+| Feature | Backend | Notes |
+|---------|---------|-------|
+| `simd-simsimd` (default) | `simsimd` | Unchanged default behavior; the 144ns benchmark below is this path. |
+| `lattice-simd` | `lattice-embed` | Opt-in. Wins at runtime if both features are enabled. Requires Rust >= 1.93; the default build stays on the workspace MSRV. |
+| *(no features)* | scalar fallback | `--no-default-features` with neither backend enabled. |
+
+- Cosine similarity: **144ns** (384-dim vectors, default `simd-simsimd` backend)
 - Batch processing: **Linear scaling** with candidate count
+
+```sh
+# Default: simd-simsimd
+cargo build -p ruvector-tiny-dancer-core
+
+# Opt into lattice-simd (still compiles simsimd into the dependency graph,
+# since features are additive; lattice wins the runtime selection)
+cargo build -p ruvector-tiny-dancer-core --features lattice-simd
+
+# Lattice only, with simsimd excluded from the dependency graph entirely
+cargo build -p ruvector-tiny-dancer-core --no-default-features --features lattice-simd
+
+# Scalar fallback, no SIMD backend compiled in
+cargo build -p ruvector-tiny-dancer-core --no-default-features
+```
 
 ### Zero-Copy Operations
 

--- a/crates/ruvector-tiny-dancer-core/src/feature_engineering.rs
+++ b/crates/ruvector-tiny-dancer-core/src/feature_engineering.rs
@@ -5,6 +5,7 @@
 use crate::error::{Result, TinyDancerError};
 use crate::types::Candidate;
 use chrono::Utc;
+#[cfg(all(not(feature = "lattice-simd"), feature = "simd-simsimd"))]
 use simsimd::SpatialSimilarity;
 
 /// Feature vector for a candidate
@@ -130,7 +131,13 @@ impl FeatureEngineer {
             .collect()
     }
 
-    /// Compute cosine similarity using SIMD-optimized simsimd
+    /// Cosine similarity between two equal-length vectors.
+    ///
+    /// The kernel is feature-selected and exactly one arm compiles. All three
+    /// agree on the boundary conventions, which `backend_matches_scalar_reference`
+    /// checks: two all-zero vectors score `1.0`, and a zero vector against a
+    /// non-zero one scores `0.0`. Those are the values this path has always
+    /// returned, and a backend swap is not the place to change them.
     fn cosine_similarity(&self, a: &[f32], b: &[f32]) -> Result<f32> {
         if a.len() != b.len() {
             return Err(TinyDancerError::InvalidInput(format!(
@@ -140,12 +147,32 @@ impl FeatureEngineer {
             )));
         }
 
-        // Use simsimd for SIMD-accelerated cosine similarity
-        let similarity = f32::cosine(a, b)
-            .ok_or_else(|| TinyDancerError::FeatureError("Cosine similarity failed".to_string()))?;
+        #[cfg(feature = "lattice-simd")]
+        {
+            // Returns similarity directly, so there is no `1 - x` here. It also
+            // reports 0.0 for a zero norm, which collides with the genuine
+            // "orthogonal" answer, so the all-zero case is separated out on the
+            // cold path to keep the conventions above.
+            let similarity = lattice_embed::simd::cosine_similarity(a, b);
+            if similarity == 0.0 && is_all_zero(a) && is_all_zero(b) {
+                return Ok(1.0);
+            }
+            Ok(similarity)
+        }
 
-        // Convert distance to similarity (simsimd returns distance as f64)
-        Ok(1.0_f32 - similarity as f32)
+        #[cfg(all(not(feature = "lattice-simd"), feature = "simd-simsimd"))]
+        {
+            // `SpatialSimilarity::cosine` returns a DISTANCE, hence the `1 - x`.
+            let distance = f32::cosine(a, b).ok_or_else(|| {
+                TinyDancerError::FeatureError("Cosine similarity failed".to_string())
+            })?;
+            Ok(1.0_f32 - distance as f32)
+        }
+
+        #[cfg(all(not(feature = "lattice-simd"), not(feature = "simd-simsimd")))]
+        {
+            Ok(scalar_cosine_similarity(a, b))
+        }
     }
 
     /// Calculate recency score using exponential decay
@@ -201,6 +228,36 @@ impl Default for FeatureEngineer {
     }
 }
 
+/// Scalar cosine similarity. Serves as the `--no-default-features` backend and
+/// as the reference `backend_matches_scalar_reference` checks the compiled
+/// backend against, so it stays compiled even when a SIMD arm is selected.
+///
+/// A zero norm is not an error here: two all-zero vectors score `1.0` and a
+/// zero vector against a non-zero one scores `0.0`, matching the other arms.
+/// The `min` mirrors the clip a distance-returning kernel applies at 0.
+fn scalar_cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    let mut dot = 0.0f32;
+    let mut norm_a = 0.0f32;
+    let mut norm_b = 0.0f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        norm_a += x * x;
+        norm_b += y * y;
+    }
+
+    if norm_a == 0.0 && norm_b == 0.0 {
+        return 1.0;
+    }
+    if dot == 0.0 {
+        return 0.0;
+    }
+    (dot / (norm_a.sqrt() * norm_b.sqrt())).min(1.0)
+}
+
+fn is_all_zero(v: &[f32]) -> bool {
+    v.iter().all(|x| *x == 0.0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -231,6 +288,89 @@ mod tests {
         let b = vec![1.0, 0.0, 0.0];
         let similarity = engineer.cosine_similarity(&a, &b).unwrap();
         assert!((similarity - 1.0).abs() < 0.01);
+    }
+
+    /// Deterministic vector source. A fixed LCG keeps the grid reproducible
+    /// across arms without pulling a seeded-RNG dependency into the comparison.
+    fn lcg(state: &mut u64) -> f32 {
+        *state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((*state >> 33) as f32 / (1u64 << 31) as f32) * 2.0 - 1.0
+    }
+
+    /// Single-pass f64 reference. Deliberately NOT `scalar_cosine_similarity`:
+    /// that one accumulates in f32 and is a backend in its own right, so using
+    /// it as the reference would let a shared reduction-order bug pass.
+    fn naive_cosine(a: &[f32], b: &[f32]) -> f32 {
+        let mut dot = 0.0f64;
+        let mut norm_a = 0.0f64;
+        let mut norm_b = 0.0f64;
+        for (x, y) in a.iter().zip(b.iter()) {
+            dot += f64::from(*x) * f64::from(*y);
+            norm_a += f64::from(*x) * f64::from(*x);
+            norm_b += f64::from(*y) * f64::from(*y);
+        }
+        (dot / (norm_a.sqrt() * norm_b.sqrt())) as f32
+    }
+
+    /// Checks whichever backend compiled in against the reference, so this
+    /// covers the SimSIMD path shipping today, the scalar path, and the lattice
+    /// path alike. Dimensions straddle 4/8/16-lane widths and their remainders.
+    #[test]
+    fn backend_matches_scalar_reference() {
+        let engineer = FeatureEngineer::new();
+        const DIMS: [usize; 21] = [
+            1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 32, 63, 64, 128, 384, 768, 1000, 1023, 1024,
+        ];
+
+        for &dim in DIMS.iter() {
+            for seed_base in 0..3u64 {
+                let mut state = seed_base.wrapping_mul(7919).wrapping_add(12345);
+                let a: Vec<f32> = (0..dim).map(|_| lcg(&mut state)).collect();
+                let b: Vec<f32> = (0..dim).map(|_| lcg(&mut state)).collect();
+
+                let got = engineer.cosine_similarity(&a, &b).unwrap();
+                let want = naive_cosine(&a, &b);
+                assert!(
+                    (got - want).abs() <= 1e-4 * want.abs().max(1.0),
+                    "cosine mismatch dim={dim} seed={seed_base}: got {got}, want {want}"
+                );
+            }
+        }
+    }
+
+    /// The boundary values every backend must agree on. These are conventions
+    /// rather than arithmetic, so they are asserted exactly.
+    #[test]
+    fn backend_boundary_conventions_agree() {
+        let engineer = FeatureEngineer::new();
+        let zero = vec![0.0f32; 8];
+        let ones = vec![1.0f32; 8];
+
+        assert_eq!(
+            engineer.cosine_similarity(&zero, &zero).unwrap(),
+            1.0,
+            "two all-zero vectors"
+        );
+        assert_eq!(
+            engineer.cosine_similarity(&zero, &ones).unwrap(),
+            0.0,
+            "zero against non-zero"
+        );
+
+        let e1 = vec![1.0, 0.0, 0.0, 0.0];
+        let e2 = vec![0.0, 1.0, 0.0, 0.0];
+        assert_eq!(
+            engineer.cosine_similarity(&e1, &e2).unwrap(),
+            0.0,
+            "orthogonal"
+        );
+
+        assert!(
+            engineer.cosine_similarity(&e1, &ones).is_err(),
+            "length mismatch must stay an error on every backend"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What this is

`ruvector-tiny-dancer-core` scores candidates through one cosine kernel, wired directly to
SimSIMD through a hard dependency. The crate has no `[features]` section at all, so there is no
way to build it against a different kernel, and no way to build it without a SIMD library. This
adds a feature axis with three mutually exclusive arms and leaves the default on what ships
today.

| features | backend |
|---|---|
| default (`simd-simsimd`) | SimSIMD, unchanged |
| `lattice-simd` | `lattice-embed` kernels |
| `--no-default-features` | scalar |

`lattice-simd` wins if both are enabled, so the arms stay mutually exclusive and exhaustive.

## Let me be straight about what this does not buy you

I went into this expecting the wasm argument that motivates the same feature in `ruvector-core`
to apply here, and it does not. I measured before writing the PR rather than after, so this
section is a correction to my own premise rather than a caveat bolted onto a claim.

**The pure-Rust-dependency argument does not transfer to this crate.** It is real for
`ruvector-diskann`, where SimSIMD is the reason a C toolchain is needed. Here
`ruvector-tiny-dancer-core` also hard-depends on `rusqlite` with `bundled`, which compiles
SQLite from C. Removing SimSIMD's C-ness does not make this crate buildable without a C
compiler, so I am not going to pretend it does.

**This does not fix the wasm build**, for reasons in the next section.

What is left is smaller and still worth having: a backend that can be selected at all, a scalar
path where there was none, and — for callers that opt in — the option of converging on one
kernel set instead of two implementations of the same arithmetic with independent rounding
behaviour inside one search path. To be precise about state versus option: the default build
still selects SimSIMD and the lockfile currently carries two `lattice-embed` versions, so this
PR offers the convergence, it does not put the workspace in that state.

**Performance.** An earlier revision of this description made no performance claim because the
local host could not certify A/B deltas in the plausible range (an A/A control on byte-identical
source produced differences up to 9.97%). Numbers were subsequently taken on a host that can
support the claim; see the Measurement section below.

## Something I found while scoping this, unrelated to the change

`ruvector-tiny-dancer-wasm` does not build for `wasm32-unknown-unknown`. It is
`crate-type = ["cdylib", "rlib"]` with `wasm-bindgen`, and on unmodified `main`:

```
cargo check -p ruvector-tiny-dancer-wasm --target wasm32-unknown-unknown
error: the wasm*-unknown-unknown targets are not supported by default,
       you may need to enable the "js" feature
   --> getrandom-0.2.17/src/lib.rs:346:9
```

That is the first blocker, not the only one. Shimming it locally the way
`ruvector-diskann/Cargo.toml` already does for the same crate:

```toml
[target.'cfg(target_arch = "wasm32")'.dependencies]
getrandom02 = { package = "getrandom", version = "0.2", features = ["js"] }
```

moves the failure to the next one:

```
cargo:warning=sqlite3/sqlite3.c:14678:10: fatal error: 'stdio.h' file not found
error occurred in cc-rs: ... --target=wasm32-unknown-unknown ... -c sqlite3/sqlite3.c
```

`libsqlite3-sys` building bundled SQLite for wasm32, reached through the unconditional
`rusqlite` dependency in `ruvector-tiny-dancer-core`. I stopped there and reverted the probe, so
I do not know whether SimSIMD is a third blocker behind it — the build never gets that far.

**Why CI does not catch it:** `ruvector-tiny-dancer-wasm` is only ever compiled for the native
host. It appears in the nextest package list in `ci.yml` and in an `--exclude` list in another
native job, and none of the PR-triggered CI workflows build it for `wasm32-unknown-unknown`
(the release workflow does run `wasm-pack build` for this crate, so the categorical statement
stops at PR CI). The `wasm32` target jobs that
do exist (`build-attention.yml`, `build-graph-transformer.yml`, `metabiohacker-ci.yml`) cover
other crates. A gate whose trigger set does not intersect what its instrument actually reaches
produces greens that read as evidence.

I am reporting this rather than fixing it because the fix is a scoping decision about your
storage layer, not a drive-by. If you do want the wasm path, the order looks like: gate
`rusqlite` behind a feature or a target, shim `getrandom`, and then the SIMD layer is the next
thing in the way — which this PR makes removable rather than removes: `lattice-embed` compiles
for wasm32 and SimSIMD does not, but `ruvector-tiny-dancer-wasm` still consumes this crate's
default features, so its manifest would also need `default-features = false` plus `lattice-simd`
for the swap to reach it. That is an ordering observation, not a claim that this
PR unlocks anything on its own.

## Conventions, which are the interesting part

The two libraries disagree on what "cosine" returns. `SpatialSimilarity::cosine` returns a
**distance**, which is why the existing code reads `1.0 - f32::cosine(a, b)`.
`lattice_embed::simd::cosine_similarity` returns a **similarity** directly, so its adapter has no
`1 - x`. The arms are not interchangeable text and a copy-paste between them would silently
invert the score.

They also disagree on zero norms. `lattice-embed` returns `0.0` for a zero norm, which collides
with the genuine "orthogonal" answer. The behaviour this path has always had is preserved on
every arm:

- two all-zero vectors score `1.0`
- a zero vector against a non-zero one scores `0.0`
- a length mismatch stays an error

I did not assume those values, I measured them: `backend_boundary_conventions_agree` asserts them
exactly and **passes on the unmodified default arm**, which is what establishes them as the
incumbent behaviour rather than my guess at it. Restoring the all-zero case costs a cold-path
check that only runs when the kernel already returned `0.0`.

For the record, `1.0` for two all-zero vectors is arguably the wrong answer, since cosine is
undefined there. I have deliberately not changed it. A backend swap that also changes semantics
is two changes wearing one hat, and which value that should be is your call, not mine.

## Verification

| arm | result |
|---|---|
| `test --lib` (default, SimSIMD) | 33 passed, 0 failed |
| `test --features lattice-simd --lib` | 33 passed, 0 failed |
| `test --no-default-features --lib` (scalar) | 33 passed, 0 failed |
| `test --no-default-features --features lattice-simd --lib` | 33 passed, 0 failed |
| `clippy --all-targets -- -D warnings` (default) | clean |
| `clippy --features lattice-simd --all-targets -- -D warnings` | clean |
| `clippy --no-default-features --all-targets -- -D warnings` | clean |
| `clippy --no-default-features --features lattice-simd --all-targets -- -D warnings` | clean |

Same test count in every arm, and both new tests are named in each arm's output, which is what
shows they are backend-independent rather than compiled into one configuration.

Mutation-checked **per adapter**, not per patch, since mutating a patch as a unit only certifies
its best line. Each mutation must fail its own arm and leave the default arm green — the second
half is what proves it stayed inside its own `cfg` block instead of breaking the crate outright.

| mutation | own arm | default arm |
|---|---|---|
| lattice adapter: `cosine_similarity(a, b)` -> `(a, a)` | fails (2 of 5) | green |
| lattice: drop the all-zero -> `1.0` restoration | fails (1 of 5) | green |
| scalar: drop the `sqrt` on both norms | fails (1 of 5) | green |
| scalar: all-zero returns `0.0` instead of `1.0` | fails (1 of 5) | green |

The probe echoes each mutation's diff before running, so a regex that silently failed to apply
cannot be scored as a passing arm, and it reports an instrument failure rather than a result if
no test suite actually ran.

## Two consequences worth stating

**This resolves a second copy of `lattice-embed` into the workspace.** `ruvector-core` pins
`0.6.1`; this pins `0.7.1`, which is the version the other in-flight lattice PRs move to. `^0.6`
and `^0.7` cannot unify, so until those land, a build enabling both
`ruvector-core/lattice-embeddings` and `ruvector-tiny-dancer-core/lattice-simd` compiles
`lattice-embed` twice. Both versions are visible in `Cargo.lock`. Whichever of these PRs lands
second will want a lockfile rebase.

**The lockfile diff is `lattice-embed` only.** The resolver also wanted to move `tempfile`'s
`getrandom` edge from `0.3.4` to `0.4.3`; that is unrelated to this change and not required by
it, so it is reverted here and `cargo check -p ruvector-tiny-dancer-core --features lattice-simd
--locked` resolves cleanly without it.

## Cost

`lattice-embed` requires Rust >= 1.93. Enabling this feature raises the effective MSRV for
whoever turns it on. The default build is unaffected and stays on the workspace MSRV. That is the
real price and it is why the feature is opt-in and off by default.


## Measurement

Apple silicon Mac mini, macOS, aarch64, rustc 1.93.0, the crate's own
`feature_engineering` bench target, Criterion `--measurement-time 10`. Both
phases are the same commit and differ only by the feature flag.

The baseline here is not scalar. This crate's `default` is `["simd-simsimd"]`,
so the off side is SimSIMD and this table is a backend-to-backend comparison,
which is the harder of the two comparisons a backend PR can be asked to win.

| benchmark | off (SimSIMD) | on (lattice-embed) | change (95% CI) | p |
|-----------|---------------|--------------------|-----------------|---|
| `cosine_similarity_384d` | 107.71 ns | 73.377 ns | -34.52% .. -32.04% | 0.00 |
| `feature_weighting` (3 cases) | 53.26-53.98 ns | 47.76-48.28 ns | -11.75% .. -7.15% | 0.00 |

CPU idle was sampled every 20s inside each measured phase, three samples each.
Off phase minimum 76%, on phase minimum 68%. The on phase dipped slightly below
the bar I hold myself to, and the direction of that dip runs against the on side
rather than for it.

One number here is worth flagging as an open question rather than a result. In
`ruvector-core`, the same SimSIMD-to-lattice swap on 384-dimension cosine
measures roughly -52%; here the same swap on a 384-dimension cosine measures
-33%, and the SimSIMD side itself costs 107.7 ns here against roughly 57 ns
there for what should be the same kernel and the same dimension. The difference
is wrapper overhead in this crate's cosine path, not the kernel, and it is
untouched by this PR. It is the reason the end-to-end `feature_weighting` numbers
land at -8 to -10% rather than tracking the kernel figure: the kernel is not the
whole cost on this path.


---

**Note on this PR's CI.** `Tests (core-and-rest)` is red on every branch in this repository,
including `main`: the job is cancelled at its 240-minute cap while still compiling and never
reaches the test phase. #786 restores the exclusion list that the shard's `packages:` value loses
to a shell comment, #784 unblocks the `ruvector-filter` test target that the compiler cannot
finish, and #787 fixes a deadlock waiting behind both. That failure is not caused by this branch.

