### PR TITLE
fix(filter): unblock Tests (core-and-rest) — internally tagged recursive enum stalls rustc

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,12 +4,14 @@ git-fetch-with-cli = true
 [registries.crates-io]
 protocol = "git"
 
-# `ruvector-filter` carries `#![recursion_limit = "4096"]` (PR #389) to
-# survive trait-resolution overflow when serde_json's `Serializer` blanket
-# impl recurses through the crate's expression types. The deeper resolution
-# in turn drives rustc's own process stack past the default 8 MB on x86_64
-# Linux, so cargo test/cargo check must run with a larger thread stack.
-# 16 MB is rustc's documented suggested value when this happens.
+# `ruvector-filter` no longer needs a raised stack: its `FilterExpression`
+# logical variants (`And`/`Or`/`Not`) are struct-shaped now, which removed
+# the trait-resolution recursion that used to overflow rustc's process
+# stack, and `cargo test -p ruvector-filter` builds and runs clean even at
+# a 2 MB `RUST_MIN_STACK` (well under the 8 MB default). This setting is
+# kept anyway because no workspace-wide measurement has been done to show
+# every other crate is fine without it — treat it as still load-bearing
+# for the workspace as a whole until that measurement happens.
 [env]
 RUST_MIN_STACK = "16777216"
 

--- a/crates/ruvector-filter/src/evaluator.rs
+++ b/crates/ruvector-filter/src/evaluator.rs
@@ -41,9 +41,9 @@ impl<'a> FilterEvaluator<'a> {
                 top_left,
                 bottom_right,
             } => self.evaluate_geo_bbox(field, *top_left, *bottom_right),
-            FilterExpression::And(filters) => self.evaluate_and(filters),
-            FilterExpression::Or(filters) => self.evaluate_or(filters),
-            FilterExpression::Not(filter) => self.evaluate_not(filter),
+            FilterExpression::And { exprs } => self.evaluate_and(exprs),
+            FilterExpression::Or { exprs } => self.evaluate_or(exprs),
+            FilterExpression::Not { expr } => self.evaluate_not(expr),
             FilterExpression::Exists { field } => self.evaluate_exists(field),
             FilterExpression::IsNull { field } => self.evaluate_is_null(field),
         }
@@ -103,9 +103,9 @@ impl<'a> FilterEvaluator<'a> {
             FilterExpression::Match { field, text } => Self::get_field_value(payload, field)
                 .and_then(|v| v.as_str())
                 .is_some_and(|s| s.to_lowercase().contains(&text.to_lowercase())),
-            FilterExpression::And(filters) => filters.iter().all(|f| self.matches(payload, f)),
-            FilterExpression::Or(filters) => filters.iter().any(|f| self.matches(payload, f)),
-            FilterExpression::Not(filter) => !self.matches(payload, filter),
+            FilterExpression::And { exprs } => exprs.iter().all(|f| self.matches(payload, f)),
+            FilterExpression::Or { exprs } => exprs.iter().any(|f| self.matches(payload, f)),
+            FilterExpression::Not { expr } => !self.matches(payload, expr),
             FilterExpression::Exists { field } => Self::get_field_value(payload, field).is_some(),
             FilterExpression::IsNull { field } => {
                 Self::get_field_value(payload, field).is_none_or(|v| v.is_null())

--- a/crates/ruvector-filter/src/expression.rs
+++ b/crates/ruvector-filter/src/expression.rs
@@ -64,9 +64,15 @@ pub enum FilterExpression {
     },
 
     // Logical operators
-    And(Vec<FilterExpression>),
-    Or(Vec<FilterExpression>),
-    Not(Box<FilterExpression>),
+    And {
+        exprs: Vec<FilterExpression>,
+    },
+    Or {
+        exprs: Vec<FilterExpression>,
+    },
+    Not {
+        expr: Box<FilterExpression>,
+    },
 
     // Existence check
     Exists {
@@ -176,19 +182,21 @@ impl FilterExpression {
 
     /// Create an AND filter
     pub fn and(filters: Vec<FilterExpression>) -> Self {
-        Self::And(filters)
+        Self::And { exprs: filters }
     }
 
     /// Create an OR filter
     pub fn or(filters: Vec<FilterExpression>) -> Self {
-        Self::Or(filters)
+        Self::Or { exprs: filters }
     }
 
     /// Create a NOT filter
     // Public API constructor mirrors `and`/`or`; not the `std::ops::Not` trait.
     #[allow(clippy::should_implement_trait)]
     pub fn not(filter: FilterExpression) -> Self {
-        Self::Not(Box::new(filter))
+        Self::Not {
+            expr: Box::new(filter),
+        }
     }
 
     /// Create an EXISTS filter
@@ -231,12 +239,12 @@ impl FilterExpression {
             | Self::IsNull { field } => {
                 fields.push(field.clone());
             }
-            Self::And(exprs) | Self::Or(exprs) => {
+            Self::And { exprs } | Self::Or { exprs } => {
                 for expr in exprs {
                     expr.collect_fields(fields);
                 }
             }
-            Self::Not(expr) => {
+            Self::Not { expr } => {
                 expr.collect_fields(fields);
             }
         }
@@ -257,7 +265,7 @@ mod tests {
             FilterExpression::eq("status", json!("active")),
             FilterExpression::gte("age", json!(18)),
         ]);
-        assert!(matches!(filter, FilterExpression::And(_)));
+        assert!(matches!(filter, FilterExpression::And { .. }));
     }
 
     #[test]
@@ -280,5 +288,23 @@ mod tests {
         let json = serde_json::to_string(&filter).unwrap();
         let deserialized: FilterExpression = serde_json::from_str(&json).unwrap();
         assert!(matches!(deserialized, FilterExpression::Eq { .. }));
+    }
+
+    #[test]
+    fn test_logical_operator_round_trip() {
+        let filter = FilterExpression::and(vec![
+            FilterExpression::eq("status", json!("active")),
+            FilterExpression::not(FilterExpression::or(vec![
+                FilterExpression::lt("score", json!(10)),
+                FilterExpression::exists("banned"),
+            ])),
+        ]);
+
+        let encoded = serde_json::to_string(&filter).unwrap();
+        assert!(encoded.contains("\"type\":\"and\""));
+
+        let decoded: FilterExpression = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.get_fields(), filter.get_fields());
+        assert!(matches!(decoded, FilterExpression::And { .. }));
     }
 }

--- a/crates/ruvector-filter/src/expression.rs
+++ b/crates/ruvector-filter/src/expression.rs
@@ -300,11 +300,26 @@ mod tests {
             ])),
         ]);
 
