### PR TITLE
docs: link ruvnet/LatentMesh in Related

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,10 @@ The workspace requires Rust 1.77 or newer. RVF and PostgreSQL have separate buil
 
 Contributions are welcome. Start with the [contribution guide](./docs/development/CONTRIBUTING.md). New capability claims should include an implementation link and reproducible evidence.
 
+## Related
+
+[`ruvnet/LatentMesh`](https://github.com/ruvnet/LatentMesh) — a research prototype for causally-verified latent agent communication; ADR-005 names RuVector as the store for its raw→compressed→prototype→symbolic latent-memory continuum (design-stage, not yet wired to a live RuVector instance).
+
 ## License
 
 RuVector is available under the [MIT License](./LICENSE).

--- a/npm/packages/rvforge/package.json
+++ b/npm/packages/rvforge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ruvector/rvforge",
-  "version": "0.1.0",
-  "description": "RVForge \u2014 one canonical RVF to signed platform installers",
+  "version": "0.2.0",
+  "description": "RVForge — one canonical RVF to signed platform installers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
## Summary
- LatentMesh (research prototype, causally-verified latent agent communication) names RuVector as the intended store for its raw→compressed→prototype→symbolic latent-memory continuum (ADR-005) — design-stage, not yet wired.
- Adds a new "Related" section before License, one line + link.

## Test plan
- [x] README renders correctly (additive section, no structural change)