### PR TITLE
docs+feat(rvf): ADR-009 — RVF v1 wire contract, exact magic bytes, golden vectors, CI gate

### DIFF
--- a/.github/workflows/rvf-wire-contract.yml
+++ b/.github/workflows/rvf-wire-contract.yml
@@ -1,0 +1,60 @@
+name: RVF Wire Contract
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/rvf/rvf-types/**'
+      - 'crates/rvf/rvf-wire/**'
+      - 'crates/rvf/README.md'
+      - 'docs/architecture/decisions/**'
+      - 'docs/research/rvf/**'
+      - '.github/workflows/rvf-wire-contract.yml'
+  pull_request:
+    paths:
+      - 'crates/rvf/rvf-types/**'
+      - 'crates/rvf/rvf-wire/**'
+      - 'crates/rvf/README.md'
+      - 'docs/architecture/decisions/**'
+      - 'docs/research/rvf/**'
+      - '.github/workflows/rvf-wire-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rvf-wire-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wire-contract:
+    name: Verify RVF v1 wire contract
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: crates/rvf
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        with:
+          workspaces: crates/rvf -> target
+
+      - name: Check formatting
+        run: cargo fmt -p rvf-types -p rvf-wire -- --check
+
+      - name: Clippy
+        run: cargo clippy -p rvf-types -p rvf-wire --all-targets -- -D warnings
+
+      - name: Test (includes golden wire vectors)
+        run: cargo test -p rvf-types -p rvf-wire

--- a/crates/rvf/README.md
+++ b/crates/rvf/README.md
@@ -1464,7 +1464,7 @@ let dist = hamming_distance(&bits_a, &bits_b);
 
 | Offset | Size | Field | Description |
 |--------|------|-------|-------------|
-| 0x00 | 4 | `magic` | `0x52564653` ("RVFS") |
+| 0x00 | 4 | `magic` | `0x52564653` (mnemonic "RVFS"; LE wire bytes `53 46 56 52`) |
 | 0x04 | 1 | `version` | Format version (currently 1) |
 | 0x05 | 1 | `seg_type` | Segment type (see enum below) |
 | 0x06 | 2 | `flags` | Bitfield (COMPRESSED, ENCRYPTED, SIGNED, SEALED, ATTESTED, ...) |
@@ -1708,7 +1708,13 @@ Domain profiles optimize RVF behavior for specific data types:
 
 ### Magic Number
 
-`0x52564653` (ASCII: "RVFS")
+`0x52564653`. The mnemonic "RVFS" is the big-endian rendering of that number;
+because RVF serializes little-endian, the four bytes at the start of a segment
+are `53 46 56 52`. Compare against `rvf_types::SEGMENT_MAGIC_BYTES`, never
+against an ASCII literal. The Level-0 root manifest magic is `0x52564D30`
+(mnemonic "RVM0", wire bytes `30 4D 56 52`, exported as
+`rvf_types::ROOT_MANIFEST_MAGIC_BYTES`). See ADR-009 for the full v1 wire
+contract.
 
 ### Byte Order
 

--- a/crates/rvf/rvf-types/src/constants.rs
+++ b/crates/rvf/rvf-types/src/constants.rs
@@ -1,10 +1,41 @@
 //! Magic numbers, alignment requirements, and size limits for the RVF format.
+//!
+//! # Mnemonics versus wire bytes
+//!
+//! The magic values below are numeric constants whose *big-endian* rendering
+//! spells a human-readable mnemonic ("RVFS", "RVM0"). RVF v1 serializes every
+//! multi-byte integer little-endian, so the bytes that actually appear on the
+//! wire are the reverse of the mnemonic. Reading the mnemonic as if it were
+//! the byte sequence is the single most common way to misparse an RVF file.
+//!
+//! Use [`SEGMENT_MAGIC_BYTES`] and [`ROOT_MANIFEST_MAGIC_BYTES`] whenever you
+//! need to compare or emit raw bytes; never hand-write an ASCII literal.
+//!
+//! See ADR-009 (RVF Version 1 Wire Contract) for the normative statement.
 
-/// Segment header magic: "RVFS" in ASCII (little-endian u32).
+/// Segment header magic. Mnemonic "RVFS" (big-endian rendering of the number).
+///
+/// On the wire this serializes little-endian as `53 46 56 52`. See
+/// [`SEGMENT_MAGIC_BYTES`] for the exact byte sequence.
 pub const SEGMENT_MAGIC: u32 = 0x5256_4653;
 
-/// Root manifest magic: "RVM0" in ASCII (little-endian u32).
+/// Root manifest magic. Mnemonic "RVM0" (big-endian rendering of the number).
+///
+/// On the wire this serializes little-endian as `30 4D 56 52`. See
+/// [`ROOT_MANIFEST_MAGIC_BYTES`] for the exact byte sequence.
 pub const ROOT_MANIFEST_MAGIC: u32 = 0x5256_4D30;
+
+/// The exact four bytes a v1 segment header starts with: `53 46 56 52`.
+///
+/// Byte-slice comparisons against a segment header must use this constant, not
+/// an ASCII literal such as `b"RVFS"`.
+pub const SEGMENT_MAGIC_BYTES: [u8; 4] = SEGMENT_MAGIC.to_le_bytes();
+
+/// The exact four bytes a v1 Level-0 root manifest starts with: `30 4D 56 52`.
+///
+/// Byte-slice comparisons against a root manifest must use this constant, not
+/// an ASCII literal such as `b"RVM0"`.
+pub const ROOT_MANIFEST_MAGIC_BYTES: [u8; 4] = ROOT_MANIFEST_MAGIC.to_le_bytes();
 
 /// All segments must start at a 64-byte aligned boundary (AVX-512 / cache-line width).
 pub const SEGMENT_ALIGNMENT: usize = 64;
@@ -26,18 +57,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn magic_bytes_match_ascii() {
-        // "RVFS" => 0x52 0x56 0x46 0x53
-        let bytes = SEGMENT_MAGIC.to_le_bytes();
-        assert_eq!(&bytes, b"SFVR"); // LE representation: 0x53, 0x46, 0x56, 0x52
-        let bytes_be = SEGMENT_MAGIC.to_be_bytes();
-        assert_eq!(&bytes_be, b"RVFS");
+    fn segment_magic_has_stable_numeric_and_wire_forms() {
+        // The numeric constant is frozen for format version 1.
+        assert_eq!(SEGMENT_MAGIC, 0x5256_4653);
+        // Little-endian serialization is what a reader actually sees.
+        assert_eq!(SEGMENT_MAGIC_BYTES, [0x53, 0x46, 0x56, 0x52]);
+        assert_eq!(SEGMENT_MAGIC.to_le_bytes(), SEGMENT_MAGIC_BYTES);
+        // Round-tripping the wire bytes recovers the numeric constant.
+        assert_eq!(u32::from_le_bytes(SEGMENT_MAGIC_BYTES), SEGMENT_MAGIC);
+        // The mnemonic only appears under big-endian rendering; it is a naming
+        // convention, not the wire encoding.
+        assert_eq!(&SEGMENT_MAGIC.to_be_bytes(), b"RVFS");
+        assert_ne!(&SEGMENT_MAGIC_BYTES, b"RVFS");
     }
 
     #[test]
-    fn root_manifest_magic_bytes() {
-        let bytes_be = ROOT_MANIFEST_MAGIC.to_be_bytes();
-        assert_eq!(&bytes_be, b"RVM0");
+    fn root_manifest_magic_has_stable_numeric_and_wire_forms() {
+        assert_eq!(ROOT_MANIFEST_MAGIC, 0x5256_4D30);
+        assert_eq!(ROOT_MANIFEST_MAGIC_BYTES, [0x30, 0x4D, 0x56, 0x52]);
+        assert_eq!(ROOT_MANIFEST_MAGIC.to_le_bytes(), ROOT_MANIFEST_MAGIC_BYTES);
+        assert_eq!(
+            u32::from_le_bytes(ROOT_MANIFEST_MAGIC_BYTES),
+            ROOT_MANIFEST_MAGIC
+        );
+        assert_eq!(&ROOT_MANIFEST_MAGIC.to_be_bytes(), b"RVM0");
+        assert_ne!(&ROOT_MANIFEST_MAGIC_BYTES, b"RVM0");
     }
 
     #[test]

--- a/crates/rvf/rvf-types/src/manifest.rs
+++ b/crates/rvf/rvf-types/src/manifest.rs
@@ -104,7 +104,7 @@ pub struct PrefetchMapPtr {
 ///
 /// | Offset | Size | Field |
 /// |--------|------|-------|
-/// | 0x000  | 4    | magic (0x52564D30 "RVM0") |
+/// | 0x000  | 4    | magic (0x52564D30, mnemonic "RVM0", wire bytes `30 4D 56 52`) |
 /// | 0x004  | 2    | version |
 /// | 0x006  | 2    | flags |
 /// | 0x008  | 8    | l1_manifest_offset |
@@ -132,7 +132,8 @@ pub struct PrefetchMapPtr {
 #[repr(C)]
 pub struct Level0Root {
     // ---- Basic header (0x000 - 0x037) ----
-    /// Magic number: must be `0x52564D30` ("RVM0").
+    /// Magic number: must be `0x52564D30` (mnemonic "RVM0"). Serialized
+    /// little-endian, so the wire bytes are `30 4D 56 52`.
     pub magic: u32,
     /// Root manifest version.
     pub version: u16,

--- a/crates/rvf/rvf-types/src/quality.rs
+++ b/crates/rvf/rvf-types/src/quality.rs
@@ -43,11 +43,12 @@ pub enum ResponseQuality {
 }
 
 /// Caller hint for quality vs latency trade-off.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
 pub enum QualityPreference {
     /// Runtime decides. Default. Fastest path that meets internal thresholds.
+    #[default]
     Auto = 0x00,
     /// Caller prefers quality over latency. Runtime may widen n_probe,
     /// extend budgets up to 4x, and block until Layer B loads.
@@ -58,12 +59,6 @@ pub enum QualityPreference {
     /// Caller explicitly accepts degraded results. Required to proceed
     /// when ResponseQuality would be Degraded or Unreliable under Auto.
     AcceptDegraded = 0x03,
-}
-
-impl Default for QualityPreference {
-    fn default() -> Self {
-        Self::Auto
-    }
 }
 
 /// Which index layers were available and used during a query.

--- a/crates/rvf/rvf-types/src/security.rs
+++ b/crates/rvf/rvf-types/src/security.rs
@@ -8,7 +8,7 @@
 /// Controls how the runtime handles unsigned or invalid signatures
 /// when opening an RVF file. Default is `Strict` — no signature means
 /// no mount in production.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
 pub enum SecurityPolicy {
@@ -18,16 +18,11 @@ pub enum SecurityPolicy {
     WarnOnly = 0x01,
     /// Require valid signature on Level 0 manifest.
     /// DEFAULT for production.
+    #[default]
     Strict = 0x02,
     /// Require valid signatures on Level 0, Level 1, and all
     /// hotset-referenced segments. Full chain verification.
     Paranoid = 0x03,
-}
-
-impl Default for SecurityPolicy {
-    fn default() -> Self {
-        Self::Strict
-    }
 }
 
 impl SecurityPolicy {
@@ -403,6 +398,6 @@ mod tests {
     #[test]
     fn reserved_offset_fits() {
         // 109 + 96 = 205 <= 252 (reserved area size)
-        assert!(HardeningFields::RESERVED_OFFSET + 96 <= 252);
+        const { assert!(HardeningFields::RESERVED_OFFSET + 96 <= 252) };
     }
 }

--- a/crates/rvf/rvf-types/src/segment.rs
+++ b/crates/rvf/rvf-types/src/segment.rs
@@ -8,7 +8,8 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct SegmentHeader {
-    /// Magic number: must be `0x52564653` ("RVFS").
+    /// Magic number: must be `0x52564653` (mnemonic "RVFS"). Serialized
+    /// little-endian, so the wire bytes are `53 46 56 52`.
     pub magic: u32,
     /// Segment format version (currently 1).
     pub version: u8,

--- a/crates/rvf/rvf-types/src/sha256.rs
+++ b/crates/rvf/rvf-types/src/sha256.rs
@@ -33,6 +33,12 @@ pub struct Sha256 {
     total_len: u64,
 }
 
+impl Default for Sha256 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Sha256 {
     /// Create a new SHA-256 hasher.
     pub fn new() -> Self {

--- a/crates/rvf/rvf-wire/src/manifest_codec.rs
+++ b/crates/rvf/rvf-wire/src/manifest_codec.rs
@@ -107,7 +107,8 @@ fn write_u64_le(buf: &mut [u8], offset: usize, val: u64) {
 
 /// Read and parse a Level 0 root manifest from a 4096-byte slice.
 ///
-/// Validates the magic (`RVM0`) and CRC32C checksum.
+/// Validates the magic (`ROOT_MANIFEST_MAGIC`, mnemonic "RVM0", wire bytes
+/// `30 4D 56 52`) and the CRC32C checksum.
 ///
 /// # Errors
 ///

--- a/crates/rvf/rvf-wire/src/reader.rs
+++ b/crates/rvf/rvf-wire/src/reader.rs
@@ -15,7 +15,8 @@ use rvf_types::{
 ///
 /// # Errors
 ///
-/// - `InvalidMagic` if the magic number does not match `RVFS`.
+/// - `InvalidMagic` if the magic number does not match `SEGMENT_MAGIC`
+///   (mnemonic "RVFS", wire bytes `53 46 56 52`).
 /// - `InvalidVersion` if the version is not supported.
 /// - `TruncatedSegment` if `data` is shorter than 64 bytes.
 pub fn read_segment_header(data: &[u8]) -> Result<SegmentHeader, RvfError> {

--- a/crates/rvf/rvf-wire/src/tail_scan.rs
+++ b/crates/rvf/rvf-wire/src/tail_scan.rs
@@ -7,18 +7,18 @@
 use crate::reader::read_segment_header;
 use rvf_types::{
     ErrorCode, RvfError, SegmentHeader, SegmentType, ROOT_MANIFEST_MAGIC, ROOT_MANIFEST_SIZE,
-    SEGMENT_ALIGNMENT, SEGMENT_HEADER_SIZE, SEGMENT_MAGIC, SEGMENT_VERSION,
+    SEGMENT_ALIGNMENT, SEGMENT_HEADER_SIZE, SEGMENT_MAGIC, SEGMENT_MAGIC_BYTES, SEGMENT_VERSION,
 };
 
 /// Find the latest manifest segment in `data` by scanning from the tail.
 ///
 /// **Fast path**: check the last 4096 bytes for the root manifest magic
-/// (`RVM0`). If valid, scan backward from that point for the enclosing
-/// MANIFEST_SEG header.
+/// (mnemonic "RVM0", wire bytes `30 4D 56 52`). If valid, scan backward from
+/// that point for the enclosing MANIFEST_SEG header.
 ///
 /// **Slow path**: scan backward from the end of `data` at 64-byte aligned
-/// boundaries, looking for a segment header with magic `RVFS` and type
-/// `MANIFEST_SEG` (0x05).
+/// boundaries, looking for a segment header with the segment magic (mnemonic
+/// "RVFS", wire bytes `53 46 56 52`) and type `MANIFEST_SEG` (0x05).
 ///
 /// Returns `(byte_offset, SegmentHeader)` of the manifest segment.
 ///
@@ -31,7 +31,7 @@ pub fn find_latest_manifest(data: &[u8]) -> Result<(usize, SegmentHeader), RvfEr
         return Err(RvfError::Code(ErrorCode::TruncatedSegment));
     }
 
-    // Fast path: check last 4096 bytes for RVM0 magic
+    // Fast path: check last 4096 bytes for the root manifest magic
     if data.len() >= ROOT_MANIFEST_SIZE {
         let root_start = data.len() - ROOT_MANIFEST_SIZE;
         let root_slice = &data[root_start..];
@@ -65,12 +65,11 @@ pub fn find_latest_manifest(data: &[u8]) -> Result<(usize, SegmentHeader), RvfEr
         }
     }
 
-    // Slow path: scan backward using the first magic byte ('R' = 0x52) as
-    // an anchor. On aligned boundaries within the data, we search for the
-    // magic byte first (memchr-style) to skip large runs of non-magic data,
-    // then verify the full 4-byte magic + version + type.
-    let magic_le = SEGMENT_MAGIC.to_le_bytes();
-    let magic_first = magic_le[0]; // 'R' = 0x52
+    // Slow path: scan backward using the first byte of the little-endian magic
+    // (0x53) as an anchor. On aligned boundaries within the data, we search for
+    // that byte first (memchr-style) to skip large runs of non-magic data, then
+    // verify the full 4-byte magic + version + type.
+    let magic_first = SEGMENT_MAGIC_BYTES[0];
     let last_aligned = (data.len().saturating_sub(SEGMENT_ALIGNMENT)) & !(SEGMENT_ALIGNMENT - 1);
     let mut scan_pos = last_aligned;
     loop {

--- a/crates/rvf/rvf-wire/tests/wire_contract_golden.rs
+++ b/crates/rvf/rvf-wire/tests/wire_contract_golden.rs
@@ -1,0 +1,139 @@
+//! Golden byte vectors for the RVF v1 wire contract (ADR-009).
+//!
+//! These tests pin the exact bytes that v1 readers in the field already
+//! accept. A diff here is not a test failure to be patched away: it means the
+//! wire format changed, which requires a new format version, dual-version
+//! readers, and fresh golden vectors for both versions.
+
+use std::fs;
+
+use rvf_types::{
+    SegmentFlags, SegmentType, ROOT_MANIFEST_MAGIC_BYTES, ROOT_MANIFEST_SIZE, SEGMENT_ALIGNMENT,
+    SEGMENT_HEADER_SIZE, SEGMENT_MAGIC_BYTES,
+};
+use rvf_wire::manifest_codec::{read_root_manifest, write_root_manifest, Level0Root};
+use rvf_wire::writer::write_segment_with_algo;
+use rvf_wire::{find_latest_manifest, write_segment};
+
+/// Checksum algorithm 2: SHAKE-256 truncated to 128 bits.
+const CHECKSUM_ALGO_SHAKE256: u8 = 2;
+
+/// The canonical empty segment: a META segment with an empty payload, segment
+/// id 0, no flags, and a SHAKE-256 content hash.
+///
+/// Bytes 0x28..0x38 are SHAKE-256 of the empty input truncated to 128 bits,
+/// which is the NIST-published value `46b9dd2b0ba88d13233b3feb743eeb24`.
+const GOLDEN_EMPTY_SHAKE256_SEGMENT: [u8; SEGMENT_HEADER_SIZE] = [
+    // 0x00 magic (LE), 0x04 version, 0x05 seg_type (META), 0x06 flags
+    0x53, 0x46, 0x56, 0x52, 0x01, 0x07, 0x00, 0x00, //
+    // 0x08 segment_id
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
+    // 0x10 payload_length
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
+    // 0x18 timestamp_ns
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
+    // 0x20 checksum_algo, 0x21 compression, 0x22 reserved_0, 0x24 reserved_1
+    0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
+    // 0x28 content_hash (16 bytes)
+    0x46, 0xB9, 0xDD, 0x2B, 0x0B, 0xA8, 0x8D, 0x13, //
+    0x23, 0x3B, 0x3F, 0xEB, 0x74, 0x3E, 0xEB, 0x24, //
+    // 0x38 uncompressed_len, 0x3C alignment_pad
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+];
+
+/// First eight bytes of a default Level-0 root manifest: the little-endian
+/// root magic followed by `version = 1` and `flags = 0`.
+const GOLDEN_ROOT_PREFIX: [u8; 8] = [0x30, 0x4D, 0x56, 0x52, 0x01, 0x00, 0x00, 0x00];
+
+/// CRC32C over bytes 0x000..0xFFC of a default Level-0 root manifest.
+const GOLDEN_ROOT_CRC32C: [u8; 4] = [0xFF, 0xDD, 0x18, 0x14];
+
+#[test]
+fn canonical_empty_segment_header_matches_golden_bytes() {
+    let segment = write_segment_with_algo(
+        SegmentType::Meta as u8,
+        &[],
+        SegmentFlags::empty(),
+        0,
+        CHECKSUM_ALGO_SHAKE256,
+    );
+
+    assert_eq!(
+        segment.len(),
+        SEGMENT_HEADER_SIZE,
+        "an empty payload occupies exactly one 64-byte header and no padding"
+    );
+    assert_eq!(segment.as_slice(), GOLDEN_EMPTY_SHAKE256_SEGMENT.as_slice());
+    assert_eq!(&segment[0..4], SEGMENT_MAGIC_BYTES.as_slice());
+}
+
+#[test]
+fn default_root_manifest_matches_golden_prefix_and_checksum() {
+    let root = write_root_manifest(&Level0Root::default());
+
+    assert_eq!(root.len(), ROOT_MANIFEST_SIZE);
+    assert_eq!(&root[0..8], GOLDEN_ROOT_PREFIX.as_slice());
+    assert_eq!(&root[0..4], ROOT_MANIFEST_MAGIC_BYTES.as_slice());
+    assert_eq!(&root[0xFFC..], GOLDEN_ROOT_CRC32C.as_slice());
+
+    // Everything between the header prefix and the trailing checksum is zero
+    // for a default root, so the golden prefix plus CRC pins the whole page.
+    assert!(
+        root[8..0xFFC].iter().all(|&b| b == 0),
+        "default root manifest must be zero-filled between header and checksum"
+    );
+}
+
+#[test]
+fn root_manifest_is_discovered_from_the_tail_without_an_offset_zero_header() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("tail_discovery.rvf");
+
+    // A leading data segment stands in for arbitrary prior content. Nothing
+    // about it identifies the file as RVF at offset zero.
+    let vec_segment = write_segment(
+        SegmentType::Vec as u8,
+        &[0xA5; 200],
+        SegmentFlags::empty(),
+        7,
+    );
+
+    // The manifest payload carries directory bytes followed by the Level-0
+    // root, which must occupy the final ROOT_MANIFEST_SIZE bytes.
+    let root = write_root_manifest(&Level0Root::default());
+    let mut manifest_payload = vec![0x11u8; SEGMENT_ALIGNMENT];
+    manifest_payload.extend_from_slice(&root);
+    let manifest_segment = write_segment(
+        SegmentType::Manifest as u8,
+        &manifest_payload,
+        SegmentFlags::empty(),
+        8,
+    );
+
+    let manifest_offset = vec_segment.len();
+    let mut file_bytes = vec_segment;
+    file_bytes.extend_from_slice(&manifest_segment);
+    fs::write(&path, &file_bytes).unwrap();
+
+    let on_disk = fs::read(&path).unwrap();
+
+    // Offset zero holds an ordinary segment, not a container header, and it is
+    // not parseable as a root manifest.
+    assert_eq!(&on_disk[0..4], SEGMENT_MAGIC_BYTES.as_slice());
+    assert_ne!(&on_disk[0..4], ROOT_MANIFEST_MAGIC_BYTES.as_slice());
+    assert!(read_root_manifest(&on_disk).is_err());
+
+    // Discovery works purely from the tail.
+    let (offset, header) = find_latest_manifest(&on_disk).unwrap();
+    assert_eq!(offset, manifest_offset);
+    assert_eq!(header.seg_type, SegmentType::Manifest as u8);
+    assert_eq!(header.segment_id, 8);
+
+    let root_start = on_disk.len() - ROOT_MANIFEST_SIZE;
+    let decoded = read_root_manifest(&on_disk[root_start..]).unwrap();
+    assert_eq!(decoded.version, 1);
+    assert_eq!(
+        decoded.root_checksum,
+        u32::from_le_bytes(GOLDEN_ROOT_CRC32C)
+    );
+}

--- a/docs/architecture/decisions/ADR-004-rvf-format.md
+++ b/docs/architecture/decisions/ADR-004-rvf-format.md
@@ -8,6 +8,17 @@
 | **Reviewers** | Architecture Review Board |
 | **Supersedes** | - |
 | **Related** | ADR-003-mcp-protocol, ADR-005-cross-platform-bindings |
+| **Superseded by** | ADR-009-rvf-v1-wire-contract (wire layout sections only) |
+
+> **The wire layout sections of this ADR are superseded by
+> [ADR-009: RVF Version 1 Wire Contract](ADR-009-rvf-v1-wire-contract.md).**
+>
+> Sections 2.2 and 2.3 describe a fixed 64-byte file header at offset zero. That
+> design was never shipped. RVF v1 has no header at offset zero: a file is an
+> append-only stream of 64-byte-aligned segments, and readers discover the
+> Level-0 root manifest from the file's tail. These diagrams are retained as a
+> historical record and must not be used to implement a reader or a writer.
+> The motivation, use cases, and non-layout decisions below remain valid.
 
 ## 1. Context
 
@@ -60,6 +71,10 @@ We adopt RVF as the universal format for vector data with a segment-based archit
 
 ### 2.2 File Header (64 bytes)
 
+> **Historical — superseded by [ADR-009](ADR-009-rvf-v1-wire-contract.md).**
+> RVF v1 files have no header at offset zero. The struct below was never
+> written by any shipped writer, and no reader should look for it.
+
 ```rust
 #[repr(C)]
 pub struct RvfHeader {
@@ -77,6 +92,11 @@ pub struct RvfHeader {
 ```
 
 ### 2.3 Segment Header (64 bytes)
+
+> **Historical — superseded by [ADR-009](ADR-009-rvf-v1-wire-contract.md).**
+> The shipped v1 segment header has a different field layout and hashing
+> scheme; see `rvf_types::SegmentHeader` and the golden vectors in
+> `crates/rvf/rvf-wire/tests/wire_contract_golden.rs`.
 
 ```rust
 #[repr(C)]

--- a/docs/architecture/decisions/ADR-005-rvf-cognitive-container.md
+++ b/docs/architecture/decisions/ADR-005-rvf-cognitive-container.md
@@ -8,6 +8,17 @@
 | **Reviewers** | Architecture Review Board |
 | **Supersedes** | - |
 | **Related** | ADR-029 (RVF Canonical Format), ADR-030 (Cognitive Container), ADR-032 (WASM Integration) |
+| **Superseded by** | ADR-009-rvf-v1-wire-contract (wire layout sections only) |
+
+> **The wire layout sections of this ADR are superseded by
+> [ADR-009: RVF Version 1 Wire Contract](ADR-009-rvf-v1-wire-contract.md).**
+>
+> Sections 2.2 and 2.3 describe a fixed 64-byte file header at offset zero. That
+> design was never shipped. RVF v1 has no header at offset zero: a file is an
+> append-only stream of 64-byte-aligned segments, and readers discover the
+> Level-0 root manifest from the file's tail. These diagrams are retained as a
+> historical record and must not be used to implement a reader or a writer.
+> The motivation, use cases, and non-layout decisions below remain valid.
 
 ## 1. Context
 
@@ -60,6 +71,10 @@ We adopt RVF as the universal format for vector data with the following segment 
 
 ### 2.2 File Header (64 bytes)
 
+> **Historical — superseded by [ADR-009](ADR-009-rvf-v1-wire-contract.md).**
+> RVF v1 files have no header at offset zero. The struct below was never
+> written by any shipped writer, and no reader should look for it.
+
 ```rust
 #[repr(C)]
 pub struct RvfHeader {
@@ -77,6 +92,11 @@ pub struct RvfHeader {
 ```
 
 ### 2.3 Segment Header (64 bytes)
+
+> **Historical — superseded by [ADR-009](ADR-009-rvf-v1-wire-contract.md).**
+> The shipped v1 segment header has a different field layout and hashing
+> scheme; see `rvf_types::SegmentHeader` and the golden vectors in
+> `crates/rvf/rvf-wire/tests/wire_contract_golden.rs`.
 
 ```rust
 #[repr(C)]

--- a/docs/architecture/decisions/ADR-009-rvf-v1-wire-contract.md
+++ b/docs/architecture/decisions/ADR-009-rvf-v1-wire-contract.md
@@ -1,0 +1,235 @@
+# ADR-009: RVF Version 1 Wire Contract
+
+| Field | Value |
+|---|---|
+| Status | Accepted |
+| Date | 2026-08-02 |
+| Authors | RuVector Architecture Team |
+| Reviewers | Repository maintainers |
+| Supersedes | Wire layout sections of ADR-004-rvf-format and ADR-005-rvf-cognitive-container |
+| Related | RVF research specification, rvf-types, rvf-wire, rvf-manifest |
+
+## 1. Context
+
+Two mutually incompatible binary layouts have both been described as "RVF" in
+this repository.
+
+The first comes from ADR-004 (`docs/architecture/decisions/ADR-004-rvf-format.md`)
+and ADR-005 (`ADR-005-rvf-cognitive-container.md`). Those documents describe a
+container that begins with a fixed 64-byte file header at offset zero, from
+which a reader learns the file's identity, version, and the location of
+everything else. Under that model, parsing starts at byte zero and proceeds
+forward.
+
+The second is the layout that the shipped crates actually implement. An RVF
+file is an append-only stream of independently verifiable segments, each
+beginning with its own 64-byte header and each starting on a 64-byte boundary.
+There is no file-level header at offset zero at all. Instead, the file's
+identity and directory live in the newest MANIFEST_SEG, and a reader finds that
+segment by inspecting the file's *tail*: the Level-0 root manifest is exactly
+4096 bytes and occupies the final 4096 bytes of the newest manifest payload.
+This is what `rvf_wire::find_latest_manifest` does, and it is the layout every
+RVF artifact in the wild already uses.
+
+A second, subtler ambiguity compounds the first. The format's magic values are
+documented by their mnemonics, "RVFS" for segments and "RVM0" for the root
+manifest. Those mnemonics are the *big-endian* rendering of the numeric
+constants `SEGMENT_MAGIC = 0x52564653` and `ROOT_MANIFEST_MAGIC = 0x52564D30`.
+RVF serializes every multi-byte integer little-endian, so the four bytes that
+actually appear at the start of a segment are `53 46 56 52`, and the four bytes
+at the start of a root manifest are `30 4D 56 52`. Neither matches the ASCII
+spelling of its own mnemonic. Documentation and pseudocode that compare
+`header[0:4]` against `b'RVFS'` describe a reader that would reject every real
+RVF file.
+
+The risk in leaving this unresolved is not merely editorial. Someone reading the
+old ADRs or the old pseudocode could reasonably conclude the shipped writers are
+buggy and "fix" them to emit big-endian magic or to prepend a header at offset
+zero. Either change would make every existing artifact unreadable, and because
+segment content hashes and manifest signatures cover these bytes, it would also
+invalidate signatures over data that had not otherwise changed. The wire format
+is a compatibility surface with deployed readers, and it needs to be treated as
+one.
+
+## 2. Decision
+
+### 2.1 Canonical file structure
+
+RVF version 1 has no fixed header at offset zero. A v1 file is a stream of
+independently verifiable segments, each beginning on a 64-byte-aligned boundary
+with its own 64-byte segment header. Segments are appended; earlier bytes are
+never rewritten in place.
+
+The latest valid MANIFEST_SEG is the single source of truth for the file's
+contents. Older manifests remain in the file and remain parseable, but a reader
+that finds a newer valid manifest must prefer it.
+
+The Level-0 root manifest is exactly 4096 bytes — one OS page — and occupies the
+final 4096 bytes of the latest manifest segment's payload. Readers therefore
+discover a file by inspecting its tail: read the last 4096 bytes, check for the
+root manifest magic, and verify the trailing CRC32C. If that fast path fails,
+fall back to scanning backward from the end of the file at 64-byte boundaries,
+looking for a segment header whose type is MANIFEST_SEG. A reader must not
+require, and must not assume the presence of, any structure at offset zero.
+
+### 2.2 Canonical byte order and magic values
+
+All multi-byte integers in the RVF v1 wire format are little-endian unless a
+field is explicitly documented otherwise.
+
+| Purpose | Numeric constant | Mnemonic (big-endian rendering) | Wire bytes (little-endian) |
+|---|---|---|---|
+| Segment header | `0x52564653` | `RVFS` | `53 46 56 52` (reads as "SFVR") |
+| Level-0 root manifest | `0x52564D30` | `RVM0` | `30 4D 56 52` (reads as "0MVR") |
+
+The mnemonic is a naming convention for humans. The wire bytes are the contract.
+Any code that compares raw bytes must use the exported constants
+`rvf_types::SEGMENT_MAGIC_BYTES` and `rvf_types::ROOT_MANIFEST_MAGIC_BYTES`
+rather than a hand-written ASCII literal. Code that compares the parsed `u32`
+must use `SEGMENT_MAGIC` / `ROOT_MANIFEST_MAGIC` and must decode with
+`u32::from_le_bytes`.
+
+### 2.3 Version stability
+
+Version 1 writers must continue to emit exactly the bytes that are already
+deployed. Changing any literal byte of the v1 wire format — the magic values,
+the field order within the segment header, the size or placement of the root
+manifest, the alignment rule — is a new format version, not a fix.
+
+Introducing a format version 2 requires, before any v2 writer ships:
+
+- a version discriminator that a v1 reader can detect and reject cleanly rather
+  than misparse;
+- dual-version readers that accept both v1 and v2 artifacts;
+- golden byte vectors committed for both versions, so neither can drift silently;
+- an explicit statement of signature and content-hash compatibility, covering
+  whether v1 signatures remain verifiable over migrated data and, if not, how
+  artifacts are re-signed.
+
+### 2.4 Normative sources
+
+The normative description of the RVF v1 wire format is, in order of precedence:
+
+1. This ADR.
+2. `docs/research/rvf/wire/binary-layout.md`.
+3. The exported constants and codecs in the `rvf-types`, `rvf-wire`, and
+   `rvf-manifest` crates.
+4. The golden byte-vector tests in `crates/rvf/rvf-wire/tests/wire_contract_golden.rs`
+   and the constant tests in `crates/rvf/rvf-types/src/constants.rs`.
+
+The offset-zero header diagrams in ADR-004 and ADR-005 are historical records of
+a design that was not shipped. They must not be used to implement a reader or a
+writer.
+
+## 3. Rationale
+
+Codifying the shipped behavior, rather than migrating the shipped behavior to
+match the older ADRs, is the cheaper and safer direction for three reasons.
+
+The tail-discovered manifest is what makes append-only writing work. A file
+header at offset zero would have to be rewritten on every commit to point at the
+new manifest, which reintroduces in-place mutation, torn-write windows, and a
+single point of corruption that invalidates the entire file. Discovering the
+manifest from the tail means a crash mid-append leaves the previous manifest
+intact and still authoritative; recovery is "scan backward until something
+verifies," which degrades gracefully rather than failing absolutely.
+
+Little-endian throughout matches the hardware every RVF reader runs on, so
+headers can be read by direct load rather than byte-swapping, and 64-byte
+segment alignment matches both the AVX-512 register width and the cache line.
+Reversing the magic to make it "read nicely" in a hex dump would buy readability
+for humans and cost a byte-swap on the hot path for machines, in a format whose
+whole point is zero-copy access.
+
+Freezing the bytes is what makes the format a contract at all. Content hashes and
+manifest signatures are computed over these exact bytes. A change that looks
+cosmetic — reversing four magic bytes — silently invalidates every signature in
+every existing artifact, with no error message that points at the cause. The
+constants are cheap to keep and expensive to change, so we keep them.
+
+## 4. Consequences
+
+**Positive.** There is now a single normative answer to "what does an RVF file
+look like," and it matches what the code does, so a new contributor reading the
+docs and a new contributor reading the crates arrive at the same place. The
+exported `*_MAGIC_BYTES` constants remove the recurring endianness mistake from
+the class of bugs that can be written. Golden vectors turn an accidental wire
+change from a silent compatibility break into a failing test in CI.
+
+**Negative.** The older ADRs remain in the tree with layout sections that are now
+explicitly historical, which is a small ongoing source of confusion for anyone
+who reads them without the superseding note. The mnemonic-versus-wire-bytes
+distinction is genuinely counterintuitive and will keep needing to be explained;
+we accept that cost in exchange for not breaking deployed artifacts.
+
+**Neutral.** The golden vectors pin `Level0Root::default()` and the canonical
+empty segment header specifically. Fields that a default root leaves zeroed are
+covered by the trailing CRC32C but are not independently pinned; extending
+coverage to populated manifests is future work, not a gap in the contract.
+
+## 5. Security requirements
+
+Magic values are structural sentinels. They tell a reader where a record
+plausibly begins; they carry no authority whatsoever. Finding `53 46 56 52` at a
+64-byte boundary means "a segment header may start here," not "this is a
+trustworthy segment."
+
+Before acting on any segment, a reader must validate, in this order: the format
+version (rejecting unsupported versions rather than guessing); the segment type
+(unknown types are preserved but not interpreted); every declared length against
+the actual remaining bytes, so a declared payload length can never induce a read
+past the end of the mapping; the 64-byte alignment of the segment start; the
+content hash over the payload, compared in constant time; and, where the segment
+carries one, the signature chain.
+
+For the Level-0 root manifest specifically, the CRC32C at offset `0xFFC` covers
+bytes `0x000..0xFFC` and must be verified before any offset or length in the
+manifest is dereferenced. CRC32C is an integrity check against corruption, not
+an authentication mechanism; it must never be treated as evidence of
+authenticity.
+
+No executable payload — embedded kernel images, eBPF programs, or WASM modules
+carried in KERNEL, EBPF, or profile segments — may be activated on the strength
+of a matching magic value and a matching content hash alone. Activation requires
+a verified signature from a trusted key and an explicit policy decision by the
+host. A content hash proves the bytes are the bytes the writer wrote; it says
+nothing about whether the writer was authorized.
+
+## 6. Acceptance criteria
+
+This ADR is satisfied when all of the following hold in CI:
+
+1. A golden byte-vector test serializes the canonical empty segment — a META
+   segment with an empty payload, segment id 0, no flags, and a SHAKE-256
+   content hash — and asserts the full 64-byte array. Its first four bytes are
+   `53 46 56 52`, and bytes `0x28..0x38` are the NIST-published SHAKE-256 value
+   for empty input truncated to 128 bits, `46b9dd2b0ba88d13233b3feb743eeb24`.
+
+2. A golden byte-vector test serializes the default Level-0 root manifest and
+   asserts that it is exactly 4096 bytes, that it begins
+   `30 4D 56 52 01 00 00 00`, and that its trailing CRC32C at offset `0xFFC` is
+   `FF DD 18 14`.
+
+3. A tail-scanning test builds an RVF byte stream through the public writer API,
+   writes it to disk, and locates the root manifest through the reader's tail
+   discovery — while asserting that offset zero holds an ordinary segment and is
+   not parseable as a root manifest, demonstrating that no fixed offset-zero
+   header is required.
+
+4. `rvf_types::SEGMENT_MAGIC_BYTES` and `rvf_types::ROOT_MANIFEST_MAGIC_BYTES`
+   are exported, and their tests assert both the numeric constant and the exact
+   little-endian byte array, including that the byte array is *not* equal to the
+   ASCII mnemonic.
+
+5. No documentation or pseudocode in the tree compares v1 wire bytes against a
+   literal ASCII string such as `b'RVFS'` or `b'RVM0'`; such comparisons use the
+   exact byte sequences or the exported constants.
+
+6. The wire-layout sections of ADR-004 and ADR-005 carry a prominent note
+   marking them superseded by this ADR.
+
+## 7. Revision history
+
+| Date | Change |
+|---|---|
+| 2026-08-02 | Codified the shipped append-only segment stream and tail-discovered manifest as the normative RVF v1 wire contract; exported exact magic byte constants; added golden byte vectors; superseded the wire-layout sections of ADR-004 and ADR-005. |

--- a/docs/research/rvf/spec/01-segment-model.md
+++ b/docs/research/rvf/spec/01-segment-model.md
@@ -33,7 +33,8 @@ to match SIMD register width.
 ```
 Offset  Size  Field              Description
 ------  ----  -----              -----------
-0x00    4     magic              0x52564653 ("RVFS" in ASCII)
+0x00    4     magic              0x52564653 (mnemonic "RVFS";
+                                 LE wire bytes 53 46 56 52)
 0x04    1     version            Segment format version (currently 1)
 0x05    1     seg_type           Segment type enum (see below)
 0x06    2     flags              Bitfield: compressed, encrypted, signed, sealed, etc.

--- a/docs/research/rvf/spec/02-manifest-system.md
+++ b/docs/research/rvf/spec/02-manifest-system.md
@@ -55,7 +55,8 @@ location: `seek(EOF - 4096)`.
 ```
 Offset  Size  Field                     Description
 ------  ----  -----                     -----------
-0x000   4     magic                     0x52564D30 ("RVM0")
+0x000   4     magic                     0x52564D30 (mnemonic "RVM0";
+                                        LE wire bytes 30 4D 56 52)
 0x004   2     version                   Root manifest version
 0x006   2     flags                     Root manifest flags
 0x008   8     l1_manifest_offset        Byte offset to Level 1 manifest segment
@@ -224,7 +225,8 @@ The MANIFEST_SEG payload structure is:
 
 Step 6 provides crash recovery. If the latest manifest write was interrupted,
 the previous manifest is still valid. Readers scan backward at 64-byte aligned
-boundaries looking for the RVFS magic + MANIFEST_SEG type.
+boundaries looking for the segment magic (wire bytes `53 46 56 52`) plus the
+MANIFEST_SEG type.
 
 ### Manifest Chain
 

--- a/docs/research/rvf/wire/binary-layout.md
+++ b/docs/research/rvf/wire/binary-layout.md
@@ -1,5 +1,12 @@
 # RVF Wire Format Reference
 
+> Normative for RVF v1 alongside
+> [ADR-009: RVF Version 1 Wire Contract](../../../architecture/decisions/ADR-009-rvf-v1-wire-contract.md).
+> All multi-byte integers are little-endian. The magic mnemonics "RVFS" and
+> "RVM0" are big-endian renderings of the numeric constants; the bytes on the
+> wire are `53 46 56 52` and `30 4D 56 52` respectively. Never compare wire
+> bytes against the ASCII spelling of a mnemonic.
+
 ## 1. File Structure
 
 An RVF file is a byte stream with no fixed header at offset 0. All structure
@@ -78,7 +85,8 @@ is absolute (not delta-encoded).
 ```
 Offset  Type    Field              Notes
 ------  ----    -----              -----
-0x00    u32     magic              Always 0x52564653 ("RVFS")
+0x00    u32     magic              Always 0x52564653 (mnemonic "RVFS";
+                                   LE wire bytes 53 46 56 52)
 0x04    u8      version            Format version (1)
 0x05    u8      seg_type           Segment type enum
 0x06    u16     flags              See flags bitfield
@@ -413,10 +421,16 @@ segment share the same compression.
 def find_latest_manifest(file):
     file_size = file.seek(0, SEEK_END)
 
+    # Magic values are little-endian on the wire, so the bytes are the
+    # REVERSE of the "RVFS" / "RVM0" mnemonics. See ADR-009; in Rust, use
+    # rvf_types::SEGMENT_MAGIC_BYTES and ROOT_MANIFEST_MAGIC_BYTES.
+    SEGMENT_MAGIC_BYTES = bytes([0x53, 0x46, 0x56, 0x52])
+    ROOT_MANIFEST_MAGIC_BYTES = bytes([0x30, 0x4D, 0x56, 0x52])
+
     # Try fast path: last 4096 bytes
     file.seek(file_size - 4096)
     root = file.read(4096)
-    if root[0:4] == b'RVM0' and verify_crc(root):
+    if root[0:4] == ROOT_MANIFEST_MAGIC_BYTES and verify_crc(root):
         return parse_root_manifest(root)
 
     # Slow path: scan backward for MANIFEST_SEG header
@@ -424,7 +438,7 @@ def find_latest_manifest(file):
     while scan_pos >= 0:
         file.seek(scan_pos)
         header = file.read(64)
-        if (header[0:4] == b'RVFS' and
+        if (header[0:4] == SEGMENT_MAGIC_BYTES and
             header[5] == 0x05 and  # MANIFEST_SEG
             verify_segment_header(header)):
             return parse_manifest_segment(file, scan_pos)


### PR DESCRIPTION
## Summary

Codifies the shipped RVF v1 wire format as the single normative contract (ADR-009), resolving the spec inconsistency where ADR-004/005 described a fixed offset-zero header while the shipped crates implement a tail-discovered manifest — flagged as the top blocker for optical/delta RVF delivery work.

## Contents
- **ADR-009** (`docs/architecture/decisions/`): tail-manifest layout normative for v1; exact little-endian wire bytes pinned (segment `53 46 56 52`, root `30 4D 56 52`); version-stability rules for any future byte change; ADR-004/005 wire sections marked superseded.
- **rvf-types**: exported `SEGMENT_MAGIC_BYTES` / `ROOT_MANIFEST_MAGIC_BYTES`; docs distinguish mnemonic (`RVFS`/`RVM0`) from wire bytes.
- **Golden vectors** (`rvf-wire/tests/wire_contract_golden.rs`), derived from shipped writer output, all claims verified empirically:
  - full 64-byte canonical empty segment header — SHAKE-256 field matches the NIST empty-input vector `46b9dd2b...`
  - root manifest: prefix `30 4D 56 52 01 00 00 00`, trailing CRC32C `FF DD 18 14`, zero-fill in between
  - tempfile round-trip proving tail discovery needs no offset-zero header
- **Bug-adjacent fixes**: `tail_scan.rs` comment documented the wrong anchor byte (code was right); doc pseudocode compared wire bytes to literal ASCII — a reader built from it would reject every real RVF file.
- **CI**: `rvf-wire-contract.yml` — fmt + clippy `-D warnings` + tests over rvf-types/rvf-wire on wire-related paths, pinned action SHAs, `contents: read`.
- Separate commit: 4 mechanical pre-existing clippy fixes in rvf-types so the new gate is green from run one.

## Verification
`cargo fmt --check`, `clippy -D warnings`: clean. Tests: rvf-types 230, rvf-wire 57 + 3 golden — all passing. Workflow YAML parses.

No wire bytes changed — existing artifacts, hashes, and signatures remain valid.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)