### PR TITLE
bench(diskann): add a Criterion harness for the distance kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9406,6 +9406,7 @@ version = "2.3.2"
 dependencies = [
  "bincode 2.0.1",
  "bytemuck",
+ "criterion 0.5.1",
  "getrandom 0.2.17",
  "memmap2",
  "parking_lot 0.12.5",

--- a/crates/ruvector-diskann/Cargo.toml
+++ b/crates/ruvector-diskann/Cargo.toml
@@ -36,6 +36,11 @@ simsimd = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3.9"
+criterion = { workspace = true }
+
+[[bench]]
+name = "distance"
+harness = false
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 # wasm32 SIMD128 correctness + A/B timing tests (`wasm-pack test --node`).

--- a/crates/ruvector-diskann/benches/distance.rs
+++ b/crates/ruvector-diskann/benches/distance.rs
@@ -1,0 +1,96 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use ruvector_diskann::distance::{
+    inner_product, l2_squared, pq_asymmetric_distance, scalar_l2_squared,
+};
+
+const DIMS: [usize; 4] = [128, 384, 768, 1536];
+const SEED: u64 = 0x5EED_1234_ABCD_EF01;
+const PQ_CODEBOOK_SIZE: usize = 256;
+
+fn random_vector(rng: &mut StdRng, dim: usize) -> Vec<f32> {
+    (0..dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect()
+}
+
+fn bench_l2_squared(c: &mut Criterion) {
+    let mut group = c.benchmark_group("l2_squared");
+    let mut rng = StdRng::seed_from_u64(SEED);
+
+    for &dim in DIMS.iter() {
+        let a = random_vector(&mut rng, dim);
+        let b = random_vector(&mut rng, dim);
+
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bencher, _| {
+            bencher.iter(|| black_box(l2_squared(black_box(&a), black_box(&b))));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_scalar_l2_squared(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scalar_l2_squared");
+    let mut rng = StdRng::seed_from_u64(SEED);
+
+    for &dim in DIMS.iter() {
+        let a = random_vector(&mut rng, dim);
+        let b = random_vector(&mut rng, dim);
+
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bencher, _| {
+            bencher.iter(|| black_box(scalar_l2_squared(black_box(&a), black_box(&b))));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_inner_product(c: &mut Criterion) {
+    let mut group = c.benchmark_group("inner_product");
+    let mut rng = StdRng::seed_from_u64(SEED);
+
+    for &dim in DIMS.iter() {
+        let a = random_vector(&mut rng, dim);
+        let b = random_vector(&mut rng, dim);
+
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bencher, _| {
+            bencher.iter(|| black_box(inner_product(black_box(&a), black_box(&b))));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_pq_asymmetric_distance(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pq_asymmetric_distance");
+    let mut rng = StdRng::seed_from_u64(SEED);
+
+    for &dim in DIMS.iter() {
+        let codes: Vec<u8> = (0..dim)
+            .map(|_| rng.gen_range(0..PQ_CODEBOOK_SIZE) as u8)
+            .collect();
+        let table: Vec<f32> = (0..dim * PQ_CODEBOOK_SIZE)
+            .map(|_| rng.gen_range(-1.0f32..1.0))
+            .collect();
+
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bencher, _| {
+            bencher.iter(|| {
+                black_box(pq_asymmetric_distance(
+                    black_box(&codes),
+                    black_box(&table),
+                    black_box(PQ_CODEBOOK_SIZE),
+                ))
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_l2_squared,
+    bench_scalar_l2_squared,
+    bench_inner_product,
+    bench_pq_asymmetric_distance
+);
+criterion_main!(benches);

--- a/crates/ruvector-diskann/benches/distance.rs
+++ b/crates/ruvector-diskann/benches/distance.rs
@@ -7,6 +7,9 @@ use ruvector_diskann::distance::{
 const DIMS: [usize; 4] = [128, 384, 768, 1536];
 const SEED: u64 = 0x5EED_1234_ABCD_EF01;
 const PQ_CODEBOOK_SIZE: usize = 256;
+const PQ_DSUB: usize = 8;
+// (dim, m) pairs at dsub = 8, matching the crate's exercised PQ shape (D=32, M=4).
+const PQ_DIM_M: [(usize, usize); 4] = [(128, 16), (384, 48), (768, 96), (1536, 192)];
 
 fn random_vector(rng: &mut StdRng, dim: usize) -> Vec<f32> {
     (0..dim).map(|_| rng.gen_range(-1.0f32..1.0)).collect()
@@ -64,15 +67,17 @@ fn bench_pq_asymmetric_distance(c: &mut Criterion) {
     let mut group = c.benchmark_group("pq_asymmetric_distance");
     let mut rng = StdRng::seed_from_u64(SEED);
 
-    for &dim in DIMS.iter() {
-        let codes: Vec<u8> = (0..dim)
+    for &(dim, m) in PQ_DIM_M.iter() {
+        debug_assert_eq!(dim, m * PQ_DSUB);
+        let codes: Vec<u8> = (0..m)
             .map(|_| rng.gen_range(0..PQ_CODEBOOK_SIZE) as u8)
             .collect();
-        let table: Vec<f32> = (0..dim * PQ_CODEBOOK_SIZE)
+        let table: Vec<f32> = (0..m * PQ_CODEBOOK_SIZE)
             .map(|_| rng.gen_range(-1.0f32..1.0))
             .collect();
 
-        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bencher, _| {
+        let label = format!("d{dim}_m{m}");
+        group.bench_with_input(BenchmarkId::from_parameter(&label), &m, |bencher, _| {
             bencher.iter(|| {
                 black_box(pq_asymmetric_distance(
                     black_box(&codes),


### PR DESCRIPTION
## What

Adds a Criterion benchmark harness for `ruvector-diskann`'s distance module.
The crate has four feature-agnostic public distance kernels in
`src/distance.rs` (`l2_squared`, `scalar_l2_squared`, `inner_product`,
`pq_asymmetric_distance`) and until now no `benches/` directory, no `[[bench]]`
target, and no `criterion` dev-dependency, so a performance change to this
crate cannot be measured inside the crate itself.

No behaviour change. `Cargo.toml` gains `criterion` under `[dev-dependencies]`
(workspace-pinned) and the `[[bench]]` declaration; `rand` was already a
dependency and needed nothing.

## Design notes

- One Criterion group per kernel, parameterized over dimensions
  128 / 384 / 768 / 1536.
- `simd_l2_squared` and the `wasm_simd128_*` variants are deliberately not
  benched: they are gated behind `feature = "simd"` / `target_arch = "wasm32"`
  and are not part of the default-feature build, so a default `cargo bench`
  could not reach them anyway. The harness benches what the active feature set
  provides.
- Operands from a seeded `StdRng` (`gen_range(-1.0..1.0)`) rather than constant
  fills; `black_box` on inputs and outputs.

## Verification

- `cargo bench -p ruvector-diskann --bench distance -- --test`: all 16 cases
  print `Success`.
- `cargo fmt --all -- --check`: clean (after one formatting pass on the new
  file).
- `cargo clippy -p ruvector-diskann --all-targets`: finishes with no warnings
  attributed to this crate or the new bench file.

## Why now

#766 proposes an optional distance backend for this crate and currently has no
way to carry before/after numbers. This harness is the missing instrument, kept
as its own PR so the instrument and the change it would measure are reviewed
separately.


---

**Note on this PR's CI.** `Tests (core-and-rest)` is red on every branch in this repository,
including `main`: the job is cancelled at its 240-minute cap while still compiling and never
reaches the test phase. #786 restores the exclusion list that the shard's `packages:` value loses
to a shell comment, #784 unblocks the `ruvector-filter` test target that the compiler cannot
finish, and #787 fixes a deadlock waiting behind both. That failure is not caused by this branch.
