### PR TITLE
bench(spann): add a Criterion harness for the distance kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10603,6 +10603,10 @@ dependencies = [
 [[package]]
 name = "ruvector-spann"
 version = "0.1.0"
+dependencies = [
+ "criterion 0.5.1",
+ "rand 0.8.6",
+]
 
 [[package]]
 name = "ruvector-sparse-inference"

--- a/crates/ruvector-spann/Cargo.toml
+++ b/crates/ruvector-spann/Cargo.toml
@@ -13,3 +13,9 @@ path = "src/bin/benchmark.rs"
 [dependencies]
 
 [dev-dependencies]
+criterion = { workspace = true }
+rand = { workspace = true }
+
+[[bench]]
+name = "distance"
+harness = false

--- a/crates/ruvector-spann/benches/distance.rs
+++ b/crates/ruvector-spann/benches/distance.rs
@@ -1,0 +1,42 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use ruvector_spann::distance::{cosine_distance, l2_squared};
+
+const DIMENSIONS: [usize; 4] = [128, 384, 768, 1536];
+const SEED: u64 = 0x5eed_5eed_5eed_5eed;
+
+fn random_vector(rng: &mut StdRng, dim: usize) -> Vec<f32> {
+    (0..dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect()
+}
+
+fn bench_l2_squared(c: &mut Criterion) {
+    let mut group = c.benchmark_group("l2_squared");
+    for &dim in DIMENSIONS.iter() {
+        let mut rng = StdRng::seed_from_u64(SEED);
+        let a = random_vector(&mut rng, dim);
+        let b = random_vector(&mut rng, dim);
+
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bench, _| {
+            bench.iter(|| black_box(l2_squared(black_box(&a), black_box(&b))));
+        });
+    }
+    group.finish();
+}
+
+fn bench_cosine_distance(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cosine_distance");
+    for &dim in DIMENSIONS.iter() {
+        let mut rng = StdRng::seed_from_u64(SEED);
+        let a = random_vector(&mut rng, dim);
+        let b = random_vector(&mut rng, dim);
+
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bench, _| {
+            bench.iter(|| black_box(cosine_distance(black_box(&a), black_box(&b))));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_l2_squared, bench_cosine_distance);
+criterion_main!(benches);


### PR DESCRIPTION
## What

Adds a Criterion benchmark harness for `ruvector-spann`'s distance module. The
crate has distance kernels in `src/distance.rs`: `l2_squared` is on the index
hot path (`src/kmeans.rs`, `src/index.rs`), and `cosine_distance` is a public
kernel with no production call site today, covered by the same harness. Until
now the crate had no `benches/`
directory, no `[[bench]]` target, and no `criterion` dev-dependency — so a
performance change to this crate cannot be measured inside the crate itself.

No behaviour change. The only `Cargo.toml` additions are under
`[dev-dependencies]` (`criterion`, `rand`, both at the workspace-pinned
versions) plus the `[[bench]]` declaration.

## Design notes

- One Criterion group per public distance function, parameterized over
  dimensions 128 / 384 / 768 / 1536.
- Operands come from a seeded `StdRng` (`gen_range(-1.0..1.0)`), not constant
  fills, so runs are reproducible while still exercising data-dependent
  behaviour. Several existing benches elsewhere in the workspace use
  constant-fill vectors, which say nothing about data dependence; this harness
  deliberately does not inherit that.
- `black_box` on both inputs and outputs.

## Verification

- `cargo bench -p ruvector-spann --bench distance -- --test`: all 8 cases
  print `Success`.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p ruvector-spann --all-targets`: no Clippy diagnostic names
  the new bench file. Pre-existing, unrelated output remains: Cargo's
  workspace profile-ignored warnings and the `ruvector-attention` bench/bin
  double-target warning, both untouched here.

## Why now

#763 proposes an optional distance backend for this crate and currently has no
way to carry before/after numbers. This harness is the missing instrument, kept
as its own PR so the instrument and the change it would measure are reviewed
separately.


---

**Note on this PR's CI.** `Tests (core-and-rest)` is red on every branch in this repository,
including `main`: the job is cancelled at its 240-minute cap while still compiling and never
reaches the test phase. #786 restores the exclusion list that the shard's `packages:` value loses
to a shell comment, #784 unblocks the `ruvector-filter` test target that the compiler cannot
finish, and #787 fixes a deadlock waiting behind both. That failure is not caused by this branch.

