### PR TITLE
ci: give heavy-shard packages a 90-minute nextest test bound

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,3 +7,14 @@
 # 5 periods (10 minutes), surfacing it as a normal test failure.
 [profile.default]
 slow-timeout = { period = "120s", terminate-after = 5 }
+
+# The heavy CI shards (ml-research-heavy, core-and-rest-heavy) exist to host
+# legitimately long-running tests — e.g. ruvector-mincut::subpolynomial tests
+# and ruvector-nervous-system::pattern_separation_collision_rate exceed 10
+# minutes by design and were killed by the default cap on the first sharded
+# run of main. Give those packages a 90-minute per-test bound instead: still
+# far below the 240-minute job budget, so a genuine hang fails the job in
+# 1.5h rather than 4h.
+[[profile.default.overrides]]
+filter = 'package(ruvector-attention) | package(ruvector-mincut) | package(ruvector-fpga-transformer) | package(ruvector-graph-transformer) | package(ruvllm) | package(ruvllm-cli) | package(ruvector-dag) | package(ruvector-nervous-system) | package(ruvector-math) | package(ruvector-consciousness) | package(prime-radiant) | package(mcp-brain) | package(ruvector-decompiler)'
+slow-timeout = { period = "300s", terminate-after = 18 }


### PR DESCRIPTION
Follow-up to #822. The 10-minute `terminate-after` cap was sized for the regular shards and killed legitimately long tests on the first genuinely-sharded run of `main` ([run 31714159600](https://github.com/ruvnet/RuVector/actions/runs/31714159600)):

- **ml-research-heavy**: `ruvector-mincut::subpolynomial` `test_certify_cuts`, `test_delete_edge`, `test_incremental_updates` — all TIMEOUT at exactly 600s
- **core-and-rest-heavy**: `ruvector-nervous-system::retrieval_quality::pattern_separation_collision_rate` — killed at 600s

Historical successful runs of those shards take up to ~75 minutes wall-clock with individual tests exceeding 10 minutes by design — the heavy shards exist to host them.

Fix: a `[[profile.default.overrides]]` block scoped to the 13 packages of the two heavy shards with `slow-timeout = { period = "300s", terminate-after = 18 }` (90 min). A genuine hang in a heavy package now bounds at 1.5h instead of the 4h job budget; every other package keeps the 10-minute cap. Config validated locally with `cargo-nextest show-config` (exit 0).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)