-        let encoded = serde_json::to_string(&filter).unwrap();
-        assert!(encoded.contains("\"type\":\"and\""));
+        // Exact wire shape, per the `#[serde(tag = "type", rename_all = "snake_case")]`
+        // enum definition: each variant is `{"type": <snake_case variant name>, ...struct fields}`.
+        let expected = json!({
+            "type": "and",
+            "exprs": [
+                {"type": "eq", "field": "status", "value": "active"},
+                {"type": "not", "expr": {
+                    "type": "or",
+                    "exprs": [
+                        {"type": "lt", "field": "score", "value": 10},
+                        {"type": "exists", "field": "banned"},
+                    ]
+                }},
+            ]
+        });
 
-        let decoded: FilterExpression = serde_json::from_str(&encoded).unwrap();
-        assert_eq!(decoded.get_fields(), filter.get_fields());
-        assert!(matches!(decoded, FilterExpression::And { .. }));
+        let actual = serde_json::to_value(&filter).unwrap();
+        assert_eq!(actual, expected);
+
+        let decoded: FilterExpression = serde_json::from_value(actual).unwrap();
+        assert_eq!(serde_json::to_value(&decoded).unwrap(), expected);
     }
 }

--- a/crates/ruvector-filter/src/lib.rs
+++ b/crates/ruvector-filter/src/lib.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "4096"]
-
 //! # rUvector Filter
 //!
 //! Advanced payload indexing and filtering for rUvector.


### PR DESCRIPTION
## What this fixes

`Tests (core-and-rest)` on `main` does not fail, it runs out of clock. In the most
recent Workspace CI run on `main` (run `30767906155`, head `cc602dc2`) every other job
is green and that one job ran 21:29:04Z to 01:29:26Z and was cancelled by the
240-minute `timeout-minutes`. It never reaches the test phase; it is still compiling
when the limit hits.

The compile that never finishes is `ruvector-filter`'s test target. `cargo check -p
ruvector-filter --all-targets` finishes in about 10 seconds; `cargo test -p
ruvector-filter --no-run` on the same tree does not finish. Sampling the running
`rustc` (three independent samples on `main`) shows a single thread at ~98% CPU with
39k-60k `rustc_infer::infer::relate::generalize::Generalizer` /
`structurally_relate_tys` frames on the stack. It is a type-inference blowup, not slow
codegen.

## Cause

`FilterExpression` is internally tagged and recursive:

```rust
#[derive(Debug, Clone, Serialize, Deserialize)]
#[serde(tag = "type", rename_all = "snake_case")]
pub enum FilterExpression {
    Eq { field: String, value: Value },
    // ...
    And(Vec<FilterExpression>),
    Or(Vec<FilterExpression>),
    Not(Box<FilterExpression>),
}
```

serde's derive serializes an internally tagged **newtype** variant by wrapping the
outer serializer in `serde::private::ser::TaggedSerializer<S>`. When the newtype
payload transitively contains `Self`, the instantiation is
`TaggedSerializer<TaggedSerializer<...>>` with no bound, so the compiler walks a type
tower that only stops at `recursion_limit`. The crate already carried
`#![recursion_limit = "2048"]`, raised to `4096` in April to clear an `E0275`
(`&mut Vec<u8>: std::io::Write` overflow while instantiating the serde_json
`Serializer`). Raising the limit converted a fast error into a long compile; it did not
remove the tower.

