### PR TITLE
chore(rvforge): 0.2.0

### DIFF
--- a/npm/packages/rvforge/package.json
+++ b/npm/packages/rvforge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ruvector/rvforge",
-  "version": "0.1.0",
-  "description": "RVForge \u2014 one canonical RVF to signed platform installers",
+  "version": "0.2.0",
+  "description": "RVForge — one canonical RVF to signed platform installers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
Records the published version. `@ruvector/rvforge@0.2.0` is live on npm.

Minor rather than patch because `create` is a new command that changes what the package can do — 0.1.0 could verify and package an `.rvf` but could not produce one, so the documented flow was unreachable from a clean install.

Verified against the published tarball, not just the source tree: installed `@ruvector/rvforge@0.2.0` from the registry into an empty directory and ran `init --keygen` → `create` → `validate --deep`. All exit 0, signature present. That is the check 0.1.0 needed and did not get.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_01ParP55bZs2iTGEGvpnUecx