### PR TITLE
test(metrics): test_gather_metrics depends on another test having run first

### DIFF
--- a/crates/ruvector-metrics/src/lib.rs
+++ b/crates/ruvector-metrics/src/lib.rs
@@ -88,8 +88,15 @@ mod tests {
 
     #[test]
     fn test_gather_metrics() {
+        // The metrics are `lazy_static`, so they register with the default
+        // Prometheus registry on first use. Touch one here rather than relying
+        // on another test in the same process having done it: each test gets
+        // its own process under a per-test runner, and this assertion then has
+        // an empty registry to read.
+        COLLECTIONS_TOTAL.set(0.0);
+
         let metrics = gather_metrics();
-        assert!(metrics.contains("ruvector"));
+        assert!(metrics.contains("ruvector_collections_total"));
     }
 
     #[test]


### PR DESCRIPTION
## What this fixes

`ruvector-metrics::tests::test_gather_metrics` passes only because another test in the
same process happened to run first.

The metrics are `lazy_static`, so each one registers with the default Prometheus
registry the first time it is dereferenced. `test_gather_metrics` dereferences none of
them; it calls `gather_metrics()` and asserts the output contains `"ruvector"`. Under
`cargo test` all tests share one process and `test_record_search` touches two metrics,
so by the time the assertion runs the registry is usually populated. Under a
per-test-process runner the registry is empty and the assertion fails every time.

```
cargo test        -p ruvector-metrics                                  15 passed
cargo nextest run -p ruvector-metrics                                  14 passed, 1 failed
cargo nextest run -p ruvector-metrics -E 'test(test_gather_metrics)'    0 passed, 1 failed
```

The workflow runs `cargo nextest run`, so this is a deterministic failure there, not a
flake.

## The change

The test touches a metric itself before gathering, and asserts on that metric's name
instead of the bare `"ruvector"` substring. It no longer depends on execution order or
on sharing a process with another test.

## Verification

- `cargo nextest run -p ruvector-metrics`: 15 passed.
- `cargo nextest run -p ruvector-metrics -E 'test(test_gather_metrics)'`: 1 passed,
  which is the case that failed before.
- `cargo test -p ruvector-metrics`: 15 passed.
- `cargo clippy -p ruvector-metrics --all-targets -- -D warnings` clean; `cargo fmt`
  applied.

## Context

A recent `Tests (core-and-rest)` run reached its 240-minute cap while still compiling,
so it never got to the test phase and this failure has not been reported there. #784,
#786 and #787 address what keeps that job from finishing; this is one of the results
waiting behind them.
