### PR TITLE
fix(node): verify effective config and contain mutable indexes

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -148,21 +148,41 @@ jobs:
           (matrix.settings.platform == 'darwin-x64' && runner.os == 'macOS' && runner.arch == 'X64') ||
           (matrix.settings.platform == 'darwin-arm64' && runner.os == 'macOS' && runner.arch == 'ARM64') ||
           (matrix.settings.platform == 'win32-x64-msvc' && runner.os == 'Windows')
-        continue-on-error: true
         shell: bash
         run: |
-          # Test the locally built .node file directly
+          # Test the locally built .node file directly. This is deliberately
+          # independent of installed @ruvector/core/platform packages so a PR
+          # cannot pass by loading older published bytes.
           NODE_FILE="npm/packages/core/index.${{ matrix.settings.platform }}.node"
-          if [ -f "$NODE_FILE" ]; then
-            echo "Testing native module: $NODE_FILE"
-            node -e "
-              const native = require('./$NODE_FILE');
-              console.log('Native module exports:', Object.keys(native));
-              console.log('✅ Native module loaded successfully');
-            "
-          else
-            echo "⚠️ Native module not found at $NODE_FILE - skipping test"
-          fi
+          test -f "$NODE_FILE"
+          echo "Testing native module: $NODE_FILE"
+          node -e "
+            const native = require('./$NODE_FILE');
+            if (typeof native.VectorDb !== 'function') {
+              throw new Error('Fresh native binary does not export VectorDb');
+            }
+            const storagePath = 'memory://native-effective-options-' + process.pid;
+            const db = new native.VectorDb({
+              dimensions: 4,
+              distanceMetric: 'Euclidean',
+              storagePath
+            });
+            if (typeof db.getOptions !== 'function') {
+              throw new Error('Fresh native binary does not export VectorDb.getOptions()');
+            }
+            const options = db.getOptions();
+            if (
+              options.dimensions !== 4 ||
+              options.distanceMetric !== 'euclidean' ||
+              options.storagePath !== storagePath ||
+              options.indexType !== 'flat' ||
+              options.hnswConfig != null
+            ) {
+              throw new Error('Unexpected effective options: ' + JSON.stringify(options));
+            }
+            console.log('Native effective options:', options);
+            console.log('✅ Fresh native getOptions() smoke passed');
+          "
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/crates/ruvector-core/src/vector_db.rs
+++ b/crates/ruvector-core/src/vector_db.rs
@@ -504,7 +504,11 @@ mod tests {
     #[test]
     fn options_report_persisted_configuration_after_reopen_override() -> Result<()> {
         let dir = tempdir().unwrap();
-        let storage_path = dir.path().join("effective-options.db").to_string_lossy().to_string();
+        let storage_path = dir
+            .path()
+            .join("effective-options.db")
+            .to_string_lossy()
+            .to_string();
 
         {
             let original = DbOptions {

--- a/crates/ruvector-core/src/vector_db.rs
+++ b/crates/ruvector-core/src/vector_db.rs
@@ -499,6 +499,43 @@ mod tests {
         assert_eq!(db.len().unwrap(), 1);
         assert!(!std::path::Path::new("memory:").exists());
     }
+
+    #[cfg(feature = "storage")]
+    #[test]
+    fn options_report_persisted_configuration_after_reopen_override() -> Result<()> {
+        let dir = tempdir().unwrap();
+        let storage_path = dir.path().join("effective-options.db").to_string_lossy().to_string();
+
+        {
+            let original = DbOptions {
+                dimensions: 2,
+                distance_metric: DistanceMetric::Euclidean,
+                storage_path: storage_path.clone(),
+                hnsw_config: None,
+                quantization: None,
+            };
+            let db = VectorDB::new(original)?;
+            assert_eq!(db.options().dimensions, 2);
+            assert_eq!(db.options().distance_metric, DistanceMetric::Euclidean);
+            assert!(db.options().hnsw_config.is_none());
+        }
+
+        let conflicting_reopen = DbOptions {
+            dimensions: 3,
+            distance_metric: DistanceMetric::Cosine,
+            storage_path: storage_path.clone(),
+            hnsw_config: Some(HnswConfig::default()),
+            quantization: None,
+        };
+        let reopened = VectorDB::new(conflicting_reopen)?;
+        let effective = reopened.options();
+        assert_eq!(effective.dimensions, 2);
+        assert_eq!(effective.distance_metric, DistanceMetric::Euclidean);
+        assert!(effective.hnsw_config.is_none());
+        assert_eq!(effective.storage_path, storage_path);
+        Ok(())
+    }
+
     use std::path::Path;
     use tempfile::tempdir;
 

--- a/crates/ruvector-node/src/lib.rs
+++ b/crates/ruvector-node/src/lib.rs
@@ -140,6 +140,126 @@ impl From<JsDbOptions> for DbOptions {
     }
 }
 
+/// Effective database configuration after persisted options have been loaded.
+///
+/// Unlike constructor options, this object describes the index that native core
+/// actually created. Metric and index names use stable lowercase spellings so
+/// JavaScript wrappers can compare them without depending on N-API enum casing.
+#[napi(object)]
+#[derive(Debug)]
+pub struct EffectiveDbOptions {
+    /// Effective vector dimensions
+    pub dimensions: u32,
+    /// Effective distance metric: cosine, euclidean, dotproduct, or manhattan
+    pub distance_metric: String,
+    /// Effective storage identity
+    pub storage_path: String,
+    /// Effective HNSW configuration; absent means FlatIndex
+    pub hnsw_config: Option<JsHnswConfig>,
+    /// Effective index implementation: hnsw or flat
+    pub index_type: String,
+}
+
+fn canonical_metric_name(metric: DistanceMetric) -> &'static str {
+    match metric {
+        DistanceMetric::Euclidean => "euclidean",
+        DistanceMetric::Cosine => "cosine",
+        DistanceMetric::DotProduct => "dotproduct",
+        DistanceMetric::Manhattan => "manhattan",
+    }
+}
+
+fn effective_options_to_js(options: &DbOptions) -> Result<EffectiveDbOptions> {
+    let dimensions = u32::try_from(options.dimensions)
+        .map_err(|_| Error::from_reason("Effective dimensions exceed the JavaScript u32 range"))?;
+    let hnsw_config = options
+        .hnsw_config
+        .as_ref()
+        .map(|config| -> Result<JsHnswConfig> {
+            Ok(JsHnswConfig {
+                m: Some(u32::try_from(config.m).map_err(|_| {
+                    Error::from_reason("Effective HNSW m exceeds the JavaScript u32 range")
+                })?),
+                ef_construction: Some(u32::try_from(config.ef_construction).map_err(|_| {
+                    Error::from_reason(
+                        "Effective HNSW efConstruction exceeds the JavaScript u32 range",
+                    )
+                })?),
+                ef_search: Some(u32::try_from(config.ef_search).map_err(|_| {
+                    Error::from_reason(
+                        "Effective HNSW efSearch exceeds the JavaScript u32 range",
+                    )
+                })?),
+                max_elements: Some(u32::try_from(config.max_elements).map_err(|_| {
+                    Error::from_reason(
+                        "Effective HNSW maxElements exceeds the JavaScript u32 range",
+                    )
+                })?),
+            })
+        })
+        .transpose()?;
+
+    Ok(EffectiveDbOptions {
+        dimensions,
+        distance_metric: canonical_metric_name(options.distance_metric).to_string(),
+        storage_path: options.storage_path.clone(),
+        index_type: if hnsw_config.is_some() {
+            "hnsw".to_string()
+        } else {
+            "flat".to_string()
+        },
+        hnsw_config,
+    })
+}
+
+#[cfg(test)]
+mod effective_options_tests {
+    use super::*;
+
+    #[test]
+    fn reports_canonical_effective_flat_options() {
+        let options = DbOptions {
+            dimensions: 16,
+            distance_metric: DistanceMetric::DotProduct,
+            storage_path: "/tmp/effective.db".to_string(),
+            hnsw_config: None,
+            quantization: None,
+        };
+
+        let effective = effective_options_to_js(&options).expect("options should convert");
+        assert_eq!(effective.dimensions, 16);
+        assert_eq!(effective.distance_metric, "dotproduct");
+        assert_eq!(effective.storage_path, "/tmp/effective.db");
+        assert_eq!(effective.index_type, "flat");
+        assert!(effective.hnsw_config.is_none());
+    }
+
+    #[test]
+    fn reports_effective_hnsw_parameters() {
+        let options = DbOptions {
+            dimensions: 3,
+            distance_metric: DistanceMetric::Euclidean,
+            storage_path: "memory://effective".to_string(),
+            hnsw_config: Some(HnswConfig {
+                m: 12,
+                ef_construction: 80,
+                ef_search: 40,
+                max_elements: 5_000,
+            }),
+            quantization: None,
+        };
+
+        let effective = effective_options_to_js(&options).expect("options should convert");
+        assert_eq!(effective.distance_metric, "euclidean");
+        assert_eq!(effective.index_type, "hnsw");
+        let hnsw = effective.hnsw_config.expect("HNSW config should be present");
+        assert_eq!(hnsw.m, Some(12));
+        assert_eq!(hnsw.ef_construction, Some(80));
+        assert_eq!(hnsw.ef_search, Some(40));
+        assert_eq!(hnsw.max_elements, Some(5_000));
+    }
+}
+
 /// Vector entry
 #[napi(object)]
 pub struct JsVectorEntry {
@@ -274,6 +394,17 @@ impl VectorDB {
         Ok(Self {
             inner: Arc::new(RwLock::new(db)),
         })
+    }
+
+    /// Return the effective native configuration after persisted options have
+    /// overridden constructor input.
+    #[napi]
+    pub fn get_options(&self) -> Result<EffectiveDbOptions> {
+        let db = self
+            .inner
+            .read()
+            .map_err(|_| Error::from_reason("Vector database lock poisoned"))?;
+        effective_options_to_js(db.options())
     }
 
     /// Insert a vector entry into the database

--- a/crates/ruvector-node/src/lib.rs
+++ b/crates/ruvector-node/src/lib.rs
@@ -186,9 +186,7 @@ fn effective_options_to_js(options: &DbOptions) -> Result<EffectiveDbOptions> {
                     )
                 })?),
                 ef_search: Some(u32::try_from(config.ef_search).map_err(|_| {
-                    Error::from_reason(
-                        "Effective HNSW efSearch exceeds the JavaScript u32 range",
-                    )
+                    Error::from_reason("Effective HNSW efSearch exceeds the JavaScript u32 range")
                 })?),
                 max_elements: Some(u32::try_from(config.max_elements).map_err(|_| {
                     Error::from_reason(
@@ -252,7 +250,9 @@ mod effective_options_tests {
         let effective = effective_options_to_js(&options).expect("options should convert");
         assert_eq!(effective.distance_metric, "euclidean");
         assert_eq!(effective.index_type, "hnsw");
-        let hnsw = effective.hnsw_config.expect("HNSW config should be present");
+        let hnsw = effective
+            .hnsw_config
+            .expect("HNSW config should be present");
         assert_eq!(hnsw.m, Some(12));
         assert_eq!(hnsw.ef_construction, Some(80));
         assert_eq!(hnsw.ef_search, Some(40));

--- a/npm/packages/core/README.md
+++ b/npm/packages/core/README.md
@@ -113,6 +113,13 @@ new VectorDb(options: {
 - `delete(id: string): Promise<boolean>` - Remove a vector
 - `len(): Promise<number>` - Count total vectors
 - `get(id: string): Promise<VectorEntry | null>` - Retrieve vector by ID
+- `getOptions(): EffectiveDbOptions` - Read the authoritative effective
+  dimensions, lowercase distance metric, storage path, index type, and HNSW
+  settings after persisted configuration has been restored
+
+`getOptions()` reports native effective state, not merely constructor input.
+Use it when reopening a persistent store before claiming a particular metric or
+index implementation.
 
 ## Performance Benchmarks
 

--- a/npm/packages/core/index.d.ts
+++ b/npm/packages/core/index.d.ts
@@ -14,8 +14,27 @@ export interface SearchResult {
   score: number;
 }
 
+export type DistanceMetric = 'cosine' | 'euclidean' | 'dotproduct' | 'manhattan';
+export type IndexType = 'hnsw' | 'flat';
+
+export interface HnswConfig {
+  m?: number;
+  efConstruction?: number;
+  efSearch?: number;
+  maxElements?: number;
+}
+
+export interface EffectiveDbOptions {
+  dimensions: number;
+  distanceMetric: DistanceMetric;
+  storagePath: string;
+  hnswConfig?: HnswConfig;
+  indexType: IndexType;
+}
+
 export class VectorDb {
-  constructor(options: { dimensions: number; storagePath?: string; distanceMetric?: string; hnswConfig?: any });
+  constructor(options: { dimensions: number; storagePath?: string; distanceMetric?: string; hnswConfig?: HnswConfig });
+  getOptions(): EffectiveDbOptions;
   insert(entry: VectorEntry): Promise<string>;
   insertBatch(entries: VectorEntry[]): Promise<string[]>;
   search(query: SearchQuery): Promise<SearchResult[]>;

--- a/npm/packages/core/test.js
+++ b/npm/packages/core/test.js
@@ -8,6 +8,22 @@ async function test() {
   console.log('Testing native module...');
 
   try {
+    const configured = new VectorDB({
+      dimensions: 4,
+      distanceMetric: 'Euclidean',
+      storagePath: `memory://get-options-${process.pid}`
+    });
+    const effective = configured.getOptions();
+    if (
+      effective.dimensions !== 4 ||
+      effective.distanceMetric !== 'euclidean' ||
+      effective.indexType !== 'flat' ||
+      effective.hnswConfig != null
+    ) {
+      throw new Error(`Unexpected effective options: ${JSON.stringify(effective)}`);
+    }
+    console.log('✓ Effective configuration getter');
+
     // Create database
     const db = VectorDB.withDimensions(128);
     console.log('✓ Created database');

--- a/npm/packages/ruvector/README.md
+++ b/npm/packages/ruvector/README.md
@@ -1851,6 +1851,7 @@ new VectorDb(options: {
   dimensions: number;        // Vector dimensionality (required)
   maxElements?: number;      // Max vectors (default: 10000)
   storagePath?: string;      // Persistent path; defaults to ./ruvector.db
+  indexType?: 'hnsw' | 'flat'; // HNSW by default; flat for mutable IDs
   ef_construction?: number;  // HNSW construction parameter (default: 200)
   m?: number;               // HNSW M parameter (default: 16)
   distanceMetric?: string;  // 'cosine', 'euclidean', or 'dot' (default: 'cosine')
@@ -1864,6 +1865,12 @@ Insert a vector into the database.
 
 An explicit `id` is a single-value upsert. Reusing it replaces the searchable
 vector and metadata; it does not create another search result with the same ID.
+
+For `indexType: 'hnsw'`, replacing an ID or deleting a vector rebuilds the native
+HNSW graph from persistent storage. This is a correctness containment for the
+native backend's non-removable graph nodes and costs O(N) per replacement or
+successful delete. Use `indexType: 'flat'` for high-frequency mutable state. Flat
+updates in place, trading O(1) mutation for O(N) search.
 
 ```javascript
 const id = await db.insert({
@@ -1970,6 +1977,46 @@ The store retains its vector dimension. Reopening the same path for a different
 dimension preserves the existing data and rejects mismatched vector operations.
 Use a distinct explicit `storagePath` for each embedding model or schema.
 `VectorIndex` is the high-level isolated temporary-index API.
+
+Native core restores the configuration persisted inside an existing store,
+which may differ from new constructor options. The npm wrapper reads the
+authoritative native `getOptions()` result after open and requires its dimension,
+metric, index type, storage identity, and HNSW parameters to match. A mismatch
+fails closed before the wrapper accepts traffic.
+
+Older native binaries without `getOptions()` cannot certify effective persisted
+configuration. Conservative HNSW access remains available with
+`configurationVerified: false`; flat construction requires the coordinated core
+release that exposes the getter.
+
+### Mutable indexes
+
+```javascript
+const mutable = new VectorDb({
+  dimensions: 128,
+  storagePath: './mutable-field.db',
+  indexType: 'flat'
+});
+
+console.log(mutable.getIndexInfo());
+// {
+//   indexType: 'flat',
+//   dimensions: 128,
+//   distanceMetric: 'cosine',
+//   storagePath: '/absolute/path/mutable-field.db',
+//   mutationMode: 'in-place',
+//   configurationVerified: true
+// }
+```
+
+Use flat indexes for routing fields, centroids, configuration heads, and other
+records replaced frequently, but accept mutable traffic only when
+`configurationVerified === true`, `indexType === 'flat'`, and
+`mutationMode === 'in-place'`. Use HNSW for larger, predominantly append-only
+collections where sublinear search justifies the graph. HNSW mutation rebuilds
+require file-backed storage; a non-file storage URI fails clearly instead of
+silently serving a damaged graph. Public index info uses lowercase canonical
+metric names: `cosine`, `euclidean`, `dotproduct`, or `manhattan`.
 
 ## 📦 Platform Support
 

--- a/npm/packages/ruvector/README.md
+++ b/npm/packages/ruvector/README.md
@@ -259,7 +259,7 @@ async function tutorial() {
   const db = new VectorDb({
     dimensions: 128,           // Vector size - MUST match your embeddings
     maxElements: 10000,        // Maximum vectors (can grow automatically)
-    storagePath: './my-vectors.db'  // Persist to disk (omit for in-memory)
+    storagePath: './my-vectors.db'  // Explicit persistent identity for this schema
   });
 
   console.log('✅ Database created successfully');
@@ -1850,7 +1850,7 @@ PHASE 3: Reflection
 new VectorDb(options: {
   dimensions: number;        // Vector dimensionality (required)
   maxElements?: number;      // Max vectors (default: 10000)
-  storagePath?: string;      // Persistent storage path
+  storagePath?: string;      // Persistent path; defaults to ./ruvector.db
   ef_construction?: number;  // HNSW construction parameter (default: 200)
   m?: number;               // HNSW M parameter (default: 16)
   distanceMetric?: string;  // 'cosine', 'euclidean', or 'dot' (default: 'cosine')
@@ -1861,6 +1861,9 @@ new VectorDb(options: {
 
 #### insert(entry: VectorEntry): Promise<string>
 Insert a vector into the database.
+
+An explicit `id` is a single-value upsert. Reusing it replaces the searchable
+vector and metadata; it does not create another search result with the same ID.
 
 ```javascript
 const id = await db.insert({
@@ -1951,18 +1954,22 @@ const db3 = new VectorDb({
 ### Persistence
 
 ```javascript
-// Auto-save to disk
+// Prefer an explicit path for every durable vector schema.
 const persistent = new VectorDb({
   dimensions: 128,
   storagePath: './persistent.db'
 });
 
-// In-memory only (faster, but data lost on exit)
-const temporary = new VectorDb({
+// Omitting storagePath is still persistent and uses ./ruvector.db.
+const defaultPersistent = new VectorDb({
   dimensions: 128
-  // No storagePath = in-memory
 });
 ```
+
+The store retains its vector dimension. Reopening the same path for a different
+dimension preserves the existing data and rejects mismatched vector operations.
+Use a distinct explicit `storagePath` for each embedding model or schema.
+`VectorIndex` is the high-level isolated temporary-index API.
 
 ## 📦 Platform Support
 

--- a/npm/packages/ruvector/package.json
+++ b/npm/packages/ruvector/package.json
@@ -12,7 +12,7 @@
     "verify-dist": "node scripts/verify-dist.js",
     "prepack": "npm run build && npm run verify-dist",
     "prepublishOnly": "npm run build && npm run verify-dist",
-    "test": "node test/integration.js && node test/metaharness-sdk.js && node test/cli-commands.js && node test/metaharness-cli.js && node test/db-workflow.js && node test/mcp-stdio.js && node test/metaharness-mcp.js && node test/sigterm-cleanup.js && node test/mcp-policy.js && node test/mcp-command-security.js && node test/mcp-handshake.js && node test/startup-budget.js"
+    "test": "node test/integration.js && node test/vector-index-lifecycle.js && node test/metaharness-sdk.js && node test/cli-commands.js && node test/metaharness-cli.js && node test/db-workflow.js && node test/mcp-stdio.js && node test/metaharness-mcp.js && node test/sigterm-cleanup.js && node test/mcp-policy.js && node test/mcp-command-security.js && node test/mcp-handshake.js && node test/startup-budget.js"
   },
   "keywords": [
     "vector",

--- a/npm/packages/ruvector/src/index.ts
+++ b/npm/packages/ruvector/src/index.ts
@@ -116,39 +116,63 @@ export function getVersion(): { version: string; implementation: string } {
   };
 }
 
-/**
- * Normalize a user-friendly distance metric string (`"cosine"`, `"euclidean"`,
- * etc.) to the PascalCase variant the native `JsDistanceMetric` enum accepts.
- * Native: { Euclidean, Cosine, DotProduct, Manhattan }.
- */
-function normalizeMetric(metric: string | undefined): string | undefined {
-  if (!metric) return metric;
-  const m = metric.toLowerCase().replace(/[_\s-]/g, '');
+export type VectorDistanceMetric = 'cosine' | 'euclidean' | 'dotproduct' | 'manhattan';
+
+/** Canonical public spelling used by index info and the persisted wrapper contract. */
+function canonicalizeMetric(metric: string | undefined): VectorDistanceMetric {
+  const m = (metric ?? 'cosine').toLowerCase().replace(/[_\s-]/g, '');
   switch (m) {
     case 'cosine':
-      return 'Cosine';
+      return 'cosine';
     case 'euclidean':
     case 'l2':
-      return 'Euclidean';
+      return 'euclidean';
     case 'dot':
     case 'dotproduct':
     case 'innerproduct':
-      return 'DotProduct';
+      return 'dotproduct';
     case 'manhattan':
     case 'l1':
-      return 'Manhattan';
+      return 'manhattan';
     default:
-      return metric; // pass through; native will error with the variant list.
+      throw new Error(
+        `Invalid distance metric: expected cosine, euclidean, dotproduct, or manhattan; got "${metric}"`
+      );
   }
 }
 
-interface VectorDBOptions {
+/** Convert the canonical public spelling to the native N-API enum variant. */
+function toNativeMetric(metric: VectorDistanceMetric): string {
+  switch (metric) {
+    case 'cosine': return 'Cosine';
+    case 'euclidean': return 'Euclidean';
+    case 'dotproduct': return 'DotProduct';
+    case 'manhattan': return 'Manhattan';
+  }
+}
+
+export type VectorIndexType = 'hnsw' | 'flat';
+
+export interface VectorDBOptions {
   dimensions?: number;
   dimension?: number;
   storagePath?: string;
   distanceMetric?: string;
   metric?: string;
   hnswConfig?: any;
+  indexType?: VectorIndexType;
+}
+
+export interface VectorIndexInfo {
+  /** Requested index type; effective only when configurationVerified is true. */
+  indexType: VectorIndexType;
+  dimensions: number;
+  /** Canonical lowercase requested metric; effective only when configurationVerified is true. */
+  distanceMetric: VectorDistanceMetric;
+  storagePath: string;
+  mutationMode: 'in-place' | 'rebuild' | 'unverified';
+  /** True only when native effective configuration is proven by the wrapper contract. */
+  configurationVerified: boolean;
 }
 
 /**
@@ -156,44 +180,66 @@ interface VectorDBOptions {
  */
 class VectorDBWrapper {
   private db: any;
+  private readonly nativeOptions: any;
   private readonly requestedDimensions: number;
   private readonly usesImplicitStoragePath: boolean;
   private implicitSchemaVerified = false;
   private readonly idWriteTails = new Map<string, Promise<void>>();
+  private hnswMutationTail: Promise<void> = Promise.resolve();
+  readonly indexType: VectorIndexType;
+  private readonly distanceMetric: VectorDistanceMetric;
+  private readonly storageIdentity: string;
+  private readonly configurationVerified: boolean;
 
   constructor(options: VectorDBOptions) {
     // Accept both `distanceMetric` (canonical) and `metric` (CLI shorthand).
-    // Normalize to the PascalCase enum variant the native binding expects.
-    const distanceMetric = normalizeMetric(options.distanceMetric ?? (options as any).metric);
+    const distanceMetric = canonicalizeMetric(options.distanceMetric ?? (options as any).metric);
     const dimensions = options.dimensions ?? options.dimension;
     if (typeof dimensions !== 'number' || !Number.isInteger(dimensions) || dimensions <= 0) {
       throw new Error('Missing or invalid `dimensions` (the singular `dimension` alias is also accepted)');
     }
     this.requestedDimensions = dimensions;
     this.usesImplicitStoragePath = options.storagePath === undefined;
+    const requestedIndexType = options.indexType?.toLowerCase();
+    if (requestedIndexType !== undefined && requestedIndexType !== 'hnsw' && requestedIndexType !== 'flat') {
+      throw new Error(`Invalid indexType: expected "hnsw" or "flat", got "${options.indexType}"`);
+    }
+    if (requestedIndexType === 'flat' && options.hnswConfig != null) {
+      throw new Error('indexType "flat" cannot be combined with hnswConfig');
+    }
+    if (requestedIndexType === 'hnsw' && options.hnswConfig === null) {
+      throw new Error('indexType "hnsw" cannot be combined with hnswConfig: null');
+    }
+    this.indexType = requestedIndexType === 'flat' || options.hnswConfig === null ? 'flat' : 'hnsw';
+    this.distanceMetric = distanceMetric;
+    const requestedStoragePath = options.storagePath ?? './ruvector.db';
+    this.storageIdentity = /^[a-z][a-z0-9+.-]*:\/\//i.test(requestedStoragePath)
+      ? requestedStoragePath
+      : require('path').resolve(requestedStoragePath);
     const nativeOptions: any = {
       // The native N-API contract is plural even when callers use the public
       // singular alias. Keeping this mapping here prevents CLI/API drift.
       dimensions,
-      storagePath: options.storagePath,
-      // The N-API binding maps an omitted hnswConfig to `None`, which selects
-      // FlatIndex and unintentionally overrides ruvector-core's HNSW default.
-      // Pass the documented defaults explicitly so the high-level VectorDB
-      // remains an ANN database unless callers deliberately provide another
-      // HNSW configuration.
-      hnswConfig: options.hnswConfig === undefined
+      // Pin even the implicit path at construction so a later process.chdir()
+      // cannot make a containment rebuild open a different database.
+      storagePath: this.storageIdentity,
+    };
+    // N-API selects FlatIndex only when hnswConfig is omitted. Passing null is
+    // rejected by the binding, so do not add the property for a flat index.
+    if (this.indexType === 'hnsw') {
+      nativeOptions.hnswConfig = options.hnswConfig === undefined
         ? {
             m: 32,
             efConstruction: 200,
             efSearch: 100,
             maxElements: 10_000_000,
           }
-        : options.hnswConfig,
-    };
-    if (distanceMetric !== undefined) {
-      nativeOptions.distanceMetric = distanceMetric;
+        : { ...options.hnswConfig };
     }
-    this.db = new implementation.VectorDb(nativeOptions);
+    nativeOptions.distanceMetric = toNativeMetric(distanceMetric);
+    this.nativeOptions = nativeOptions;
+    this.db = new implementation.VectorDb(this.cloneNativeOptions());
+    this.configurationVerified = this.verifyEffectiveNativeOptions(this.db);
   }
 
   /**
@@ -235,10 +281,154 @@ class VectorDBWrapper {
     }
   }
 
-  /** Remove an existing index node before reusing its ID. */
-  private async deleteExisting(id: string): Promise<void> {
-    if (await this.db.get(id)) {
-      await this.db.delete(id);
+  private cloneNativeOptions(): any {
+    return {
+      ...this.nativeOptions,
+      ...(this.nativeOptions.hnswConfig === undefined
+        ? {}
+        : { hnswConfig: { ...this.nativeOptions.hnswConfig } }),
+    };
+  }
+
+  private normalizedHnswConfig(config: any): {
+    m: number;
+    efConstruction: number;
+    efSearch: number;
+    maxElements: number;
+  } {
+    const normalized = {
+      m: config?.m ?? 32,
+      efConstruction: config?.efConstruction ?? 200,
+      efSearch: config?.efSearch ?? 100,
+      maxElements: config?.maxElements ?? 10_000_000,
+    };
+    for (const [name, value] of Object.entries(normalized)) {
+      if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+        throw new Error(`Invalid effective HNSW configuration: ${name}=${String(value)}`);
+      }
+    }
+    return normalized;
+  }
+
+  /**
+   * Native core restores persisted options instead of constructor input. Only
+   * its authoritative getter can certify the effective metric and index type.
+   */
+  private verifyEffectiveNativeOptions(candidate: any): boolean {
+    if (implementationType !== 'native') return false;
+
+    if (typeof candidate?.getOptions !== 'function') {
+      if (this.indexType === 'flat') {
+        throw new Error(
+          'Cannot certify a flat index with this @ruvector/core build because it does not expose ' +
+          'getOptions(). Upgrade to a coordinated core release before using mutable flat indexes.'
+        );
+      }
+      return false;
+    }
+
+    let effective: any;
+    try {
+      effective = candidate.getOptions();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Cannot verify effective native vector configuration: ${message}`);
+    }
+    if (!effective || typeof effective !== 'object' || typeof effective.then === 'function') {
+      throw new Error('Cannot verify effective native vector configuration: getOptions() returned an invalid value');
+    }
+    if (
+      typeof effective.dimensions !== 'number' ||
+      !Number.isInteger(effective.dimensions) ||
+      effective.dimensions <= 0 ||
+      typeof effective.distanceMetric !== 'string' ||
+      typeof effective.storagePath !== 'string' ||
+      (effective.indexType !== 'hnsw' && effective.indexType !== 'flat')
+    ) {
+      throw new Error('Cannot verify effective native vector configuration: getOptions() returned an invalid shape');
+    }
+
+    const effectiveMetric = canonicalizeMetric(effective.distanceMetric);
+    const effectiveIndexType: VectorIndexType = effective.indexType;
+    const hasHnswConfig = effective.hnswConfig !== undefined && effective.hnswConfig !== null;
+    if ((effectiveIndexType === 'hnsw') !== hasHnswConfig) {
+      throw new Error(
+        'Cannot verify effective native vector configuration: indexType and hnswConfig disagree'
+      );
+    }
+
+    const requestedHnsw = this.indexType === 'hnsw'
+      ? this.normalizedHnswConfig(this.nativeOptions.hnswConfig)
+      : undefined;
+    const effectiveHnsw = effectiveIndexType === 'hnsw'
+      ? this.normalizedHnswConfig(effective.hnswConfig)
+      : undefined;
+    const hnswMatches = requestedHnsw === undefined && effectiveHnsw === undefined ||
+      requestedHnsw !== undefined && effectiveHnsw !== undefined &&
+      requestedHnsw.m === effectiveHnsw.m &&
+      requestedHnsw.efConstruction === effectiveHnsw.efConstruction &&
+      requestedHnsw.efSearch === effectiveHnsw.efSearch &&
+      requestedHnsw.maxElements === effectiveHnsw.maxElements;
+
+    const mismatch = effective.dimensions !== this.requestedDimensions ||
+      effectiveMetric !== this.distanceMetric ||
+      effectiveIndexType !== this.indexType ||
+      effective.storagePath !== this.storageIdentity ||
+      !hnswMatches;
+    if (mismatch) {
+      const location = this.usesImplicitStoragePath
+        ? 'implicit persistent store "./ruvector.db"'
+        : `persistent store "${this.storageIdentity}"`;
+      throw new Error(
+        `Effective vector configuration mismatch at ${location}: native reports ` +
+        `dimensions=${effective.dimensions}, distanceMetric=${effectiveMetric}, ` +
+        `indexType=${effectiveIndexType}; requested dimensions=${this.requestedDimensions}, ` +
+        `distanceMetric=${this.distanceMetric}, indexType=${this.indexType}. ` +
+        'Persisted native configuration overrides constructor options; reopen with matching options ' +
+        'or use a new storagePath.'
+      );
+    }
+
+    return true;
+  }
+
+  /**
+   * hnsw_rs cannot remove graph nodes. Reopen the same persistent store so the
+   * native constructor rebuilds a clean graph from the unique storage records.
+   */
+  private assertHnswRebuildSupported(): void {
+    if (implementationType !== 'native' || this.indexType !== 'hnsw') return;
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(this.storageIdentity)) {
+      throw new Error(
+        'Cannot safely rebuild a mutable HNSW index backed by a non-file storage URI. ' +
+        'Use indexType "flat" for mutable explicit IDs.'
+      );
+    }
+  }
+
+  private rebuildNativeHnswIndex(): void {
+    if (implementationType !== 'native' || this.indexType !== 'hnsw') return;
+    this.assertHnswRebuildSupported();
+
+    const previous = this.db;
+    try {
+      const replacement = new implementation.VectorDb(this.cloneNativeOptions());
+      const replacementVerified = this.verifyEffectiveNativeOptions(replacement);
+      if (replacementVerified !== this.configurationVerified) {
+        throw new Error(
+          'Replacement native index changed configuration-verification status; refusing to attach it'
+        );
+      }
+      this.db = replacement;
+    } catch (error) {
+      this.db = previous;
+      const message = error instanceof Error ? error.message : String(error);
+      const diagnosed = new Error(
+        'The vector mutation was persisted, but the HNSW containment rebuild failed. ' +
+        `The previous wrapper remains attached; reopen this storage before further search. ${message}`
+      );
+      (diagnosed as any).cause = error;
+      throw diagnosed;
     }
   }
 
@@ -275,6 +465,41 @@ class VectorDBWrapper {
     }
   }
 
+  /** HNSW rebuilds replace the whole native index, so serialize every mutation. */
+  private async withMutationLock<T>(ids: string[], operation: () => Promise<T>): Promise<T> {
+    if (implementationType !== 'native' || this.indexType !== 'hnsw') {
+      return this.withIdWriteLocks(ids, operation);
+    }
+
+    const previous = this.hnswMutationTail;
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    const tail = previous.then(() => gate);
+    this.hnswMutationTail = tail;
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.hnswMutationTail === tail) this.hnswMutationTail = Promise.resolve();
+    }
+  }
+
+  getIndexInfo(): VectorIndexInfo {
+    return {
+      indexType: this.indexType,
+      dimensions: this.requestedDimensions,
+      distanceMetric: this.distanceMetric,
+      storagePath: this.storageIdentity,
+      mutationMode: implementationType === 'native' && this.indexType === 'hnsw'
+        ? 'rebuild'
+        : this.configurationVerified && this.indexType === 'flat'
+          ? 'in-place'
+          : 'unverified',
+      configurationVerified: this.configurationVerified,
+    };
+  }
+
   /**
    * Insert a vector with optional metadata (objects are auto-converted to JSON)
    */
@@ -293,16 +518,13 @@ class VectorDBWrapper {
 
     await this.verifyImplicitSchema(vector);
 
-    return this.withIdWriteLocks(entry.id === undefined ? [] : [entry.id], async () => {
-      // Storage already treats an explicit ID as an upsert, but HNSW appends a
-      // second graph node. Deleting first keeps storage, get(), stats, and search
-      // on the same single-value semantics.
-      if (entry.id !== undefined) {
-        await this.deleteExisting(entry.id);
-      }
-
+    return this.withMutationLock(entry.id === undefined ? [] : [entry.id], async () => {
+      const replacesExisting = entry.id !== undefined && await this.db.get(entry.id) !== null;
       try {
-        return await this.db.insert(nativeEntry);
+        if (replacesExisting) this.assertHnswRebuildSupported();
+        const id = await this.db.insert(nativeEntry);
+        if (replacesExisting) this.rebuildNativeHnswIndex();
+        return id;
       } catch (error) {
         this.rethrowWithStorageContext(error);
       }
@@ -315,7 +537,7 @@ class VectorDBWrapper {
   async insertBatch(entries: Array<{ id?: string; vector: Float32Array | number[]; metadata?: Record<string, any> }>): Promise<string[]> {
     if (entries.length === 0) return [];
 
-    // Validate and serialize the complete batch before deleting an old value.
+    // Validate and serialize the complete batch before mutating an old value.
     // Repeated explicit IDs use deterministic last-write-wins semantics.
     const nativeEntries = entries.map(entry => {
       const vector = entry.vector instanceof Float32Array
@@ -339,14 +561,17 @@ class VectorDBWrapper {
       .map((entry, index) => ({ entry, index }))
       .filter(({ entry, index }) => entry.id === undefined || lastIndexById.get(entry.id) === index);
 
-    return this.withIdWriteLocks([...lastIndexById.keys()], async () => {
+    return this.withMutationLock([...lastIndexById.keys()], async () => {
+      let replacesExisting = false;
       for (const id of lastIndexById.keys()) {
-        await this.deleteExisting(id);
+        if (await this.db.get(id)) replacesExisting = true;
       }
 
       let insertedIds: string[];
       try {
+        if (replacesExisting) this.assertHnswRebuildSupported();
         insertedIds = await this.db.insertBatch(retainedIndexes.map(({ entry }) => entry));
+        if (replacesExisting) this.rebuildNativeHnswIndex();
       } catch (error) {
         this.rethrowWithStorageContext(error);
       }
@@ -417,7 +642,12 @@ class VectorDBWrapper {
    * Delete a vector by ID
    */
   async delete(id: string): Promise<boolean> {
-    return this.db.delete(id);
+    return this.withMutationLock([id], async () => {
+      if (await this.db.get(id)) this.assertHnswRebuildSupported();
+      const deleted = await this.db.delete(id);
+      if (deleted) this.rebuildNativeHnswIndex();
+      return deleted;
+    });
   }
 
   /**
@@ -449,7 +679,7 @@ export const NativeVectorDb = implementation.VectorDb;
 export interface VectorIndexOptions {
   dimension: number;
   metric?: string;
-  indexType?: string;
+  indexType?: VectorIndexType;
   hnswConfig?: any;
 }
 
@@ -463,21 +693,31 @@ export class VectorIndex {
   private db: VectorDBWrapper;
   private readonly _dimension: number;
   private readonly _metric?: string;
-  private readonly _indexType?: string;
   private readonly _hnswConfig: any;
   private _storagePath: string;
+  readonly indexType: VectorIndexType;
 
   constructor(opts: VectorIndexOptions) {
     if (opts.dimension <= 0) {
       throw new Error(`Invalid dimensions: must be positive, got ${opts.dimension}`);
     }
+    const requestedIndexType = opts.indexType === undefined
+      ? 'hnsw'
+      : String(opts.indexType).toLowerCase();
+    if (requestedIndexType !== 'hnsw' && requestedIndexType !== 'flat') {
+      throw new Error(`Invalid indexType: expected "hnsw" or "flat", got "${opts.indexType}"`);
+    }
+    if (requestedIndexType === 'flat' && opts.hnswConfig != null) {
+      throw new Error('indexType "flat" cannot be combined with hnswConfig');
+    }
+    if (requestedIndexType === 'hnsw' && opts.hnswConfig === null) {
+      throw new Error('indexType "hnsw" cannot be combined with hnswConfig: null');
+    }
     this._dimension = opts.dimension;
     this._metric = opts.metric;
-    this._indexType = opts.indexType?.toLowerCase();
-    // Passing null selects the native flat index. Undefined lets the wrapper
-    // apply its documented HNSW defaults.
-    this._hnswConfig = this._indexType === 'flat'
-      ? null
+    this.indexType = requestedIndexType;
+    this._hnswConfig = this.indexType === 'flat'
+      ? undefined
       : opts.hnswConfig === undefined
         ? undefined
         : { ...opts.hnswConfig };
@@ -496,6 +736,7 @@ export class VectorIndex {
       distanceMetric: this._metric,
       storagePath,
       hnswConfig: this._hnswConfig,
+      indexType: this.indexType,
     });
   }
 
@@ -536,6 +777,10 @@ export class VectorIndex {
   async stats(): Promise<{ vectorCount: number; dimension: number }> {
     const count = await this.db.len();
     return { vectorCount: count, dimension: this._dimension };
+  }
+
+  getIndexInfo(): VectorIndexInfo {
+    return this.db.getIndexInfo();
   }
 
   async clear(): Promise<void> {

--- a/npm/packages/ruvector/src/index.ts
+++ b/npm/packages/ruvector/src/index.ts
@@ -142,13 +142,26 @@ function normalizeMetric(metric: string | undefined): string | undefined {
   }
 }
 
+interface VectorDBOptions {
+  dimensions?: number;
+  dimension?: number;
+  storagePath?: string;
+  distanceMetric?: string;
+  metric?: string;
+  hnswConfig?: any;
+}
+
 /**
  * Wrapper class that automatically handles metadata JSON conversion
  */
 class VectorDBWrapper {
   private db: any;
+  private readonly requestedDimensions: number;
+  private readonly usesImplicitStoragePath: boolean;
+  private implicitSchemaVerified = false;
+  private readonly idWriteTails = new Map<string, Promise<void>>();
 
-  constructor(options: { dimensions?: number; dimension?: number; storagePath?: string; distanceMetric?: string; metric?: string; hnswConfig?: any }) {
+  constructor(options: VectorDBOptions) {
     // Accept both `distanceMetric` (canonical) and `metric` (CLI shorthand).
     // Normalize to the PascalCase enum variant the native binding expects.
     const distanceMetric = normalizeMetric(options.distanceMetric ?? (options as any).metric);
@@ -156,6 +169,8 @@ class VectorDBWrapper {
     if (typeof dimensions !== 'number' || !Number.isInteger(dimensions) || dimensions <= 0) {
       throw new Error('Missing or invalid `dimensions` (the singular `dimension` alias is also accepted)');
     }
+    this.requestedDimensions = dimensions;
+    this.usesImplicitStoragePath = options.storagePath === undefined;
     const nativeOptions: any = {
       // The native N-API contract is plural even when callers use the public
       // singular alias. Keeping this mapping here prevents CLI/API drift.
@@ -182,12 +197,93 @@ class VectorDBWrapper {
   }
 
   /**
+   * The native backend persists to `./ruvector.db` when storagePath is omitted.
+   * On reopen it adopts the stored schema, so the mismatch is first observable
+   * when a caller submits a vector. Add storage identity without mislabelling a
+   * normal bad-vector error as a persisted-schema collision.
+   */
+  private rethrowWithStorageContext(error: unknown): never {
+    const message = error instanceof Error ? error.message : String(error);
+    const mismatch = message.match(/expected\s+(\d+)\s*,\s*(?:got|actual)\s+(\d+)/i);
+    const storedDimensions = mismatch ? Number(mismatch[1]) : undefined;
+    const submittedDimensions = mismatch ? Number(mismatch[2]) : undefined;
+
+    if (
+      this.usesImplicitStoragePath &&
+      storedDimensions !== undefined &&
+      submittedDimensions === this.requestedDimensions &&
+      storedDimensions !== this.requestedDimensions
+    ) {
+      const diagnosed = new Error(
+        `Vector schema collision at implicit persistent store "./ruvector.db": ` +
+        `the caller requested ${this.requestedDimensions} dimensions, but the existing store ` +
+        `expects ${storedDimensions}. Pass an explicit \`storagePath\` for each vector schema ` +
+        `or reopen this store with ${storedDimensions} dimensions. Original error: ${message}`
+      );
+      (diagnosed as any).cause = error;
+      throw diagnosed;
+    }
+
+    throw error;
+  }
+
+  private validateVector(vector: Float32Array): void {
+    if (vector.length !== this.requestedDimensions) {
+      throw new Error(
+        `Vector dimension mismatch: expected ${this.requestedDimensions}, got ${vector.length}`
+      );
+    }
+  }
+
+  /** Remove an existing index node before reusing its ID. */
+  private async deleteExisting(id: string): Promise<void> {
+    if (await this.db.get(id)) {
+      await this.db.delete(id);
+    }
+  }
+
+  /** Detect an implicit persisted-schema mismatch before any upsert deletes data. */
+  private async verifyImplicitSchema(vector: Float32Array): Promise<void> {
+    if (!this.usesImplicitStoragePath || this.implicitSchemaVerified) return;
+    try {
+      await this.db.search({ vector, k: 1 });
+    } catch (error) {
+      this.rethrowWithStorageContext(error);
+    }
+    this.implicitSchemaVerified = true;
+  }
+
+  /** Serialize only writes whose explicit ID sets overlap. */
+  private async withIdWriteLocks<T>(ids: string[], operation: () => Promise<T>): Promise<T> {
+    const reservations = [...new Set(ids)].sort().map(id => {
+      const previous = this.idWriteTails.get(id) ?? Promise.resolve();
+      let release!: () => void;
+      const gate = new Promise<void>(resolve => { release = resolve; });
+      const tail = previous.then(() => gate);
+      this.idWriteTails.set(id, tail);
+      return { id, previous, release, tail };
+    });
+
+    await Promise.all(reservations.map(({ previous }) => previous));
+    try {
+      return await operation();
+    } finally {
+      for (const { id, release, tail } of reservations) {
+        release();
+        if (this.idWriteTails.get(id) === tail) this.idWriteTails.delete(id);
+      }
+    }
+  }
+
+  /**
    * Insert a vector with optional metadata (objects are auto-converted to JSON)
    */
   async insert(entry: { id?: string; vector: Float32Array | number[]; metadata?: Record<string, any> }): Promise<string> {
+    const vector = entry.vector instanceof Float32Array ? entry.vector : new Float32Array(entry.vector);
+    this.validateVector(vector);
     const nativeEntry: any = {
       id: entry.id,
-      vector: entry.vector instanceof Float32Array ? entry.vector : new Float32Array(entry.vector),
+      vector,
     };
 
     // Auto-convert metadata object to JSON string
@@ -195,28 +291,89 @@ class VectorDBWrapper {
       nativeEntry.metadata = JSON.stringify(entry.metadata);
     }
 
-    return this.db.insert(nativeEntry);
+    await this.verifyImplicitSchema(vector);
+
+    return this.withIdWriteLocks(entry.id === undefined ? [] : [entry.id], async () => {
+      // Storage already treats an explicit ID as an upsert, but HNSW appends a
+      // second graph node. Deleting first keeps storage, get(), stats, and search
+      // on the same single-value semantics.
+      if (entry.id !== undefined) {
+        await this.deleteExisting(entry.id);
+      }
+
+      try {
+        return await this.db.insert(nativeEntry);
+      } catch (error) {
+        this.rethrowWithStorageContext(error);
+      }
+    });
   }
 
   /**
    * Insert multiple vectors in batch
    */
   async insertBatch(entries: Array<{ id?: string; vector: Float32Array | number[]; metadata?: Record<string, any> }>): Promise<string[]> {
-    const nativeEntries = entries.map(entry => ({
-      id: entry.id,
-      vector: entry.vector instanceof Float32Array ? entry.vector : new Float32Array(entry.vector),
-      metadata: entry.metadata ? JSON.stringify(entry.metadata) : undefined,
-    }));
+    if (entries.length === 0) return [];
 
-    return this.db.insertBatch(nativeEntries);
+    // Validate and serialize the complete batch before deleting an old value.
+    // Repeated explicit IDs use deterministic last-write-wins semantics.
+    const nativeEntries = entries.map(entry => {
+      const vector = entry.vector instanceof Float32Array
+        ? entry.vector
+        : new Float32Array(entry.vector);
+      this.validateVector(vector);
+      return {
+        id: entry.id,
+        vector,
+        metadata: entry.metadata ? JSON.stringify(entry.metadata) : undefined,
+      };
+    });
+    const lastIndexById = new Map<string, number>();
+    nativeEntries.forEach((entry, index) => {
+      if (entry.id !== undefined) lastIndexById.set(entry.id, index);
+    });
+
+    await this.verifyImplicitSchema(nativeEntries[0].vector);
+
+    const retainedIndexes = nativeEntries
+      .map((entry, index) => ({ entry, index }))
+      .filter(({ entry, index }) => entry.id === undefined || lastIndexById.get(entry.id) === index);
+
+    return this.withIdWriteLocks([...lastIndexById.keys()], async () => {
+      for (const id of lastIndexById.keys()) {
+        await this.deleteExisting(id);
+      }
+
+      let insertedIds: string[];
+      try {
+        insertedIds = await this.db.insertBatch(retainedIndexes.map(({ entry }) => entry));
+      } catch (error) {
+        this.rethrowWithStorageContext(error);
+      }
+
+      // Preserve the historical one-result-per-input return shape. Earlier
+      // duplicates resolve to the same explicit ID as their winning final value.
+      const ids = new Array<string>(entries.length);
+      retainedIndexes.forEach(({ index }, retainedIndex) => {
+        ids[index] = insertedIds[retainedIndex];
+      });
+      nativeEntries.forEach((entry, index) => {
+        if (ids[index] === undefined && entry.id !== undefined) ids[index] = entry.id;
+      });
+      return ids;
+    });
   }
 
   /**
    * Search for similar vectors (metadata is auto-parsed from JSON)
    */
   async search(query: { vector: Float32Array | number[]; k: number; filter?: Record<string, any>; efSearch?: number }): Promise<Array<{ id: string; score: number; vector?: Float32Array; metadata?: Record<string, any> }>> {
+    const vector = query.vector instanceof Float32Array
+      ? query.vector
+      : new Float32Array(query.vector);
+    this.validateVector(vector);
     const nativeQuery: any = {
-      vector: query.vector instanceof Float32Array ? query.vector : new Float32Array(query.vector),
+      vector,
       k: query.k,
       efSearch: query.efSearch,
     };
@@ -226,7 +383,12 @@ class VectorDBWrapper {
       nativeQuery.filter = JSON.stringify(query.filter);
     }
 
-    const results = await this.db.search(nativeQuery);
+    let results: any[];
+    try {
+      results = await this.db.search(nativeQuery);
+    } catch (error) {
+      this.rethrowWithStorageContext(error);
+    }
 
     // Auto-parse metadata JSON strings back to objects
     return results.map((r: any) => ({
@@ -284,20 +446,57 @@ export const NativeVectorDb = implementation.VectorDb;
 // Backwards-compat surface used by tests and older integrations
 // ────────────────────────────────────────────────────────────────────────────
 
-/** High-level index class compatible with the test-suite API. */
+export interface VectorIndexOptions {
+  dimension: number;
+  metric?: string;
+  indexType?: string;
+  hnswConfig?: any;
+}
+
+/**
+ * High-level index class compatible with the test-suite API.
+ *
+ * VectorIndex uses an isolated temporary store. Use VectorDb with an explicit
+ * storagePath when the storage identity must remain durable across processes.
+ */
 export class VectorIndex {
   private db: VectorDBWrapper;
-  private _dimension: number;
+  private readonly _dimension: number;
+  private readonly _metric?: string;
+  private readonly _indexType?: string;
+  private readonly _hnswConfig: any;
   private _storagePath: string;
 
-  constructor(opts: { dimension: number; metric?: string; indexType?: string }) {
+  constructor(opts: VectorIndexOptions) {
     if (opts.dimension <= 0) {
       throw new Error(`Invalid dimensions: must be positive, got ${opts.dimension}`);
     }
     this._dimension = opts.dimension;
+    this._metric = opts.metric;
+    this._indexType = opts.indexType?.toLowerCase();
+    // Passing null selects the native flat index. Undefined lets the wrapper
+    // apply its documented HNSW defaults.
+    this._hnswConfig = this._indexType === 'flat'
+      ? null
+      : opts.hnswConfig === undefined
+        ? undefined
+        : { ...opts.hnswConfig };
     // Use a unique temp path per instance to avoid cross-instance dimension conflicts
-    this._storagePath = require('os').tmpdir() + `/ruvector-idx-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
-    this.db = new VectorDBWrapper({ dimensions: opts.dimension, distanceMetric: opts.metric, storagePath: this._storagePath });
+    this._storagePath = this.createStoragePath();
+    this.db = this.createDatabase(this._storagePath);
+  }
+
+  private createStoragePath(): string {
+    return require('os').tmpdir() + `/ruvector-idx-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
+  }
+
+  private createDatabase(storagePath: string): VectorDBWrapper {
+    return new VectorDBWrapper({
+      dimensions: this._dimension,
+      distanceMetric: this._metric,
+      storagePath,
+      hnswConfig: this._hnswConfig,
+    });
   }
 
   async insert(entry: { id?: string; values: number[] }): Promise<string> {
@@ -340,10 +539,10 @@ export class VectorIndex {
   }
 
   async clear(): Promise<void> {
-    // Create a fresh db at a new temp path to reset state
-    const newPath = require('os').tmpdir() + `/ruvector-idx-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
+    // Create a fresh isolated store while retaining metric and index settings.
+    const newPath = this.createStoragePath();
     this._storagePath = newPath;
-    this.db = new VectorDBWrapper({ dimensions: this._dimension, storagePath: newPath });
+    this.db = this.createDatabase(newPath);
   }
 
   async optimize(): Promise<void> {

--- a/npm/packages/ruvector/test/vector-index-lifecycle.js
+++ b/npm/packages/ruvector/test/vector-index-lifecycle.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+const assert = require('node:assert/strict');
+const { rm, mkdtemp } = require('node:fs/promises');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const test = require('node:test');
+
+const { VectorDb, VectorIndex } = require('../dist/index.js');
+
+async function removeIndexStores(paths) {
+  for (const path of paths) {
+    if (path) await rm(path, { force: true });
+  }
+}
+
+test('VectorIndex.clear preserves the requested Euclidean ranking', async () => {
+  const index = new VectorIndex({ dimension: 2, metric: 'euclidean', indexType: 'hnsw' });
+  const paths = [index._storagePath];
+  const rows = [
+    { id: 'far-collinear', values: [10, 0] },
+    { id: 'near-angled', values: [0.8, 0.6] },
+  ];
+
+  try {
+    await index.insertBatch(rows);
+    const before = await index.search([1, 0], { k: 2 });
+
+    await index.clear();
+    paths.push(index._storagePath);
+    await index.insertBatch(rows);
+    const after = await index.search([1, 0], { k: 2 });
+
+    assert.deepEqual(before.map(result => result.id), ['near-angled', 'far-collinear']);
+    assert.deepEqual(after.map(result => result.id), before.map(result => result.id));
+  } finally {
+    await removeIndexStores(paths);
+  }
+});
+
+test('explicit ID inserts and batches remain single-value upserts', async () => {
+  const index = new VectorIndex({ dimension: 3, metric: 'cosine', indexType: 'hnsw' });
+  const paths = [index._storagePath];
+
+  try {
+    await index.insert({ id: 'same-id', values: [1, 0, 0] });
+    await index.insert({ id: 'same-id', values: [0, 1, 0] });
+
+    assert.deepEqual(await index.stats(), { vectorCount: 1, dimension: 3 });
+    assert.deepEqual((await index.get('same-id')).values, [0, 1, 0]);
+
+    const currentMatches = await index.search([0, 1, 0], { k: 10 });
+    assert.deepEqual(currentMatches.map(result => result.id), ['same-id']);
+
+    const staleMatches = await index.search([1, 0, 0], { k: 10 });
+    assert.deepEqual(staleMatches.map(result => result.id), ['same-id']);
+    assert.ok(staleMatches[0].score > 0.9, 'search must score the current vector, not a stale node');
+
+    const ids = await index.insertBatch([
+      { id: 'same-id', values: [1, 0, 0] },
+      { id: 'same-id', values: [0, 0, 1] },
+    ]);
+    assert.deepEqual(ids, ['same-id', 'same-id']);
+    assert.deepEqual(await index.stats(), { vectorCount: 1, dimension: 3 });
+    assert.deepEqual((await index.get('same-id')).values, [0, 0, 1]);
+
+    const batchMatches = await index.search([0, 0, 1], { k: 10 });
+    assert.deepEqual(batchMatches.map(result => result.id), ['same-id']);
+
+    await Promise.all([
+      index.insert({ id: 'same-id', values: [1, 0, 0] }),
+      index.insert({ id: 'same-id', values: [0, 1, 0] }),
+      index.insert({ id: 'same-id', values: [0, 0, 1] }),
+    ]);
+    const concurrentCurrent = await index.get('same-id');
+    const concurrentMatches = await index.search(concurrentCurrent.values, { k: 10 });
+    assert.deepEqual(concurrentMatches.map(result => result.id), ['same-id']);
+    assert.deepEqual(await index.stats(), { vectorCount: 1, dimension: 3 });
+  } finally {
+    await removeIndexStores(paths);
+  }
+});
+
+test('storage identity is explicit and implicit schema collisions are diagnosed', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'ruvector-storage-identity-'));
+  const explicitPath = join(directory, 'sixteen.db');
+  const originalDirectory = process.cwd();
+
+  try {
+    const explicit = new VectorDb({ dimensions: 16, storagePath: explicitPath });
+    await explicit.insert({ id: 'sixteen', vector: new Float32Array(16).fill(1) });
+    assert.equal(await explicit.len(), 1);
+
+    process.chdir(directory);
+    const first = new VectorDb({ dimensions: 3 });
+    await first.insert({ id: 'preserve-me', vector: [1, 0, 0] });
+
+    const conflicting = new VectorDb({ dimensions: 16 });
+    await assert.rejects(
+      conflicting.search({ vector: new Float32Array(3), k: 1 }),
+      /Vector dimension mismatch: expected 16, got 3/i
+    );
+    await assert.rejects(
+      conflicting.search({ vector: new Float32Array(16), k: 1 }),
+      /schema collision at implicit persistent store "\.\/ruvector\.db"/i
+    );
+    await assert.rejects(
+      conflicting.insert({ id: 'preserve-me', vector: new Float32Array(16).fill(1) }),
+      error => {
+        assert.match(error.message, /schema collision at implicit persistent store "\.\/ruvector\.db"/i);
+        assert.match(error.message, /requested 16 dimensions/i);
+        assert.match(error.message, /expects 3/i);
+        assert.match(error.message, /explicit `storagePath`/i);
+        return true;
+      }
+    );
+
+    const preserved = await first.get('preserve-me');
+    assert.deepEqual(Array.from(preserved.vector), [1, 0, 0]);
+  } finally {
+    process.chdir(originalDirectory);
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/npm/packages/ruvector/test/vector-index-lifecycle.js
+++ b/npm/packages/ruvector/test/vector-index-lifecycle.js
@@ -1,16 +1,80 @@
 #!/usr/bin/env node
 
 const assert = require('node:assert/strict');
-const { rm, mkdtemp } = require('node:fs/promises');
+const { access, rm, mkdtemp } = require('node:fs/promises');
 const { tmpdir } = require('node:os');
 const { join } = require('node:path');
 const test = require('node:test');
 
-const { VectorDb, VectorIndex } = require('../dist/index.js');
+// Published @ruvector/core 0.1.32 predates the authoritative getOptions()
+// binding. Keep local regression runs meaningful with a narrow constructor
+// proxy; CI and the coordinated core release exercise the real native getter.
+const coreModulePath = require.resolve('@ruvector/core');
+const loadedCore = require(coreModulePath);
+if (typeof loadedCore.VectorDb.prototype.getOptions !== 'function') {
+  const RealNativeVectorDb = loadedCore.VectorDb;
+  const effectiveByStorage = new Map();
+  const canonicalMetric = metric => {
+    const value = String(metric ?? 'Cosine').toLowerCase().replace(/[_\s-]/g, '');
+    if (value === 'l2') return 'euclidean';
+    if (value === 'dot' || value === 'innerproduct') return 'dotproduct';
+    if (value === 'l1') return 'manhattan';
+    return value;
+  };
+
+  class NativeVectorDbWithOptions {
+    constructor(options) {
+      this.inner = new RealNativeVectorDb(options);
+      const storagePath = options.storagePath ?? './ruvector.db';
+      const requested = {
+        dimensions: options.dimensions,
+        distanceMetric: canonicalMetric(options.distanceMetric),
+        storagePath,
+        hnswConfig: options.hnswConfig === undefined
+          ? undefined
+          : {
+              m: options.hnswConfig.m ?? 32,
+              efConstruction: options.hnswConfig.efConstruction ?? 200,
+              efSearch: options.hnswConfig.efSearch ?? 100,
+              maxElements: options.hnswConfig.maxElements ?? 10_000_000,
+            },
+        indexType: options.hnswConfig === undefined ? 'flat' : 'hnsw',
+      };
+      this.effective = effectiveByStorage.get(storagePath) ?? requested;
+      effectiveByStorage.set(storagePath, this.effective);
+    }
+
+    getOptions() { return { ...this.effective }; }
+    insert(entry) { return this.inner.insert(entry); }
+    insertBatch(entries) { return this.inner.insertBatch(entries); }
+    search(query) { return this.inner.search(query); }
+    delete(id) { return this.inner.delete(id); }
+    get(id) { return this.inner.get(id); }
+    len() { return this.inner.len(); }
+    isEmpty() { return this.inner.isEmpty(); }
+  }
+
+  require.cache[coreModulePath].exports = {
+    ...loadedCore,
+    VectorDb: NativeVectorDbWithOptions,
+    VectorDB: NativeVectorDbWithOptions,
+  };
+}
+
+const { NativeVectorDb, VectorDb, VectorIndex } = require('../dist/index.js');
 
 async function removeIndexStores(paths) {
   for (const path of paths) {
     if (path) await rm(path, { force: true });
+  }
+}
+
+async function pathExists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -81,6 +145,263 @@ test('explicit ID inserts and batches remain single-value upserts', async () => 
   }
 });
 
+test('native HNSW containment survives 100 replacements and delete cycles', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'ruvector-hnsw-rebuild-'));
+  try {
+    const db = new VectorDb({
+      dimensions: 2,
+      storagePath: join(directory, 'vectors.db'),
+      indexType: 'hnsw',
+    });
+    assert.deepEqual(db.getIndexInfo(), {
+      indexType: 'hnsw',
+      dimensions: 2,
+      distanceMetric: 'cosine',
+      storagePath: join(directory, 'vectors.db'),
+      mutationMode: 'rebuild',
+      configurationVerified: true,
+    });
+
+    await db.insert({ id: 'mutable', vector: [1, 0], metadata: { revision: -1 } });
+    for (let revision = 0; revision < 100; revision++) {
+      const vector = revision % 2 === 0 ? [1, 0] : [0, 1];
+      await db.insert({ id: 'mutable', vector, metadata: { revision } });
+      const matches = await db.search({ vector, k: 10 });
+      assert.deepEqual(matches.map(result => result.id), ['mutable'], `replacement ${revision}`);
+      assert.equal((await db.get('mutable')).metadata.revision, revision);
+      assert.equal(await db.len(), 1);
+    }
+
+    for (let revision = 100; revision < 200; revision++) {
+      const vector = revision % 2 === 0 ? [1, 0] : [0, 1];
+      assert.equal(await db.delete('mutable'), true);
+      await db.insert({ id: 'mutable', vector, metadata: { revision } });
+      const matches = await db.search({ vector, k: 10 });
+      assert.deepEqual(matches.map(result => result.id), ['mutable'], `delete cycle ${revision}`);
+      assert.equal(await db.len(), 1);
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('flat selector supports 100 in-place mutable updates', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'ruvector-flat-upsert-'));
+  try {
+    const db = new VectorDb({
+      dimensions: 2,
+      storagePath: join(directory, 'vectors.db'),
+      indexType: 'flat',
+    });
+    assert.deepEqual(db.getIndexInfo(), {
+      indexType: 'flat',
+      dimensions: 2,
+      distanceMetric: 'cosine',
+      storagePath: join(directory, 'vectors.db'),
+      mutationMode: 'in-place',
+      configurationVerified: true,
+    });
+
+    await db.insert({ id: 'mutable', vector: [1, 0], metadata: { revision: -1 } });
+    for (let revision = 0; revision < 100; revision++) {
+      const vector = revision % 2 === 0 ? [1, 0] : [0, 1];
+      await db.insert({ id: 'mutable', vector, metadata: { revision } });
+      const matches = await db.search({ vector, k: 10 });
+      assert.deepEqual(matches.map(result => result.id), ['mutable'], `flat replacement ${revision}`);
+      assert.equal(await db.len(), 1);
+    }
+
+    const compatibility = new VectorDb({
+      dimensions: 2,
+      storagePath: join(directory, 'compatibility.db'),
+      hnswConfig: null,
+    });
+    assert.equal(compatibility.indexType, 'flat');
+    await compatibility.insert({ id: 'flat', vector: [1, 0] });
+    assert.deepEqual(
+      (await compatibility.search({ vector: [1, 0], k: 1 })).map(result => result.id),
+      ['flat']
+    );
+
+    const index = new VectorIndex({ dimension: 2, indexType: 'flat' });
+    const indexPath = index._storagePath;
+    try {
+      assert.equal(index.indexType, 'flat');
+      assert.equal(index.getIndexInfo().mutationMode, 'in-place');
+    } finally {
+      await removeIndexStores([indexPath]);
+    }
+
+    const normalized = new VectorIndex({ dimension: 2, indexType: 'FLAT' });
+    const normalizedPath = normalized._storagePath;
+    try {
+      assert.equal(normalized.indexType, 'flat');
+      assert.equal(normalized.getIndexInfo().indexType, 'flat');
+    } finally {
+      await removeIndexStores([normalizedPath]);
+    }
+
+    assert.throws(
+      () => new VectorIndex({ dimension: 2, indexType: 'tree' }),
+      /Invalid indexType: expected "hnsw" or "flat"/i
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('authoritative native options reject persisted index and metric mismatch', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'ruvector-config-contract-'));
+  const storagePath = join(directory, 'vectors.db');
+  try {
+    const original = new VectorDb({
+      dimensions: 2,
+      distanceMetric: 'euclidean',
+      storagePath,
+      indexType: 'hnsw',
+    });
+    await original.insert({ id: 'preserved', vector: [1, 0] });
+
+    const reopened = new VectorDb({
+      dimensions: 2,
+      distanceMetric: 'EUCLIDEAN',
+      storagePath,
+      indexType: 'HNSW',
+    });
+    assert.deepEqual(reopened.getIndexInfo(), {
+      indexType: 'hnsw',
+      dimensions: 2,
+      distanceMetric: 'euclidean',
+      storagePath,
+      mutationMode: 'rebuild',
+      configurationVerified: true,
+    });
+
+    assert.throws(
+      () => new VectorDb({
+        dimensions: 2,
+        distanceMetric: 'cosine',
+        storagePath,
+        indexType: 'flat',
+      }),
+      error => {
+        assert.match(error.message, /Vector configuration mismatch/i);
+        assert.match(error.message, /native reports dimensions=2, distanceMetric=euclidean, indexType=hnsw/i);
+        assert.match(error.message, /requested dimensions=2, distanceMetric=cosine, indexType=flat/i);
+        return true;
+      }
+    );
+
+    assert.deepEqual(
+      (await reopened.search({ vector: [1, 0], k: 10 })).map(result => result.id),
+      ['preserved']
+    );
+
+    const descriptor = Object.getOwnPropertyDescriptor(NativeVectorDb.prototype, 'getOptions');
+    Object.defineProperty(NativeVectorDb.prototype, 'getOptions', {
+      ...descriptor,
+      value() {
+        const effective = descriptor.value.call(this);
+        return effective.storagePath === storagePath
+          ? { ...effective, distanceMetric: 'cosine' }
+          : effective;
+      },
+    });
+    try {
+      await assert.rejects(
+        reopened.insert({ id: 'preserved', vector: [0, 1] }),
+        /HNSW containment rebuild failed.*effective vector configuration mismatch/is
+      );
+    } finally {
+      Object.defineProperty(NativeVectorDb.prototype, 'getOptions', descriptor);
+    }
+
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('native bindings without getOptions never certify flat indexes', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'ruvector-legacy-config-'));
+  const storagePath = join(directory, 'legacy.db');
+  try {
+    const legacy = new NativeVectorDb({
+      dimensions: 2,
+      distanceMetric: 'Euclidean',
+      storagePath,
+    });
+    await legacy.insert({ id: 'legacy', vector: new Float32Array([1, 0]) });
+    const descriptor = Object.getOwnPropertyDescriptor(NativeVectorDb.prototype, 'getOptions');
+    assert.equal(typeof descriptor?.value, 'function', 'test requires the upgraded native getter');
+    Object.defineProperty(NativeVectorDb.prototype, 'getOptions', {
+      ...descriptor,
+      value: undefined,
+    });
+    try {
+      assert.throws(
+        () => new VectorDb({
+          dimensions: 2,
+          distanceMetric: 'euclidean',
+          storagePath,
+          indexType: 'flat',
+        }),
+        /does not expose getOptions/i
+      );
+
+      const conservative = new VectorDb({
+        dimensions: 2,
+        distanceMetric: 'cosine',
+        storagePath,
+        indexType: 'hnsw',
+      });
+      assert.deepEqual(conservative.getIndexInfo(), {
+        indexType: 'hnsw',
+        dimensions: 2,
+        distanceMetric: 'cosine',
+        storagePath,
+        mutationMode: 'rebuild',
+        configurationVerified: false,
+      });
+
+      await conservative.insert({ id: 'legacy', vector: [0, 1] });
+      assert.deepEqual(
+        (await conservative.search({ vector: [0, 1], k: 10 })).map(result => result.id),
+        ['legacy']
+      );
+    } finally {
+      Object.defineProperty(NativeVectorDb.prototype, 'getOptions', descriptor);
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('implicit storage identity remains pinned across chdir and HNSW rebuild', async () => {
+  const firstDirectory = await mkdtemp(join(tmpdir(), 'ruvector-cwd-first-'));
+  const secondDirectory = await mkdtemp(join(tmpdir(), 'ruvector-cwd-second-'));
+  const originalDirectory = process.cwd();
+
+  try {
+    process.chdir(firstDirectory);
+    const db = new VectorDb({ dimensions: 2, indexType: 'hnsw' });
+    await db.insert({ id: 'mutable', vector: [1, 0] });
+
+    process.chdir(secondDirectory);
+    await db.insert({ id: 'mutable', vector: [0, 1] });
+    assert.deepEqual(
+      (await db.search({ vector: [0, 1], k: 1 })).map(result => result.id),
+      ['mutable']
+    );
+    assert.equal(await pathExists(join(firstDirectory, 'ruvector.db')), true);
+    assert.equal(await pathExists(join(secondDirectory, 'ruvector.db')), false);
+    assert.equal(db.getIndexInfo().storagePath, join(firstDirectory, 'ruvector.db'));
+  } finally {
+    process.chdir(originalDirectory);
+    await rm(firstDirectory, { recursive: true, force: true });
+    await rm(secondDirectory, { recursive: true, force: true });
+  }
+});
+
 test('storage identity is explicit and implicit schema collisions are diagnosed', async () => {
   const directory = await mkdtemp(join(tmpdir(), 'ruvector-storage-identity-'));
   const explicitPath = join(directory, 'sixteen.db');
@@ -95,22 +416,17 @@ test('storage identity is explicit and implicit schema collisions are diagnosed'
     const first = new VectorDb({ dimensions: 3 });
     await first.insert({ id: 'preserve-me', vector: [1, 0, 0] });
 
-    const conflicting = new VectorDb({ dimensions: 16 });
     await assert.rejects(
-      conflicting.search({ vector: new Float32Array(3), k: 1 }),
-      /Vector dimension mismatch: expected 16, got 3/i
+      first.search({ vector: new Float32Array(16), k: 1 }),
+      /Vector dimension mismatch: expected 3, got 16/i
     );
-    await assert.rejects(
-      conflicting.search({ vector: new Float32Array(16), k: 1 }),
-      /schema collision at implicit persistent store "\.\/ruvector\.db"/i
-    );
-    await assert.rejects(
-      conflicting.insert({ id: 'preserve-me', vector: new Float32Array(16).fill(1) }),
+    assert.throws(
+      () => new VectorDb({ dimensions: 16 }),
       error => {
-        assert.match(error.message, /schema collision at implicit persistent store "\.\/ruvector\.db"/i);
-        assert.match(error.message, /requested 16 dimensions/i);
-        assert.match(error.message, /expects 3/i);
-        assert.match(error.message, /explicit `storagePath`/i);
+        assert.match(error.message, /effective vector configuration mismatch at implicit persistent store "\.\/ruvector\.db"/i);
+        assert.match(error.message, /native reports dimensions=3/i);
+        assert.match(error.message, /requested dimensions=16/i);
+        assert.match(error.message, /new storagePath/i);
         return true;
       }
     );


### PR DESCRIPTION
## Summary

This fixes five reproduced correctness failures across the native binding and high-level `ruvector` npm API:

1. `VectorIndex.clear()` recreated the database without its requested metric.
2. HNSW same-ID insertion created duplicate searchable graph nodes.
3. Repeated HNSW delete/reinsert made search permanently empty while `len()` remained one.
4. `VectorIndex({ indexType: 'flat' })` passed `hnswConfig: null`, which N-API rejects; FlatIndex is selected by omitting the property.
5. Native core restores persisted configuration over constructor input. Reopening an HNSW/Euclidean store as flat/cosine therefore produced HNSW behavior while `getIndexInfo()` falsely reported flat/in-place/Cosine.

The fix reports and validates authoritative native options, makes unverified state explicit, and preserves storage-collision diagnostics without a wrapper sidecar.

## Root cause

### HNSW tombstones

Native HNSW removal deletes `vectors`, `id_to_idx`, and `idx_to_id` mappings, but `hnsw_rs` cannot remove the graph node. Search drops unmapped nearest nodes without over-fetching or backfilling. After repeated replacements, every returned candidate can be a tombstone, producing an empty result even though persistent storage still contains one live vector.

Revisioned physical IDs do not solve this: insert-new/delete-old failed after approximately eleven one-live-node replacements. FlatIndex survived 100 same-ID replacements and delete/reinsert cycles.

### Requested options were not effective options

`CoreVectorDB::new` intentionally loads persisted `DbOptions` and replaces the requested dimension, metric, HNSW configuration, and index selection. Core already retains the effective options through `VectorDB::options()`, but N-API did not expose them. The npm wrapper could therefore report only its request, not the index actually opened.

## What changed

### Authoritative native effective-options getter

`ruvector-node` now exposes synchronous `VectorDb.getOptions()` backed by `CoreVectorDB::options()`:

```ts
interface EffectiveDbOptions {
  dimensions: number;
  distanceMetric: 'cosine' | 'euclidean' | 'dotproduct' | 'manhattan';
  storagePath: string;
  indexType: 'hnsw' | 'flat';
  hnswConfig?: {
    m?: number;
    efConstruction?: number;
    efSearch?: number;
    maxElements?: number;
  };
}
```

The getter derives `indexType` from effective persisted `hnsw_config` and returns canonical lowercase metric names. Native conversion rejects values that cannot fit the JavaScript `u32` contract.

The high-level wrapper calls the getter after every native open, including every HNSW containment rebuild, before attaching the candidate index. It compares effective dimension, metric, storage identity, index type, and normalized HNSW parameters. Any mismatch fails closed before traffic; a replacement mismatch retains the previous native handle and produces a recovery-directed error.

`getIndexInfo()` now returns canonical lowercase metrics plus:

```ts
mutationMode: 'in-place' | 'rebuild' | 'unverified';
configurationVerified: boolean;
```

Only an authoritative matching native getter sets `configurationVerified: true`. Older native binaries without `getOptions()` may remain in conservative HNSW/rebuild mode with `configurationVerified: false`; flat construction is rejected. Non-native backends are never certified as flat/in-place. Mutable field adapters must require verified, flat, and in-place.

### Correct flat selection

`VectorDb` and `VectorIndex` accept `indexType: 'hnsw' | 'flat'`. Flat selection omits `hnswConfig` from native options; no `null` reaches N-API. Compatibility input `hnswConfig: null` is normalized to the same omission. Runtime values are normalized (`FLAT` becomes `flat`) and invalid types fail at construction.

### HNSW correctness containment

For native file-backed HNSW, replacing an explicit ID or successfully deleting a vector reopens the same persistent store so native construction rebuilds one clean graph node per unique record. Every native HNSW mutation is serialized per wrapper because a rebuild replaces the whole index. Unsupported URI-backed replacement/delete is rejected before persistence changes.

This containment is O(N) for replacement and delete. FlatIndex remains the intended choice for frequently updated routing fields.

### Lifecycle and storage identity

`VectorIndex.clear()` retains metric, normalized index type, and cloned HNSW settings through one construction factory. The wrapper resolves even implicit `./ruvector.db` to an absolute identity at construction, so `process.chdir()` cannot redirect a later rebuild.

Insert, batch, and search validate requested dimensions. Effective native mismatch now fails at construction; older unverified HNSW bindings retain the non-mutating implicit-schema probe and actionable collision diagnostic.

## Regression coverage

`npm/packages/ruvector/test/vector-index-lifecycle.js` covers:

* Euclidean ranking before and after `clear()`
* sequential, batch, and concurrent same-ID updates
* 100 actual HNSW replacements after a seed insert
* 100 HNSW delete/reinsert cycles
* 100 actual FlatIndex replacements after a seed insert
* real flat omission semantics and `hnswConfig: null` compatibility
* matching authoritative native reopen with canonical metric reporting
* persisted HNSW/Euclidean reopened as flat/cosine failing closed
* old native binding without `getOptions()` rejecting flat certification while conservative HNSW reports `configurationVerified: false`
* effective-options verification on every HNSW rebuild
* implicit path pinning across `process.chdir()`
* explicit 16-dimensional storage, wrong query dimensions, and implicit 3D/16D collision preservation

Rust coverage adds canonical flat/HNSW N-API conversion and proves that core persisted options override conflicting reopen input while remaining visible through `VectorDB::options()`. `npm/packages/core/test.js` checks the real `getOptions()` object on a memory-backed FlatIndex when run against the rebuilt binding.

`Build Native Modules` now fails unless each native runner can load the freshly
built `.node` file and synchronously read exact dimensions, canonical metric,
storage identity, FlatIndex selection, and absent HNSW settings from
`VectorDb.getOptions()`. The smoke no longer skips a missing binary or uses
`continue-on-error`, and it cannot resolve older installed platform bytes.

## Validation

The local environment has published `@ruvector/core@0.1.32`, which predates `getOptions()`. The lifecycle test installs a narrow constructor proxy only in that case; it delegates vector operations to the real native binding and simulates core persisted-option override for wrapper verification tests. CI must additionally run against the rebuilt binding.

```text
NODE_PATH=/workspace/scratch/1a029ca34c64/node_modules node test/vector-index-lifecycle.js
8 passed, 0 failed

NODE_PATH=/workspace/scratch/1a029ca34c64/node_modules node test/integration.js
passed

NODE_PATH=/workspace/scratch/1a029ca34c64/node_modules node test/db-workflow.js
9 passed, 0 failed

TypeScript 5.9 full-package noEmit via temporary dependency path mapping
passed

node --check src/index.ts
passed

node --check test/vector-index-lifecycle.js
passed

node --check ../core/test.js
passed

git diff --check
passed
```

No Rust toolchain is installed in this worktree (`cargo: command not found`), so local `cargo fmt`, `cargo check`, Rust unit tests, N-API rebuild, and `npm/packages/core/test.js` against that rebuilt binary were unavailable. Required CI gates are:

```text
cargo fmt --check
cargo check -p ruvector-node
cargo test -p ruvector-node effective_options_tests
cargo test -p ruvector-core options_report_persisted_configuration_after_reopen_override
npm test --prefix npm/packages/core   # after N-API build
npm test --prefix npm/packages/ruvector
```

On draft head `0470919`, GitHub's `Build Native Modules` workflow completed
successfully for all five platform targets. The hardened direct-binary
`getOptions()` smoke passed on native Linux x64, macOS arm64, and Windows x64
runners; Linux arm64 and macOS x64 cross-build artifacts also completed.

## Security review

The RuVector parallel scanner was initialized explicitly and limited to changed/reachable Rust, TypeScript, and regression-test files. It reported 27 medium `template-injection` findings. The generic interpolation rule flags Rust formatting, local errors, assertion labels, and temporary filenames; none reaches evaluation, HTML, SQL, a shell, or another execution sink, so these are analyzer false positives.

The change adds no network boundary, command execution, dynamic evaluation, credential handling, or sidecar file trust boundary. Test deletion remains restricted to `mkdtemp` directories and generated temporary database paths.

## Release sequencing

This is a coordinated native/API release. Publish rebuilt platform binding packages and `@ruvector/core` containing `getOptions()` before publishing high-level `ruvector`. The source does not pin an unpublished package number; runtime feature detection fails closed for flat indexes on older binaries. Release automation should bump the `@ruvector/core` dependency floor when the coordinated version is assigned.

The PR build now gates the real N-API artifact directly. **The remaining npm
publication blocker** is to repeat that test against sealed, virgin tarballs in
the protected release workflow with the compatibility proxy disabled, then
coordinate every platform package, `@ruvector/core`, and high-level `ruvector`
version/dependency floor before anything ships. The public lowercase metric
contract and expanded `getIndexInfo()` union should use an additive minor
`ruvector` release (recommended `0.3.0`) rather than an unannounced patch.

## Performance and residual risk

* Native HNSW replacement and successful delete are synchronous O(N) rebuilds and can temporarily duplicate index memory until the old N-API object is collected.
* Flat mutation is in place, but search is O(N).
* Mutation serialization and ID locks are per wrapper. Separate `VectorDb` instances and processes targeting one store are not coordinated.
* Persistence plus HNSW reconstruction is not one transaction. If reconstruction fails, the mutation may already be durable; the wrapper retains its previous index and throws a recovery-directed error.
* Raw `NativeVectorDb` clients bypass high-level fail-closed comparison. Consumers requiring certified mutable behavior must use the high-level wrapper and check `configurationVerified`.
* `VectorIndex.clear()` rotates to a fresh isolated temporary store; it does not truncate a durable user-owned path.

The durable upstream HNSW fix remains native graph deletion/compaction plus transactional upsert. The effective-options getter independently closes the persisted-configuration observability gap for every wrapper.
