### PR TITLE
ci: acknowledge pgrx serde_cbor advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -28,6 +28,7 @@ ignore = [
     # and revisit when the parent dep migrates.
 
     "RUSTSEC-2021-0140",  # rusttype — transitive via plotters; pure rendering, no untrusted input
+    "RUSTSEC-2021-0127",  # serde_cbor — unmaintained transitive dependency of pgrx; no maintained version satisfies pgrx
     "RUSTSEC-2022-0054",  # wee_alloc — transitive via wasm-bindgen-cli internals
     "RUSTSEC-2024-0370",  # proc-macro-error — build-time only (proc-macro), no runtime exposure
     "RUSTSEC-2024-0380",  # pqcrypto-dilithium — replaced by pqcrypto-mldsa, awaiting parent migration


### PR DESCRIPTION
## Summary

- acknowledge the new informational `RUSTSEC-2021-0127` advisory
- document that `serde_cbor` is an unmaintained transitive dependency of `pgrx`
- restore PostgreSQL Extension security-audit CI while continuing to fail on actual vulnerabilities

## Verification

- `cargo audit --file crates/ruvector-postgres/Cargo.lock`
- `git diff --check`

Follow-up to #819 post-merge validation.