Measured on `main`, one variable at a time:

| tree | `cargo test -p ruvector-filter --no-run` |
|---|---|
| `main` as-is | no completion (killed after the filter `rustc` held the CPU 150s straight) |
| only `expression.rs`'s `#[cfg(test)]` module stubbed out | 10s |
| only `test_serialization` kept, everything else in that module removed | no completion |
| that test reduced to just `serde_json::to_string(&filter)` | no completion |
| `#[serde(tag = "type")]` removed, recursion and tests unchanged | 5s |

The last row is the isolating one: the recursion is fine, the internal tag is fine, the
combination of an internal tag with a self-referential *newtype* variant is what the
compiler cannot close.

The same shape is also a runtime error, independent of build time. serde cannot encode
an internally tagged newtype variant whose payload is a sequence:

```
E::Xs(vec![1, 2])   => Err("cannot serialize tagged newtype variant E::Xs containing a sequence")
E::Inner(Box::new(Leaf { a: 1 })) => Ok("{\"type\":\"inner\",\"a\":1}")
```

So `FilterExpression::And` and `FilterExpression::Or` could never be serialized at all.
`Not` is not better off, only differently broken: its payload encodes as a map, so the
tag is merged into it and the result carries two `type` keys, which serde_json then
refuses to read back.

```
Not(Eq { field: "status" })  =>  Ok("{\"type\":\"not\",\"type\":\"eq\",\"field\":\"status\"}")
round trip                   =>  Err("duplicate field `type` at line 1 column 20")
```

None of the three logical variants had a working round trip. The existing
`test_serialization` only covered an `Eq` value, so nothing caught it.

## The change

The three logical variants become struct variants:

```rust
And { exprs: Vec<FilterExpression> },
Or  { exprs: Vec<FilterExpression> },
Not { expr: Box<FilterExpression> },
```

A struct variant serializes its fields directly through the outer serializer, so no
wrapper type nests. The wire encoding of every comparison variant is unchanged
(`{"type":"eq","field":...,"value":...}`), and `and`/`or`/`not` keep their signatures,
so callers that construct through the builders are untouched. `ruvector-node`,
`ruvector-wasm` and the doc examples all go through those builders and needed no
changes. Direct pattern matches on the three variants are updated in
`evaluator.rs`.

With the tower gone the crate builds at the **default** recursion limit, so the
explicit `#![recursion_limit]` attribute is dropped rather than lowered.

`test_logical_operator_round_trip` is added: it asserts the encoded value of a nested
and/not/or expression against the exact expected JSON object, then decodes it and checks
that it re-encodes to the same object. On the previous shape that test fails during
serialization.

## Compatibility

This is a breaking change to a public type and should be released as one.

- Rust callers that construct or pattern-match the tuple forms
  (`FilterExpression::And(v)`, `Or(v)`, `Not(b)`) must move to the named-field forms.
  The `and`, `or` and `not` builders are unchanged. No code in this repository outside
  `ruvector-filter` itself constructs or matches the three changed variants:
  `ruvector-wasm` and the crate's doc examples go through the builders, and the Node
  binding only uses the comparison forms, which are untouched.
- The JSON encoding of the three logical variants changes, but no previously valid
  document is affected: `And` and `Or` could not be produced at all, and a produced
  `Not` document could not be read back. Comparison variants (`eq`, `ne`, `gt`, `gte`,
  `lt`, `lte`, `range`, `in`, `match`, `geo_radius`, `geo_bounding_box`, `exists`,
  `is_null`) are byte-identical before and after.

## Verification

- `cargo test -p ruvector-filter --no-run`: no completion before, 10s after, at the
  default recursion limit.
- `cargo test -p ruvector-filter`: 17 tests plus 2 doc-tests pass.
- `cargo clippy -p ruvector-filter --all-targets -- -D warnings`: clean. `cargo fmt`
  applied.
- `cargo check -p ruvector-node --all-targets` and `cargo check -p ruvector-wasm
  --features collections`: both build.
- The full `core-and-rest` shard argument list from `ci.yml` (`--workspace` plus its 99
  `--exclude`s) with `--no-run`: 227 test executables link, zero errors. On `main` that
  same job on CI never reaches the test phase.

## Note on this PR's own CI

`Tests (core-and-rest)` will not go green on this branch alone. Two other things keep
that job from reporting: its `--exclude` list never reaches cargo (#786), and
`ruvector-delta-index` deadlocks in a test once the job gets that far (#787). All three
are needed before the job produces a result rather than a timeout.
