### PR TITLE
fix(ci): shard package lists are truncated at a '#' — core-and-rest runs the whole workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,15 @@ jobs:
             # iter-231 all cancelled at the timeout boundary). The wasm
             # crates are a natural sub-group: thin bindings on top of host
             # crates, easy to compile + test in isolation.
+            # Iter 233 — `ruvllm-wasm` excluded from native nextest:
+            # 11 of its 195 tests (sona_instant + workers::feature_detect)
+            # fail or SIGABRT on native because they're wasm-target
+            # specific (need wasm-bindgen-test). Surfaced by iter-232's
+            # split; previously masked by the iter-228..231 timeout
+            # cancellations of the megaShard. Tracking as workspace
+            # follow-up — fix is to gate the affected modules behind
+            # `#[cfg(target_arch = "wasm32")]` or migrate to
+            # wasm-bindgen-test runners.
             packages: >-
               -p neural-trader-wasm
               -p ruvector-acorn-wasm
@@ -207,15 +216,6 @@ jobs:
               -p ruvector-tiny-dancer-wasm
               -p ruvector-verified-wasm
               -p ruvector-wasm
-              # Iter 233 — `ruvllm-wasm` excluded from native nextest:
-              # 11 of its 195 tests (sona_instant + workers::feature_detect)
-              # fail or SIGABRT on native because they're wasm-target
-              # specific (need wasm-bindgen-test). Surfaced by iter-232's
-              # split; previously masked by the iter-228..231 timeout
-              # cancellations of the megaShard. Tracking as workspace
-              # follow-up — fix is to gate the affected modules behind
-              # `#[cfg(target_arch = "wasm32")]` or migrate to
-              # wasm-bindgen-test runners.
           - name: research-nightly
             # Nightly research PoC crates (iter 240+). Kept in a separate shard
             # so their compile + test time doesn't inflate core-and-rest.
@@ -239,9 +239,9 @@ jobs:
             # Everything else: core, delta, server/cluster, etc.
             # Uses --workspace + --exclude to subtract the groups above so we
             # don't have to enumerate ~100 crates by hand.
+            # Nightly research crates run in the research-nightly shard (iter 240+)
             packages: >-
               --workspace
-              # Nightly research crates run in the research-nightly shard (iter 240+)
               --exclude photonlayer-core
               --exclude photonlayer-bench
               --exclude photonlayer-cli


### PR DESCRIPTION
## What this fixes

`packages:` in the `test` job's matrix is a folded scalar (`>-`). YAML folds every
line of the block into one single-line string, and `#` inside a folded scalar is
ordinary content, not a comment. That string is pasted into the step's script by
`${{ matrix.packages }}` before bash parses it, and bash then treats the `#` as the
start of a comment and drops the rest of the line.

`core-and-rest` puts a comment on the second line of the block, so the intended
command

```
cargo nextest run --no-fail-fast --workspace --exclude photonlayer-core ...(99 excludes)
```

is actually run as

```
cargo nextest run --no-fail-fast --workspace
```

Every exclusion is dropped. The catch-all shard runs the whole workspace, including
all the crates that `research-nightly`, `core-and-rest-heavy`, `core-and-rest-wasm`,
`ruvix`, `rvagent` and the ml-research shards were created to hoist out of it. That
is the shard sitting at `timeout-minutes: 240`.

`core-and-rest-wasm` has the same construct, but its comment block is the last thing
in the scalar, so today only the comment is lost. It is one reordering away from
truncating the package list the same way.

## The change

Both comment blocks move above the `packages:` key, where YAML reads them as
comments. The comment text is unchanged and no package list is edited.

## How this was checked

Load the workflow, take each shard's resolved `packages` string, and paste it into a
shell script the way the runner does, then count the arguments bash actually produces:

| shard | args before | args after |
|---|---|---|
| core-and-rest | 4 | 202 |
| core-and-rest-wasm | 59 | 59 |
| every other shard | unchanged | unchanged |

After the change no `packages` value contains `#`.

Running the restored `core-and-rest` argument list locally (`cargo nextest run
--no-fail-fast` plus the 199 restored words) links 227 test binaries and executes 3121
tests, so the exclusion list is accepted by cargo as written.

## Note

Restoring the exclusions is necessary for that job to finish, but on its own it is not
sufficient: the job also stalls compiling `ruvector-filter`'s test target, which is
addressed separately in #784. Both are needed before `Tests (core-and-rest)` reports a
real result rather than a timeout.
