### PR TITLE
feat(ruvllm): cross-model KV-cache migration — linear mapper + quality gate (PIR WP13, ADR-314)

### DIFF
--- a/crates/ruvllm/Cargo.toml
+++ b/crates/ruvllm/Cargo.toml
@@ -134,6 +134,11 @@ wasm-simd = []
 # Quantization support (requires platform-specific SIMD)
 quantize = []
 
+# Cross-model KV-cache migration: closed-form linear mapper + transfer-quality
+# gate (arXiv:2608.03893, PIR WP13, ADR-314). Default-OFF so it cannot affect
+# existing builds.
+kv-migration = []
+
 # P5 Optimization: Optional routing metrics collection
 # Disable for production to avoid Instant::now() syscall overhead (~0.04-0.08µs)
 routing-metrics = []

--- a/crates/ruvllm/src/kv_migration/mapper.rs
+++ b/crates/ruvllm/src/kv_migration/mapper.rs
@@ -56,6 +56,25 @@ use super::LayerKvTensor;
 /// normal equations solvable when calibration tokens barely cover `src_dim`.
 pub const DEFAULT_RIDGE_LAMBDA: f32 = 1e-4;
 
+/// Maximum flattened per-token KV dimension (`num_kv_heads * head_dim`)
+/// accepted by [`LinearKvMapper::fit`], on both the source and target side.
+///
+/// The closed-form solve is O(n³) in the source dimension and allocates an
+/// `[n, n]` Gram matrix, so calibration input of size O(tokens · n) buys
+/// O(n³) work — an unbounded `n` is a denial-of-service hazard (`n = 65_536`
+/// would request a ~17 GB Gram matrix, and an allocation failure aborts the
+/// process). 8192 comfortably covers realistic flattened KV dimensions while
+/// keeping the solve tractable.
+pub const MAX_FIT_DIM: usize = 8192;
+
+/// Maximum number of calibration layers accepted by [`LinearKvMapper::fit`].
+/// Each layer costs two independent O(n³) solves (keys and values).
+pub const MAX_CALIBRATION_LAYERS: usize = 512;
+
+/// Maximum calibration tokens per layer accepted by [`LinearKvMapper::fit`].
+/// Bounds the O(tokens · n²) Gram-matrix accumulation.
+pub const MAX_CALIBRATION_TOKENS: usize = 1 << 20;
+
 /// Paired calibration activations for one layer: the same token sequence's
 /// K/V tensors as produced by the source model and by the target model.
 #[derive(Debug, Clone)]
@@ -135,11 +154,27 @@ impl LinearKvMapper {
     /// `calibration` holds one [`CalibrationLayerPair`] per layer, in layer
     /// order. All layers must share the same source and target dimensions.
     /// `ridge_lambda` must be positive; see [`DEFAULT_RIDGE_LAMBDA`].
+    ///
+    /// ## Cost
+    ///
+    /// Per layer, the closed-form solve costs O(tokens · n² + n³ + n² · m)
+    /// time and allocates an `[n, n]` Gram matrix, where `n` is the source
+    /// dimension and `m` the target dimension — the O(n³) term dominates for
+    /// realistic shapes. Inputs are bounded by [`MAX_FIT_DIM`],
+    /// [`MAX_CALIBRATION_LAYERS`], and [`MAX_CALIBRATION_TOKENS`]; anything
+    /// larger is rejected up front, before any allocation or solve.
     pub fn fit(calibration: &[CalibrationLayerPair], ridge_lambda: f32) -> Result<Self> {
         if calibration.is_empty() {
             return Err(RuvLLMError::KvCache(
                 "cannot fit LinearKvMapper from empty calibration set".to_string(),
             ));
+        }
+        if calibration.len() > MAX_CALIBRATION_LAYERS {
+            return Err(RuvLLMError::KvCache(format!(
+                "calibration set has {} layers, exceeding MAX_CALIBRATION_LAYERS = {}",
+                calibration.len(),
+                MAX_CALIBRATION_LAYERS
+            )));
         }
         if !(ridge_lambda > 0.0) || !ridge_lambda.is_finite() {
             return Err(RuvLLMError::KvCache(format!(
@@ -149,8 +184,20 @@ impl LinearKvMapper {
 
         let source_dim = calibration[0].source.dim();
         let target_dim = calibration[0].target.dim();
+        if source_dim == 0 || target_dim == 0 {
+            return Err(RuvLLMError::KvCache(format!(
+                "calibration dims must be non-zero, got {source_dim}->{target_dim}"
+            )));
+        }
+        if source_dim > MAX_FIT_DIM || target_dim > MAX_FIT_DIM {
+            return Err(RuvLLMError::KvCache(format!(
+                "calibration dims {source_dim}->{target_dim} exceed MAX_FIT_DIM = {MAX_FIT_DIM} \
+                 (the solve is O(n³) in the source dimension)"
+            )));
+        }
 
-        let mut layers = Vec::with_capacity(calibration.len());
+        // Validate every layer BEFORE the first O(n³) solve, so a malformed
+        // set is rejected without paying for any partial fit.
         for (idx, pair) in calibration.iter().enumerate() {
             if pair.source.dim() != source_dim || pair.target.dim() != target_dim {
                 return Err(RuvLLMError::KvCache(format!(
@@ -159,6 +206,17 @@ impl LinearKvMapper {
                     pair.target.dim()
                 )));
             }
+            if pair.source.tokens() > MAX_CALIBRATION_TOKENS {
+                return Err(RuvLLMError::KvCache(format!(
+                    "layer {idx} has {} calibration tokens, exceeding MAX_CALIBRATION_TOKENS = {}",
+                    pair.source.tokens(),
+                    MAX_CALIBRATION_TOKENS
+                )));
+            }
+        }
+
+        let mut layers = Vec::with_capacity(calibration.len());
+        for pair in calibration.iter() {
             let w_k = ridge_least_squares(&pair.source.keys, &pair.target.keys, ridge_lambda)?;
             let w_v = ridge_least_squares(&pair.source.values, &pair.target.values, ridge_lambda)?;
             layers.push(LayerMaps { w_k, w_v });

--- a/crates/ruvllm/src/kv_migration/mapper.rs
+++ b/crates/ruvllm/src/kv_migration/mapper.rs
@@ -1,0 +1,301 @@
+//! KV mappers: the [`KvMapper`] trait and the closed-form
+//! [`LinearKvMapper`] from arXiv:2608.03893.
+//!
+//! ## Approach
+//!
+//! For each transformer layer `l`, the linear mapper learns two matrices
+//! `W_k[l]` and `W_v[l]` of shape `[src_dim, tgt_dim]` such that
+//!
+//! ```text
+//! K_tgt ≈ K_src · W_k[l]      V_tgt ≈ V_src · W_v[l]
+//! ```
+//!
+//! where `K_src` is `[tokens, src_dim]` and `K_tgt` is `[tokens, tgt_dim]`,
+//! with `dim = num_kv_heads * head_dim` (the flattened per-token KV vector).
+//!
+//! The fit is the closed-form ridge-regularized least-squares solution
+//! (normal equations):
+//!
+//! ```text
+//! W = (Xᵀ X + λ I)⁻¹ Xᵀ Y
+//! ```
+//!
+//! solved by Gaussian elimination with partial pivoting — no external
+//! linear-algebra dependency beyond `ndarray`, which the crate already uses.
+//!
+//! ## Head-count / head-dim mismatch
+//!
+//! Following the paper, geometry mismatches between source and target
+//! (different `num_kv_heads`, different `head_dim`, or both) are handled by
+//! learning the projection over the *flattened* per-token KV vector:
+//! `W` is `[src_heads * src_head_dim, tgt_heads * tgt_head_dim]`, so any
+//! rectangular geometry change is expressible. When the head grids align,
+//! the learned `W` naturally converges to the paper's block-diagonal
+//! per-head projection; when they do not, the full matrix subsumes the
+//! paper's block/linear projection without special-casing.
+//!
+//! ## Assumptions (documented per ADR-314)
+//!
+//! 1. Calibration pairs are *position-aligned*: row `t` of the source
+//!    activations and row `t` of the target activations correspond to the
+//!    same token at the same position (same tokenizer, or a shared prefix
+//!    tokenized identically by both models).
+//! 2. RoPE/positional encoding conventions are compatible between the two
+//!    models (true within a model family, the paper's scope).
+//! 3. Per-layer correspondence is 1:1 — source layer `l` maps to target
+//!    layer `l`. Depth-mismatched families are out of scope for this slice.
+
+use crate::error::{Result, RuvLLMError};
+use ndarray::Array2;
+
+use super::LayerKvTensor;
+
+/// Default ridge regularization strength for [`LinearKvMapper::fit`].
+///
+/// Small enough not to bias a well-conditioned fit, large enough to keep the
+/// normal equations solvable when calibration tokens barely cover `src_dim`.
+pub const DEFAULT_RIDGE_LAMBDA: f32 = 1e-4;
+
+/// Paired calibration activations for one layer: the same token sequence's
+/// K/V tensors as produced by the source model and by the target model.
+#[derive(Debug, Clone)]
+pub struct CalibrationLayerPair {
+    /// Source-model K/V for the calibration tokens, `[tokens, src_dim]`.
+    pub source: LayerKvTensor,
+    /// Target-model K/V for the same tokens, `[tokens, tgt_dim]`.
+    pub target: LayerKvTensor,
+}
+
+impl CalibrationLayerPair {
+    /// Create a pair, validating token alignment.
+    pub fn new(source: LayerKvTensor, target: LayerKvTensor) -> Result<Self> {
+        if source.tokens() != target.tokens() {
+            return Err(RuvLLMError::KvCache(format!(
+                "calibration pair token mismatch: source={}, target={}",
+                source.tokens(),
+                target.tokens()
+            )));
+        }
+        Ok(Self { source, target })
+    }
+}
+
+/// Maps a per-layer K/V tensor pair from source-model geometry to
+/// target-model geometry.
+///
+/// Implemented by [`LinearKvMapper`] (this slice) and, in a future slice,
+/// by the nonlinear [`super::MlpKvMapper`] fallback the paper prescribes
+/// for the pairs where the linear map degrades.
+pub trait KvMapper: Send + Sync {
+    /// Number of layers this mapper was fitted for.
+    fn num_layers(&self) -> usize;
+
+    /// Source flattened per-token KV dimension.
+    fn source_dim(&self) -> usize;
+
+    /// Target flattened per-token KV dimension.
+    fn target_dim(&self) -> usize;
+
+    /// Map one layer's `[tokens, src_dim]` K/V matrices into
+    /// `[tokens, tgt_dim]` target geometry.
+    fn map_layer(
+        &self,
+        layer: usize,
+        keys: &Array2<f32>,
+        values: &Array2<f32>,
+    ) -> Result<(Array2<f32>, Array2<f32>)>;
+}
+
+/// Per-layer fitted projection matrices.
+#[derive(Debug, Clone)]
+struct LayerMaps {
+    /// Key projection, `[src_dim, tgt_dim]`.
+    w_k: Array2<f32>,
+    /// Value projection, `[src_dim, tgt_dim]`.
+    w_v: Array2<f32>,
+}
+
+/// Closed-form linear KV mapper (arXiv:2608.03893).
+///
+/// Fit once per (source model, target model) pair from a small paired
+/// calibration set, then applied to any number of cached sequences via two
+/// matmuls per layer.
+#[derive(Debug, Clone)]
+pub struct LinearKvMapper {
+    layers: Vec<LayerMaps>,
+    source_dim: usize,
+    target_dim: usize,
+}
+
+impl LinearKvMapper {
+    /// Fit per-layer `W_k`, `W_v` from paired calibration activations using
+    /// the closed-form ridge least-squares solution
+    /// `W = (Xᵀ X + λ I)⁻¹ Xᵀ Y`.
+    ///
+    /// `calibration` holds one [`CalibrationLayerPair`] per layer, in layer
+    /// order. All layers must share the same source and target dimensions.
+    /// `ridge_lambda` must be positive; see [`DEFAULT_RIDGE_LAMBDA`].
+    pub fn fit(calibration: &[CalibrationLayerPair], ridge_lambda: f32) -> Result<Self> {
+        if calibration.is_empty() {
+            return Err(RuvLLMError::KvCache(
+                "cannot fit LinearKvMapper from empty calibration set".to_string(),
+            ));
+        }
+        if !(ridge_lambda > 0.0) || !ridge_lambda.is_finite() {
+            return Err(RuvLLMError::KvCache(format!(
+                "ridge_lambda must be a positive finite value, got {ridge_lambda}"
+            )));
+        }
+
+        let source_dim = calibration[0].source.dim();
+        let target_dim = calibration[0].target.dim();
+
+        let mut layers = Vec::with_capacity(calibration.len());
+        for (idx, pair) in calibration.iter().enumerate() {
+            if pair.source.dim() != source_dim || pair.target.dim() != target_dim {
+                return Err(RuvLLMError::KvCache(format!(
+                    "layer {idx} dims ({}->{}) differ from layer 0 ({source_dim}->{target_dim})",
+                    pair.source.dim(),
+                    pair.target.dim()
+                )));
+            }
+            let w_k = ridge_least_squares(&pair.source.keys, &pair.target.keys, ridge_lambda)?;
+            let w_v = ridge_least_squares(&pair.source.values, &pair.target.values, ridge_lambda)?;
+            layers.push(LayerMaps { w_k, w_v });
+        }
+
+        Ok(Self {
+            layers,
+            source_dim,
+            target_dim,
+        })
+    }
+}
+
+impl KvMapper for LinearKvMapper {
+    fn num_layers(&self) -> usize {
+        self.layers.len()
+    }
+
+    fn source_dim(&self) -> usize {
+        self.source_dim
+    }
+
+    fn target_dim(&self) -> usize {
+        self.target_dim
+    }
+
+    fn map_layer(
+        &self,
+        layer: usize,
+        keys: &Array2<f32>,
+        values: &Array2<f32>,
+    ) -> Result<(Array2<f32>, Array2<f32>)> {
+        let maps = self.layers.get(layer).ok_or_else(|| {
+            RuvLLMError::KvCache(format!(
+                "layer {layer} out of range (mapper has {} layers)",
+                self.layers.len()
+            ))
+        })?;
+        if keys.ncols() != self.source_dim || values.ncols() != self.source_dim {
+            return Err(RuvLLMError::KvCache(format!(
+                "layer {layer}: input dim {} does not match mapper source dim {}",
+                keys.ncols(),
+                self.source_dim
+            )));
+        }
+        Ok((keys.dot(&maps.w_k), values.dot(&maps.w_v)))
+    }
+}
+
+/// Closed-form ridge least squares: `W = (Xᵀ X + λ I)⁻¹ Xᵀ Y`.
+///
+/// `x` is `[tokens, n]`, `y` is `[tokens, m]`; returns `W` as `[n, m]`.
+fn ridge_least_squares(x: &Array2<f32>, y: &Array2<f32>, lambda: f32) -> Result<Array2<f32>> {
+    if x.nrows() != y.nrows() {
+        return Err(RuvLLMError::KvCache(format!(
+            "least squares row mismatch: x has {}, y has {}",
+            x.nrows(),
+            y.nrows()
+        )));
+    }
+    if x.nrows() == 0 {
+        return Err(RuvLLMError::KvCache(
+            "least squares requires at least one calibration token".to_string(),
+        ));
+    }
+
+    let n = x.ncols();
+    let mut a = x.t().dot(x); // [n, n]
+    for i in 0..n {
+        a[[i, i]] += lambda;
+    }
+    let b = x.t().dot(y); // [n, m]
+    solve_linear_system(a, b)
+}
+
+/// Solve `A · W = B` for `W` by Gaussian elimination with partial pivoting.
+///
+/// `a` is `[n, n]` (consumed), `b` is `[n, m]`; returns `W` as `[n, m]`.
+/// `A` here is the ridge-regularized Gram matrix, so it is symmetric
+/// positive definite and the elimination cannot hit a zero pivot unless the
+/// inputs are degenerate (NaN/Inf), which is reported as an error.
+fn solve_linear_system(mut a: Array2<f32>, mut b: Array2<f32>) -> Result<Array2<f32>> {
+    let n = a.nrows();
+    let m = b.ncols();
+
+    // Forward elimination with partial pivoting.
+    for col in 0..n {
+        // Find pivot row.
+        let mut pivot = col;
+        let mut best = a[[col, col]].abs();
+        for row in (col + 1)..n {
+            let mag = a[[row, col]].abs();
+            if mag > best {
+                best = mag;
+                pivot = row;
+            }
+        }
+        if !best.is_finite() || best < f32::EPSILON {
+            return Err(RuvLLMError::KvCache(format!(
+                "singular or degenerate system at column {col} (pivot magnitude {best})"
+            )));
+        }
+        if pivot != col {
+            for j in 0..n {
+                a.swap([col, j], [pivot, j]);
+            }
+            for j in 0..m {
+                b.swap([col, j], [pivot, j]);
+            }
+        }
+
+        let diag = a[[col, col]];
+        for row in (col + 1)..n {
+            let factor = a[[row, col]] / diag;
+            if factor == 0.0 {
+                continue;
+            }
+            for j in col..n {
+                a[[row, j]] -= factor * a[[col, j]];
+            }
+            for j in 0..m {
+                b[[row, j]] -= factor * b[[col, j]];
+            }
+        }
+    }
+
+    // Back substitution.
+    let mut w = Array2::<f32>::zeros((n, m));
+    for row in (0..n).rev() {
+        for j in 0..m {
+            let mut acc = b[[row, j]];
+            for k in (row + 1)..n {
+                acc -= a[[row, k]] * w[[k, j]];
+            }
+            w[[row, j]] = acc / a[[row, row]];
+        }
+    }
+
+    Ok(w)
+}

--- a/crates/ruvllm/src/kv_migration/mod.rs
+++ b/crates/ruvllm/src/kv_migration/mod.rs
@@ -34,7 +34,10 @@ pub mod quality;
 #[cfg(test)]
 mod tests;
 
-pub use mapper::{CalibrationLayerPair, KvMapper, LinearKvMapper};
+pub use mapper::{
+    CalibrationLayerPair, KvMapper, LinearKvMapper, DEFAULT_RIDGE_LAMBDA, MAX_CALIBRATION_LAYERS,
+    MAX_CALIBRATION_TOKENS, MAX_FIT_DIM,
+};
 pub use quality::{
     GateDecision, LayerQuality, QualityGateConfig, QualityReport, TransferQualityGate,
 };
@@ -74,7 +77,12 @@ impl LayerKvTensor {
         num_kv_heads: usize,
         head_dim: usize,
     ) -> Result<Self> {
-        let dim = num_kv_heads * head_dim;
+        let dim = num_kv_heads.checked_mul(head_dim).ok_or_else(|| {
+            RuvLLMError::KvCache(format!(
+                "KV dimension overflow: num_kv_heads ({num_kv_heads}) * head_dim ({head_dim}) \
+                 exceeds usize"
+            ))
+        })?;
         if dim == 0 {
             return Err(RuvLLMError::KvCache("zero KV dimension".to_string()));
         }

--- a/crates/ruvllm/src/kv_migration/mod.rs
+++ b/crates/ruvllm/src/kv_migration/mod.rs
@@ -1,0 +1,217 @@
+//! Cross-Model KV-Cache Migration (PIR WP13, ADR-314)
+//!
+//! Implements the first shippable slice of cross-model KV-cache migration
+//! per arXiv:2608.03893, "Cross-Model KV Cache Transfer in LLM Families:
+//! A Closed-Form Linear Mapping for Prefill Reuse":
+//!
+//! - [`mapper::LinearKvMapper`]: a closed-form least-squares linear mapping
+//!   (per-layer `W_k`, `W_v`) fitted from paired calibration activations of
+//!   the source and target models, applied via matmul.
+//! - [`quality::TransferQualityGate`]: a transfer-quality gate that predicts
+//!   migration quality on a held-out validation set **before** any migration
+//!   happens. The paper found 2 of 6 tested model pairs degrade sharply under
+//!   the linear mapper, so we NEVER migrate blind — the gate can veto a
+//!   migration into a full re-prefill.
+//! - [`MlpKvMapper`]: a documented stub for the paper's nonlinear MLP
+//!   fallback (recovers up to +37pp HellaSwag on the degrading pairs).
+//!   The [`mapper::KvMapper`] trait already accommodates it; the
+//!   implementation is deliberately out of scope for this slice.
+//!
+//! Feature-gated behind `kv-migration` (default off) so it cannot affect
+//! existing builds.
+//!
+//! ## Data model
+//!
+//! A cache snapshot is a per-layer list of `[tokens, dim]` K/V matrices where
+//! `dim = num_kv_heads * head_dim`, i.e. the flattened per-token KV vector.
+//! This matches the flat layout produced by
+//! `TwoTierKvCache::get_all_kv()` (stride = `num_kv_heads * head_dim`);
+//! use [`LayerKvTensor::from_flat`] to adapt it.
+
+pub mod mapper;
+pub mod quality;
+
+#[cfg(test)]
+mod tests;
+
+pub use mapper::{CalibrationLayerPair, KvMapper, LinearKvMapper};
+pub use quality::{
+    GateDecision, LayerQuality, QualityGateConfig, QualityReport, TransferQualityGate,
+};
+
+use crate::error::{Result, RuvLLMError};
+use ndarray::Array2;
+
+/// A single layer's K/V tensors in `[tokens, dim]` layout, where
+/// `dim = num_kv_heads * head_dim` (the flattened per-token KV vector).
+#[derive(Debug, Clone)]
+pub struct LayerKvTensor {
+    /// Key matrix, shape `[tokens, dim]`.
+    pub keys: Array2<f32>,
+    /// Value matrix, shape `[tokens, dim]`.
+    pub values: Array2<f32>,
+}
+
+impl LayerKvTensor {
+    /// Create from key/value matrices, validating that shapes match.
+    pub fn new(keys: Array2<f32>, values: Array2<f32>) -> Result<Self> {
+        if keys.shape() != values.shape() {
+            return Err(RuvLLMError::KvCache(format!(
+                "key shape {:?} != value shape {:?}",
+                keys.shape(),
+                values.shape()
+            )));
+        }
+        Ok(Self { keys, values })
+    }
+
+    /// Build from the flat `(keys, values)` layout returned by
+    /// `TwoTierKvCache::get_all_kv()`, where each token occupies a
+    /// contiguous stride of `num_kv_heads * head_dim` floats.
+    pub fn from_flat(
+        keys: &[f32],
+        values: &[f32],
+        num_kv_heads: usize,
+        head_dim: usize,
+    ) -> Result<Self> {
+        let dim = num_kv_heads * head_dim;
+        if dim == 0 {
+            return Err(RuvLLMError::KvCache("zero KV dimension".to_string()));
+        }
+        if keys.len() != values.len() || keys.len() % dim != 0 {
+            return Err(RuvLLMError::KvCache(format!(
+                "flat KV length mismatch: keys={}, values={}, stride={}",
+                keys.len(),
+                values.len(),
+                dim
+            )));
+        }
+        let tokens = keys.len() / dim;
+        let keys = Array2::from_shape_vec((tokens, dim), keys.to_vec())
+            .map_err(|e| RuvLLMError::KvCache(e.to_string()))?;
+        let values = Array2::from_shape_vec((tokens, dim), values.to_vec())
+            .map_err(|e| RuvLLMError::KvCache(e.to_string()))?;
+        Self::new(keys, values)
+    }
+
+    /// Number of tokens in this layer tensor.
+    pub fn tokens(&self) -> usize {
+        self.keys.nrows()
+    }
+
+    /// Flattened per-token KV dimension (`num_kv_heads * head_dim`).
+    pub fn dim(&self) -> usize {
+        self.keys.ncols()
+    }
+}
+
+/// A full multi-layer KV-cache snapshot for one sequence.
+#[derive(Debug, Clone, Default)]
+pub struct KvCacheSnapshot {
+    /// Per-layer K/V tensors, ordered by layer index.
+    pub layers: Vec<LayerKvTensor>,
+}
+
+impl KvCacheSnapshot {
+    /// Create a snapshot from per-layer tensors.
+    pub fn new(layers: Vec<LayerKvTensor>) -> Self {
+        Self { layers }
+    }
+
+    /// Number of layers.
+    pub fn num_layers(&self) -> usize {
+        self.layers.len()
+    }
+}
+
+/// Outcome of a gated migration attempt.
+#[derive(Debug, Clone)]
+pub enum MigrationResult {
+    /// The gate approved: the cache was mapped to the target geometry.
+    Migrated {
+        /// The migrated cache in target-model geometry.
+        cache: KvCacheSnapshot,
+        /// The quality report that justified the migration.
+        report: QualityReport,
+    },
+    /// The gate vetoed: the caller must run a full re-prefill on the
+    /// target model instead of reusing the source cache.
+    Reprefill {
+        /// The quality report explaining the veto.
+        report: QualityReport,
+    },
+}
+
+/// Migrate a source-model KV cache into target-model geometry, gated by a
+/// predicted transfer-quality check — never migrate blind.
+///
+/// The gate assesses the fitted `mapper` against its held-out validation
+/// set first. Only if the gate's decision is [`GateDecision::Migrate`] is
+/// the source cache actually mapped; otherwise the caller gets
+/// [`MigrationResult::Reprefill`] and must prefill from scratch.
+pub fn migrate_kv_cache(
+    source_cache: &KvCacheSnapshot,
+    mapper: &dyn KvMapper,
+    gate: &TransferQualityGate,
+) -> Result<MigrationResult> {
+    if source_cache.num_layers() != mapper.num_layers() {
+        return Err(RuvLLMError::KvCache(format!(
+            "cache has {} layers but mapper was fitted for {}",
+            source_cache.num_layers(),
+            mapper.num_layers()
+        )));
+    }
+
+    let report = gate.assess(mapper)?;
+    if report.decision == GateDecision::Reprefill {
+        return Ok(MigrationResult::Reprefill { report });
+    }
+
+    let mut layers = Vec::with_capacity(source_cache.num_layers());
+    for (idx, layer) in source_cache.layers.iter().enumerate() {
+        let (keys, values) = mapper.map_layer(idx, &layer.keys, &layer.values)?;
+        layers.push(LayerKvTensor::new(keys, values)?);
+    }
+
+    Ok(MigrationResult::Migrated {
+        cache: KvCacheSnapshot::new(layers),
+        report,
+    })
+}
+
+/// Stub for the paper's nonlinear MLP fallback mapper (arXiv:2608.03893 §5).
+///
+/// The paper found that on the two model pairs where the closed-form linear
+/// mapper degrades sharply, a small per-layer MLP recovers up to +37pp
+/// HellaSwag accuracy. The [`KvMapper`] trait already accommodates this
+/// variant; this slice deliberately ships only the linear mapper, so every
+/// method of this type returns [`RuvLLMError::NotImplemented`]. Tracked as
+/// follow-up work under PIR WP13 / ADR-314.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MlpKvMapper;
+
+impl KvMapper for MlpKvMapper {
+    fn num_layers(&self) -> usize {
+        0
+    }
+
+    fn source_dim(&self) -> usize {
+        0
+    }
+
+    fn target_dim(&self) -> usize {
+        0
+    }
+
+    fn map_layer(
+        &self,
+        _layer: usize,
+        _keys: &Array2<f32>,
+        _values: &Array2<f32>,
+    ) -> Result<(Array2<f32>, Array2<f32>)> {
+        Err(RuvLLMError::NotImplemented(
+            "MlpKvMapper: nonlinear MLP fallback is a documented stub in this slice (ADR-314)"
+                .to_string(),
+        ))
+    }
+}

--- a/crates/ruvllm/src/kv_migration/quality.rs
+++ b/crates/ruvllm/src/kv_migration/quality.rs
@@ -1,0 +1,226 @@
+//! Transfer-quality gate: predict migration quality BEFORE migrating.
+//!
+//! arXiv:2608.03893 found that 2 of 6 tested model pairs degrade sharply
+//! under the closed-form linear mapper. This module implements the routing
+//! gate ADR-314 mandates: given a fitted mapper and a small held-out
+//! validation set of paired activations, compute a predicted-quality score
+//! (per-layer reconstruction cosine similarity and relative Frobenius
+//! error) and decide [`GateDecision::Migrate`] vs [`GateDecision::Reprefill`].
+//!
+//! The decision is deliberately conservative: it gates on the *worst* layer,
+//! not the mean, because a single badly-mapped layer is enough to corrupt
+//! downstream attention. A vetoed migration costs only the re-prefill we
+//! would have paid anyway; an approved bad migration silently degrades
+//! generation quality.
+
+use crate::error::{Result, RuvLLMError};
+use ndarray::Array2;
+
+use super::mapper::{CalibrationLayerPair, KvMapper};
+
+/// Gate decision: migrate the cache, or veto into a full re-prefill.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateDecision {
+    /// Predicted quality clears the thresholds — safe to migrate.
+    Migrate,
+    /// Predicted quality is below threshold — re-prefill on the target
+    /// model instead of reusing the mapped cache.
+    Reprefill,
+}
+
+/// Thresholds for the transfer-quality gate.
+///
+/// Defaults are conservative (see module docs): every layer's key AND value
+/// reconstruction must clear both thresholds or the gate vetoes.
+#[derive(Debug, Clone, Copy)]
+pub struct QualityGateConfig {
+    /// Minimum acceptable per-layer reconstruction cosine similarity
+    /// (worst layer, min of keys/values). Default: `0.92`.
+    pub min_cosine: f32,
+    /// Maximum acceptable per-layer relative Frobenius error
+    /// `‖pred − target‖_F / ‖target‖_F` (worst layer, max of keys/values).
+    /// Default: `0.25`.
+    pub max_relative_error: f32,
+}
+
+impl Default for QualityGateConfig {
+    fn default() -> Self {
+        Self {
+            min_cosine: 0.92,
+            max_relative_error: 0.25,
+        }
+    }
+}
+
+/// Reconstruction quality for one layer of the validation set.
+#[derive(Debug, Clone, Copy)]
+pub struct LayerQuality {
+    /// Layer index.
+    pub layer: usize,
+    /// Cosine similarity between mapped and true target keys.
+    pub key_cosine: f32,
+    /// Cosine similarity between mapped and true target values.
+    pub value_cosine: f32,
+    /// Relative Frobenius error for keys.
+    pub key_relative_error: f32,
+    /// Relative Frobenius error for values.
+    pub value_relative_error: f32,
+}
+
+impl LayerQuality {
+    /// Worst (lowest) cosine across keys and values.
+    pub fn worst_cosine(&self) -> f32 {
+        self.key_cosine.min(self.value_cosine)
+    }
+
+    /// Worst (highest) relative error across keys and values.
+    pub fn worst_relative_error(&self) -> f32 {
+        self.key_relative_error.max(self.value_relative_error)
+    }
+}
+
+/// Aggregated predicted-quality report produced by the gate.
+#[derive(Debug, Clone)]
+pub struct QualityReport {
+    /// Per-layer reconstruction quality.
+    pub layers: Vec<LayerQuality>,
+    /// Mean of per-layer worst cosines.
+    pub mean_cosine: f32,
+    /// Minimum per-layer worst cosine (the layer that decides the veto).
+    pub worst_cosine: f32,
+    /// Mean of per-layer worst relative errors.
+    pub mean_relative_error: f32,
+    /// Maximum per-layer worst relative error.
+    pub worst_relative_error: f32,
+    /// The gate's decision under its configured thresholds.
+    pub decision: GateDecision,
+}
+
+/// Transfer-quality gate: owns a held-out validation set of paired
+/// activations plus thresholds, and assesses a fitted mapper against them.
+///
+/// The validation set must be disjoint from the calibration set the mapper
+/// was fitted on, or the score is an overfit self-assessment.
+#[derive(Debug, Clone)]
+pub struct TransferQualityGate {
+    config: QualityGateConfig,
+    validation: Vec<CalibrationLayerPair>,
+}
+
+impl TransferQualityGate {
+    /// Create a gate from thresholds and a held-out validation set
+    /// (one [`CalibrationLayerPair`] per layer, in layer order).
+    pub fn new(config: QualityGateConfig, validation: Vec<CalibrationLayerPair>) -> Result<Self> {
+        if validation.is_empty() {
+            return Err(RuvLLMError::KvCache(
+                "TransferQualityGate requires a non-empty validation set".to_string(),
+            ));
+        }
+        Ok(Self { config, validation })
+    }
+
+    /// Create a gate with the conservative default thresholds.
+    pub fn with_defaults(validation: Vec<CalibrationLayerPair>) -> Result<Self> {
+        Self::new(QualityGateConfig::default(), validation)
+    }
+
+    /// The gate's threshold configuration.
+    pub fn config(&self) -> &QualityGateConfig {
+        &self.config
+    }
+
+    /// Assess a fitted mapper against the held-out validation set and
+    /// return the predicted-quality report with a migrate/re-prefill
+    /// decision.
+    pub fn assess(&self, mapper: &dyn KvMapper) -> Result<QualityReport> {
+        if mapper.num_layers() != self.validation.len() {
+            return Err(RuvLLMError::KvCache(format!(
+                "mapper has {} layers but validation set has {}",
+                mapper.num_layers(),
+                self.validation.len()
+            )));
+        }
+
+        let mut layers = Vec::with_capacity(self.validation.len());
+        for (idx, pair) in self.validation.iter().enumerate() {
+            let (pred_k, pred_v) = mapper.map_layer(idx, &pair.source.keys, &pair.source.values)?;
+            layers.push(LayerQuality {
+                layer: idx,
+                key_cosine: cosine_similarity(&pred_k, &pair.target.keys),
+                value_cosine: cosine_similarity(&pred_v, &pair.target.values),
+                key_relative_error: relative_error(&pred_k, &pair.target.keys),
+                value_relative_error: relative_error(&pred_v, &pair.target.values),
+            });
+        }
+
+        let n = layers.len() as f32;
+        let mean_cosine = layers.iter().map(LayerQuality::worst_cosine).sum::<f32>() / n;
+        let worst_cosine = layers
+            .iter()
+            .map(LayerQuality::worst_cosine)
+            .fold(f32::INFINITY, f32::min);
+        let mean_relative_error = layers
+            .iter()
+            .map(LayerQuality::worst_relative_error)
+            .sum::<f32>()
+            / n;
+        let worst_relative_error = layers
+            .iter()
+            .map(LayerQuality::worst_relative_error)
+            .fold(f32::NEG_INFINITY, f32::max);
+
+        // Conservative rule: every layer must clear both thresholds, and any
+        // non-finite score (NaN/Inf from degenerate inputs) is a veto.
+        let clean = worst_cosine.is_finite() && worst_relative_error.is_finite();
+        let decision = if clean
+            && worst_cosine >= self.config.min_cosine
+            && worst_relative_error <= self.config.max_relative_error
+        {
+            GateDecision::Migrate
+        } else {
+            GateDecision::Reprefill
+        };
+
+        Ok(QualityReport {
+            layers,
+            mean_cosine,
+            worst_cosine,
+            mean_relative_error,
+            worst_relative_error,
+            decision,
+        })
+    }
+}
+
+/// Flattened cosine similarity between two equally-shaped matrices.
+fn cosine_similarity(a: &Array2<f32>, b: &Array2<f32>) -> f32 {
+    debug_assert_eq!(a.shape(), b.shape());
+    let mut dot = 0.0f64;
+    let mut na = 0.0f64;
+    let mut nb = 0.0f64;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += (*x as f64) * (*y as f64);
+        na += (*x as f64) * (*x as f64);
+        nb += (*y as f64) * (*y as f64);
+    }
+    if na == 0.0 || nb == 0.0 {
+        return if na == nb { 1.0 } else { 0.0 };
+    }
+    (dot / (na.sqrt() * nb.sqrt())) as f32
+}
+
+/// Relative Frobenius error `‖a − b‖_F / ‖b‖_F`.
+fn relative_error(a: &Array2<f32>, b: &Array2<f32>) -> f32 {
+    debug_assert_eq!(a.shape(), b.shape());
+    let mut diff = 0.0f64;
+    let mut norm = 0.0f64;
+    for (x, y) in a.iter().zip(b.iter()) {
+        let d = (*x as f64) - (*y as f64);
+        diff += d * d;
+        norm += (*y as f64) * (*y as f64);
+    }
+    if norm == 0.0 {
+        return if diff == 0.0 { 0.0 } else { f32::INFINITY };
+    }
+    (diff.sqrt() / norm.sqrt()) as f32
+}

--- a/crates/ruvllm/src/kv_migration/quality.rs
+++ b/crates/ruvllm/src/kv_migration/quality.rs
@@ -18,6 +18,17 @@ use ndarray::Array2;
 
 use super::mapper::{CalibrationLayerPair, KvMapper};
 
+/// Squared-Frobenius-norm floor below which an activation matrix is treated
+/// as degenerate (all-zero or vanishingly small).
+///
+/// A degenerate operand carries no directional information, so a cosine or
+/// relative-error score computed from it is meaningless. Crucially, an
+/// all-zero validation pair must NEVER score as a perfect pass: since
+/// `pred = source · W` is zero whenever the source is zero, a zeroed
+/// validation set would otherwise approve *any* mapper unconditionally —
+/// defeating the gate's "never migrate blind" contract.
+const DEGENERATE_NORM_EPS: f64 = 1e-12;
+
 /// Gate decision: migrate the cache, or veto into a full re-prefill.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GateDecision {
@@ -110,11 +121,26 @@ pub struct TransferQualityGate {
 impl TransferQualityGate {
     /// Create a gate from thresholds and a held-out validation set
     /// (one [`CalibrationLayerPair`] per layer, in layer order).
+    ///
+    /// Rejects a validation set in which the majority of pairs (including
+    /// all of them) are degenerate — i.e. have near-zero-norm activations on
+    /// either side. Such a set cannot meaningfully assess a mapper, and an
+    /// all-zero set would otherwise approve any mapper unconditionally.
+    /// Individual degenerate pairs that slip past this check still score as
+    /// hard failures in [`Self::assess`], never as passes.
     pub fn new(config: QualityGateConfig, validation: Vec<CalibrationLayerPair>) -> Result<Self> {
         if validation.is_empty() {
             return Err(RuvLLMError::KvCache(
                 "TransferQualityGate requires a non-empty validation set".to_string(),
             ));
+        }
+        let degenerate = validation.iter().filter(|p| pair_is_degenerate(p)).count();
+        if degenerate * 2 > validation.len() {
+            return Err(RuvLLMError::KvCache(format!(
+                "validation set is degenerate: {degenerate} of {} pairs have \
+                 near-zero-norm activations and cannot assess a mapper",
+                validation.len()
+            )));
         }
         Ok(Self { config, validation })
     }
@@ -139,6 +165,26 @@ impl TransferQualityGate {
                 mapper.num_layers(),
                 self.validation.len()
             )));
+        }
+        // Real runtime dimension validation (NOT a debug_assert): the
+        // comparison helpers iterate `zip`, which silently truncates to the
+        // shorter operand in release builds — a mismatched validation set
+        // would be scored on a tiny prefix of the data. Reject it instead.
+        for (idx, pair) in self.validation.iter().enumerate() {
+            if pair.source.dim() != mapper.source_dim() {
+                return Err(RuvLLMError::KvCache(format!(
+                    "validation pair {idx}: source dim {} does not match mapper source dim {}",
+                    pair.source.dim(),
+                    mapper.source_dim()
+                )));
+            }
+            if pair.target.dim() != mapper.target_dim() {
+                return Err(RuvLLMError::KvCache(format!(
+                    "validation pair {idx}: target dim {} does not match mapper target dim {}",
+                    pair.target.dim(),
+                    mapper.target_dim()
+                )));
+            }
         }
 
         let mut layers = Vec::with_capacity(self.validation.len());
@@ -192,9 +238,28 @@ impl TransferQualityGate {
     }
 }
 
+/// Squared Frobenius norm of a matrix, accumulated in f64.
+fn squared_norm(m: &Array2<f32>) -> f64 {
+    m.iter().map(|v| (*v as f64) * (*v as f64)).sum()
+}
+
+/// True when any side of a validation pair has a near-zero-norm activation
+/// matrix, i.e. carries no signal a mapper could be assessed against.
+fn pair_is_degenerate(pair: &CalibrationLayerPair) -> bool {
+    squared_norm(&pair.source.keys) <= DEGENERATE_NORM_EPS
+        || squared_norm(&pair.source.values) <= DEGENERATE_NORM_EPS
+        || squared_norm(&pair.target.keys) <= DEGENERATE_NORM_EPS
+        || squared_norm(&pair.target.values) <= DEGENERATE_NORM_EPS
+}
+
 /// Flattened cosine similarity between two equally-shaped matrices.
+///
+/// A degenerate (near-zero-norm) operand on either side scores `-1.0` — the
+/// worst possible similarity — so a zeroed pair is a veto, never a pass.
+/// Shape equality is enforced by [`TransferQualityGate::assess`] before this
+/// is called; the assert is defense-in-depth against truncating `zip`.
 fn cosine_similarity(a: &Array2<f32>, b: &Array2<f32>) -> f32 {
-    debug_assert_eq!(a.shape(), b.shape());
+    assert_eq!(a.shape(), b.shape(), "cosine_similarity shape mismatch");
     let mut dot = 0.0f64;
     let mut na = 0.0f64;
     let mut nb = 0.0f64;
@@ -203,15 +268,20 @@ fn cosine_similarity(a: &Array2<f32>, b: &Array2<f32>) -> f32 {
         na += (*x as f64) * (*x as f64);
         nb += (*y as f64) * (*y as f64);
     }
-    if na == 0.0 || nb == 0.0 {
-        return if na == nb { 1.0 } else { 0.0 };
+    if na <= DEGENERATE_NORM_EPS || nb <= DEGENERATE_NORM_EPS {
+        return -1.0;
     }
     (dot / (na.sqrt() * nb.sqrt())) as f32
 }
 
 /// Relative Frobenius error `‖a − b‖_F / ‖b‖_F`.
+///
+/// A degenerate (near-zero-norm) target scores `f32::INFINITY` — even when
+/// the prediction is also zero — so a zeroed pair is a veto, never a pass.
+/// Shape equality is enforced by [`TransferQualityGate::assess`] before this
+/// is called; the assert is defense-in-depth against truncating `zip`.
 fn relative_error(a: &Array2<f32>, b: &Array2<f32>) -> f32 {
-    debug_assert_eq!(a.shape(), b.shape());
+    assert_eq!(a.shape(), b.shape(), "relative_error shape mismatch");
     let mut diff = 0.0f64;
     let mut norm = 0.0f64;
     for (x, y) in a.iter().zip(b.iter()) {
@@ -219,8 +289,8 @@ fn relative_error(a: &Array2<f32>, b: &Array2<f32>) -> f32 {
         diff += d * d;
         norm += (*y as f64) * (*y as f64);
     }
-    if norm == 0.0 {
-        return if diff == 0.0 { 0.0 } else { f32::INFINITY };
+    if norm <= DEGENERATE_NORM_EPS {
+        return f32::INFINITY;
     }
     (diff.sqrt() / norm.sqrt()) as f32
 }

--- a/crates/ruvllm/src/kv_migration/tests.rs
+++ b/crates/ruvllm/src/kv_migration/tests.rs
@@ -2,7 +2,10 @@
 
 use ndarray::Array2;
 
-use super::mapper::{CalibrationLayerPair, KvMapper, LinearKvMapper, DEFAULT_RIDGE_LAMBDA};
+use super::mapper::{
+    CalibrationLayerPair, KvMapper, LinearKvMapper, DEFAULT_RIDGE_LAMBDA, MAX_CALIBRATION_LAYERS,
+    MAX_CALIBRATION_TOKENS, MAX_FIT_DIM,
+};
 use super::quality::{GateDecision, QualityGateConfig, TransferQualityGate};
 use super::{migrate_kv_cache, KvCacheSnapshot, LayerKvTensor, MigrationResult, MlpKvMapper};
 
@@ -235,6 +238,138 @@ fn mlp_mapper_stub_returns_not_implemented() {
     let m = synthetic_matrix(2, 4, 3);
     let err = stub.map_layer(0, &m, &m).unwrap_err();
     assert!(err.to_string().contains("Not implemented"), "{err}");
+}
+
+/// All-zero calibration pair for degenerate-validation tests.
+fn zero_pair(tokens: usize, dim: usize) -> CalibrationLayerPair {
+    let zeros = || Array2::<f32>::zeros((tokens, dim));
+    CalibrationLayerPair::new(
+        LayerKvTensor::new(zeros(), zeros()).unwrap(),
+        LayerKvTensor::new(zeros(), zeros()).unwrap(),
+    )
+    .unwrap()
+}
+
+/// (security) An all-zero (or majority-degenerate) validation set must never
+/// be able to approve a mapper: gate construction rejects it outright, so
+/// the caller is forced down the re-prefill path.
+#[test]
+fn all_zero_validation_set_is_rejected_never_migrates() {
+    let (tokens, dim) = (16, 8);
+
+    // Entirely degenerate: rejected at construction.
+    let all_zero: Vec<CalibrationLayerPair> = (0..2).map(|_| zero_pair(tokens, dim)).collect();
+    let err = TransferQualityGate::with_defaults(all_zero).unwrap_err();
+    assert!(err.to_string().contains("degenerate"), "{err}");
+
+    // Majority degenerate (2 of 3): also rejected at construction.
+    let mut majority = vec![zero_pair(tokens, dim), zero_pair(tokens, dim)];
+    majority.push(identity_pairs(1, tokens, dim, 11).pop().unwrap());
+    let err = TransferQualityGate::with_defaults(majority).unwrap_err();
+    assert!(err.to_string().contains("degenerate"), "{err}");
+}
+
+/// (security) A minority of degenerate pairs slips past construction but
+/// scores as a hard failure — never as a perfect 1.0/0.0 pass — so the
+/// worst-layer rule vetoes into Reprefill.
+#[test]
+fn degenerate_pairs_in_mixed_validation_score_as_failures() {
+    let (layers, tokens, dim) = (3, 32, 8);
+    let calibration = identity_pairs(layers, tokens, dim, 42);
+    let mapper = LinearKvMapper::fit(&calibration, DEFAULT_RIDGE_LAMBDA).unwrap();
+
+    // 2 honest pairs + 1 all-zero pair (minority: construction succeeds).
+    let mut validation = identity_pairs(2, tokens, dim, 999);
+    validation.push(zero_pair(tokens, dim));
+    let gate = TransferQualityGate::with_defaults(validation).unwrap();
+
+    let report = gate.assess(&mapper).unwrap();
+    assert_eq!(report.decision, GateDecision::Reprefill);
+    let degen = &report.layers[2];
+    assert_eq!(degen.key_cosine, -1.0, "degenerate cosine must be a failure");
+    assert_eq!(degen.value_cosine, -1.0);
+    assert!(degen.key_relative_error.is_infinite());
+    assert!(degen.value_relative_error.is_infinite());
+    assert_eq!(report.worst_cosine, -1.0);
+}
+
+/// (security) Validation pairs whose dims do not match the mapper are
+/// rejected with an explicit error — a real runtime check, not a
+/// debug_assert that compiles out and lets `zip` truncate in release.
+#[test]
+fn dim_mismatched_validation_is_explicitly_rejected() {
+    let (layers, tokens, dim) = (2, 32, 8);
+    let calibration = identity_pairs(layers, tokens, dim, 5);
+    let mapper = LinearKvMapper::fit(&calibration, DEFAULT_RIDGE_LAMBDA).unwrap();
+
+    // Target dim 1 instead of the mapper's 8: must error, not silently
+    // score a truncated prefix.
+    let bad_target: Vec<CalibrationLayerPair> = (0..layers)
+        .map(|l| {
+            CalibrationLayerPair::new(
+                tensor(tokens, dim, 500 + l as u64),
+                tensor(tokens, 1, 600 + l as u64),
+            )
+            .unwrap()
+        })
+        .collect();
+    let gate = TransferQualityGate::with_defaults(bad_target).unwrap();
+    let err = gate.assess(&mapper).unwrap_err();
+    assert!(err.to_string().contains("target dim"), "{err}");
+
+    // Source dim 4 instead of 8: same explicit rejection.
+    let bad_source: Vec<CalibrationLayerPair> = (0..layers)
+        .map(|l| {
+            CalibrationLayerPair::new(
+                tensor(tokens, 4, 700 + l as u64),
+                tensor(tokens, dim, 800 + l as u64),
+            )
+            .unwrap()
+        })
+        .collect();
+    let gate = TransferQualityGate::with_defaults(bad_source).unwrap();
+    let err = gate.assess(&mapper).unwrap_err();
+    assert!(err.to_string().contains("source dim"), "{err}");
+}
+
+/// (security) `num_kv_heads * head_dim` overflow is rejected instead of
+/// wrapping to a small stride in release builds.
+#[test]
+fn from_flat_dimension_overflow_is_rejected() {
+    let flat = vec![0.0f32; 8];
+    let err =
+        LayerKvTensor::from_flat(&flat, &flat, (usize::MAX / 4) + 2, 4).unwrap_err();
+    assert!(err.to_string().contains("overflow"), "{err}");
+}
+
+/// (security) `fit()` bounds dimensions, layer count, and calibration
+/// length up front, before paying for any O(n³) solve or `[n, n]` alloc.
+#[test]
+fn fit_rejects_oversized_calibration_inputs() {
+    // Dimension above MAX_FIT_DIM.
+    let big_dim_pair = CalibrationLayerPair::new(
+        LayerKvTensor::new(
+            Array2::<f32>::zeros((1, MAX_FIT_DIM + 1)),
+            Array2::<f32>::zeros((1, MAX_FIT_DIM + 1)),
+        )
+        .unwrap(),
+        LayerKvTensor::new(Array2::<f32>::zeros((1, 4)), Array2::<f32>::zeros((1, 4))).unwrap(),
+    )
+    .unwrap();
+    let err = LinearKvMapper::fit(&[big_dim_pair], DEFAULT_RIDGE_LAMBDA).unwrap_err();
+    assert!(err.to_string().contains("MAX_FIT_DIM"), "{err}");
+
+    // Layer count above MAX_CALIBRATION_LAYERS.
+    let many_layers: Vec<CalibrationLayerPair> = (0..MAX_CALIBRATION_LAYERS + 1)
+        .map(|_| zero_pair(1, 1))
+        .collect();
+    let err = LinearKvMapper::fit(&many_layers, DEFAULT_RIDGE_LAMBDA).unwrap_err();
+    assert!(err.to_string().contains("MAX_CALIBRATION_LAYERS"), "{err}");
+
+    // Token count above MAX_CALIBRATION_TOKENS.
+    let long_pair = zero_pair(MAX_CALIBRATION_TOKENS + 1, 1);
+    let err = LinearKvMapper::fit(&[long_pair], DEFAULT_RIDGE_LAMBDA).unwrap_err();
+    assert!(err.to_string().contains("MAX_CALIBRATION_TOKENS"), "{err}");
 }
 
 /// Layer-count mismatch between cache and mapper is rejected up front.

--- a/crates/ruvllm/src/kv_migration/tests.rs
+++ b/crates/ruvllm/src/kv_migration/tests.rs
@@ -1,0 +1,250 @@
+//! Unit tests for KV-cache cross-model migration with synthetic geometry.
+
+use ndarray::Array2;
+
+use super::mapper::{CalibrationLayerPair, KvMapper, LinearKvMapper, DEFAULT_RIDGE_LAMBDA};
+use super::quality::{GateDecision, QualityGateConfig, TransferQualityGate};
+use super::{migrate_kv_cache, KvCacheSnapshot, LayerKvTensor, MigrationResult, MlpKvMapper};
+
+/// Deterministic pseudo-random matrix (xorshift), avoiding rand API churn.
+fn synthetic_matrix(rows: usize, cols: usize, seed: u64) -> Array2<f32> {
+    let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).max(1);
+    Array2::from_shape_fn((rows, cols), |_| {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        // Map to roughly [-1, 1).
+        ((state >> 11) as f64 / (1u64 << 53) as f64 * 2.0 - 1.0) as f32
+    })
+}
+
+fn tensor(rows: usize, cols: usize, seed: u64) -> LayerKvTensor {
+    LayerKvTensor::new(
+        synthetic_matrix(rows, cols, seed),
+        synthetic_matrix(rows, cols, seed.wrapping_add(1)),
+    )
+    .unwrap()
+}
+
+/// Identity-family pair: source and target activations are identical.
+fn identity_pairs(
+    layers: usize,
+    tokens: usize,
+    dim: usize,
+    seed: u64,
+) -> Vec<CalibrationLayerPair> {
+    (0..layers)
+        .map(|l| {
+            let t = tensor(tokens, dim, seed + l as u64 * 100);
+            CalibrationLayerPair::new(t.clone(), t).unwrap()
+        })
+        .collect()
+}
+
+/// Pair generated from a known ground-truth linear transform per layer.
+fn linear_transform_pairs(
+    layers: usize,
+    tokens: usize,
+    src_dim: usize,
+    tgt_dim: usize,
+    seed: u64,
+) -> (Vec<CalibrationLayerPair>, Vec<(Array2<f32>, Array2<f32>)>) {
+    let mut pairs = Vec::new();
+    let mut truths = Vec::new();
+    for l in 0..layers {
+        let s = l as u64 * 1000 + seed;
+        let w_k = synthetic_matrix(src_dim, tgt_dim, s + 7);
+        let w_v = synthetic_matrix(src_dim, tgt_dim, s + 8);
+        let source = tensor(tokens, src_dim, s);
+        let target = LayerKvTensor::new(source.keys.dot(&w_k), source.values.dot(&w_v)).unwrap();
+        pairs.push(CalibrationLayerPair::new(source, target).unwrap());
+        truths.push((w_k, w_v));
+    }
+    (pairs, truths)
+}
+
+/// (a) Identity-family mapping recovers the cache exactly (within fp tolerance).
+#[test]
+fn identity_family_mapping_recovers_cache_exactly() {
+    let (layers, tokens, dim) = (3, 64, 16);
+    let calibration = identity_pairs(layers, tokens, dim, 42);
+    let validation = identity_pairs(layers, tokens, dim, 999);
+
+    let mapper = LinearKvMapper::fit(&calibration, DEFAULT_RIDGE_LAMBDA).unwrap();
+    let gate = TransferQualityGate::with_defaults(validation).unwrap();
+
+    let source = KvCacheSnapshot::new(
+        (0..layers)
+            .map(|l| tensor(48, dim, 5000 + l as u64))
+            .collect(),
+    );
+    let result = migrate_kv_cache(&source, &mapper, &gate).unwrap();
+
+    match result {
+        MigrationResult::Migrated { cache, report } => {
+            assert_eq!(report.decision, GateDecision::Migrate);
+            assert!(
+                report.worst_cosine > 0.999,
+                "cosine {}",
+                report.worst_cosine
+            );
+            for (mapped, orig) in cache.layers.iter().zip(source.layers.iter()) {
+                for (m, o) in mapped.keys.iter().zip(orig.keys.iter()) {
+                    assert!((m - o).abs() < 1e-2, "key mismatch: {m} vs {o}");
+                }
+                for (m, o) in mapped.values.iter().zip(orig.values.iter()) {
+                    assert!((m - o).abs() < 1e-2, "value mismatch: {m} vs {o}");
+                }
+            }
+        }
+        MigrationResult::Reprefill { report } => {
+            panic!("identity mapping was vetoed: {report:?}")
+        }
+    }
+}
+
+/// (b) A known linear transform is recovered by fitting within tolerance.
+#[test]
+fn known_linear_transform_is_recovered_by_fit() {
+    let (layers, tokens, src_dim, tgt_dim) = (2, 128, 12, 12);
+    let (calibration, truths) = linear_transform_pairs(layers, tokens, src_dim, tgt_dim, 7);
+
+    let mapper = LinearKvMapper::fit(&calibration, 1e-6).unwrap();
+
+    // Held-out probe data mapped by the fitted W must match ground truth W.
+    for (l, (w_k, w_v)) in truths.iter().enumerate() {
+        let probe = tensor(32, src_dim, 8_000 + l as u64);
+        let (pred_k, pred_v) = mapper.map_layer(l, &probe.keys, &probe.values).unwrap();
+        let true_k = probe.keys.dot(w_k);
+        let true_v = probe.values.dot(w_v);
+        for (p, t) in pred_k.iter().zip(true_k.iter()) {
+            assert!((p - t).abs() < 1e-2, "layer {l} key: {p} vs {t}");
+        }
+        for (p, t) in pred_v.iter().zip(true_v.iter()) {
+            assert!((p - t).abs() < 1e-2, "layer {l} value: {p} vs {t}");
+        }
+    }
+}
+
+/// (c) The quality gate vetoes a deliberately-mismatched mapping.
+#[test]
+fn quality_gate_vetoes_mismatched_mapping() {
+    let (layers, tokens, dim) = (2, 64, 8);
+
+    // Mapper fitted on identity pairs...
+    let calibration = identity_pairs(layers, tokens, dim, 1);
+    let mapper = LinearKvMapper::fit(&calibration, DEFAULT_RIDGE_LAMBDA).unwrap();
+
+    // ...but validated against targets that are unrelated random tensors
+    // (a "degrading pair" in the paper's terms).
+    let mismatched: Vec<CalibrationLayerPair> = (0..layers)
+        .map(|l| {
+            CalibrationLayerPair::new(
+                tensor(tokens, dim, 300 + l as u64),
+                tensor(tokens, dim, 77_000 + l as u64),
+            )
+            .unwrap()
+        })
+        .collect();
+    let gate = TransferQualityGate::with_defaults(mismatched).unwrap();
+
+    let source = KvCacheSnapshot::new(
+        (0..layers)
+            .map(|l| tensor(16, dim, 40 + l as u64))
+            .collect(),
+    );
+    let result = migrate_kv_cache(&source, &mapper, &gate).unwrap();
+
+    match result {
+        MigrationResult::Reprefill { report } => {
+            assert_eq!(report.decision, GateDecision::Reprefill);
+            assert!(
+                report.worst_cosine < QualityGateConfig::default().min_cosine,
+                "worst cosine {} should be below threshold",
+                report.worst_cosine
+            );
+        }
+        MigrationResult::Migrated { report, .. } => {
+            panic!("mismatched mapping must be vetoed, got Migrate: {report:?}")
+        }
+    }
+}
+
+/// (d) Dimension-mismatch mapping produces correctly-shaped output.
+#[test]
+fn dimension_mismatch_mapping_produces_correct_shapes() {
+    // Source: 4 heads x 8 dim = 32; target: 2 heads x 12 dim = 24.
+    let (layers, tokens, src_dim, tgt_dim) = (2, 96, 32, 24);
+    let (calibration, _) = linear_transform_pairs(layers, tokens, src_dim, tgt_dim, 21);
+    let (validation, _) = linear_transform_pairs(layers, 48, src_dim, tgt_dim, 21);
+
+    let mapper = LinearKvMapper::fit(&calibration, 1e-6).unwrap();
+    assert_eq!(mapper.source_dim(), src_dim);
+    assert_eq!(mapper.target_dim(), tgt_dim);
+
+    let gate = TransferQualityGate::with_defaults(validation).unwrap();
+    let source = KvCacheSnapshot::new(
+        (0..layers)
+            .map(|l| tensor(10, src_dim, 60 + l as u64))
+            .collect(),
+    );
+    let result = migrate_kv_cache(&source, &mapper, &gate).unwrap();
+
+    match result {
+        MigrationResult::Migrated { cache, .. } => {
+            assert_eq!(cache.num_layers(), layers);
+            for layer in &cache.layers {
+                assert_eq!(layer.tokens(), 10);
+                assert_eq!(layer.dim(), tgt_dim);
+            }
+        }
+        MigrationResult::Reprefill { report } => {
+            panic!("consistent dim-mismatch transform should migrate: {report:?}")
+        }
+    }
+}
+
+/// from_flat adapts the TwoTierKvCache::get_all_kv flat layout.
+#[test]
+fn from_flat_roundtrip_matches_stride_layout() {
+    let (num_kv_heads, head_dim, tokens) = (2, 4, 3);
+    let stride = num_kv_heads * head_dim;
+    let keys: Vec<f32> = (0..tokens * stride).map(|i| i as f32).collect();
+    let values: Vec<f32> = (0..tokens * stride).map(|i| (i as f32) * 0.5).collect();
+
+    let t = LayerKvTensor::from_flat(&keys, &values, num_kv_heads, head_dim).unwrap();
+    assert_eq!(t.tokens(), tokens);
+    assert_eq!(t.dim(), stride);
+    assert_eq!(t.keys[[1, 0]], stride as f32);
+    assert_eq!(t.values[[2, 7]], (2 * stride + 7) as f32 * 0.5);
+
+    // Length not divisible by stride must be rejected.
+    assert!(LayerKvTensor::from_flat(
+        &keys[..stride + 1],
+        &values[..stride + 1],
+        num_kv_heads,
+        head_dim
+    )
+    .is_err());
+}
+
+/// The MLP fallback is a documented stub in this slice.
+#[test]
+fn mlp_mapper_stub_returns_not_implemented() {
+    let stub = MlpKvMapper;
+    let m = synthetic_matrix(2, 4, 3);
+    let err = stub.map_layer(0, &m, &m).unwrap_err();
+    assert!(err.to_string().contains("Not implemented"), "{err}");
+}
+
+/// Layer-count mismatch between cache and mapper is rejected up front.
+#[test]
+fn layer_count_mismatch_is_rejected() {
+    let calibration = identity_pairs(2, 32, 8, 5);
+    let validation = identity_pairs(2, 32, 8, 6);
+    let mapper = LinearKvMapper::fit(&calibration, DEFAULT_RIDGE_LAMBDA).unwrap();
+    let gate = TransferQualityGate::with_defaults(validation).unwrap();
+
+    let source = KvCacheSnapshot::new(vec![tensor(4, 8, 9)]); // 1 layer vs 2
+    assert!(migrate_kv_cache(&source, &mapper, &gate).is_err());
+}

--- a/crates/ruvllm/src/lib.rs
+++ b/crates/ruvllm/src/lib.rs
@@ -130,6 +130,8 @@ pub mod hub;
 pub mod intelligence;
 pub mod kernels;
 pub mod kv_cache;
+#[cfg(feature = "kv-migration")]
+pub mod kv_migration;
 pub mod lora;
 pub mod memory_pool;
 #[cfg(all(target_os = "macos", feature = "metal-compute"))]


### PR DESCRIPTION
## Summary

First shippable slice of cross-model KV-cache migration in `crates/ruvllm`, implementing [arXiv:2608.03893](https://arxiv.org/abs/2608.03893) — "Cross-Model KV Cache Transfer in LLM Families: A Closed-Form Linear Mapping for Prefill Reuse" — per **ADR-314** (branch `feat/pir-adrs`) and the PIR program plan's WP13 fast-follow track.

Tracking issue: #844 (child of PIR epic #837).

## What's in this slice

New module `crates/ruvllm/src/kv_migration/`, feature-gated behind `kv-migration` (**default off** — zero impact on existing builds):

| File | Contents |
|---|---|
| `mapper.rs` | `KvMapper` trait + `LinearKvMapper`: closed-form ridge least-squares fit `W = (XᵀX + λI)⁻¹XᵀY` of per-layer `W_k`/`W_v` from paired calibration activations; applied via matmul. Gaussian elimination with partial pivoting — no new dependencies (uses the crate's existing `ndarray`). |
| `quality.rs` | `TransferQualityGate`: per-layer reconstruction cosine similarity + relative Frobenius error on a **held-out** validation set, aggregated with conservative worst-layer thresholds (default min cosine 0.92, max rel. error 0.25), producing `Migrate \| Reprefill`. |
| `mod.rs` | Public API `migrate_kv_cache(source_cache, mapper, gate) -> MigrationResult` where the gate can veto into `Reprefill` — **never migrate blind** (the paper found 2 of 6 model pairs degrade sharply). `MlpKvMapper` is a documented stub for the paper's nonlinear fallback (out of scope here; the trait already accommodates it). `LayerKvTensor::from_flat` adapts `TwoTierKvCache::get_all_kv()`'s flat stride layout. |
| `tests.rs` | Synthetic-geometry unit tests (see below). |

### Key design decisions

- **Head-count / head-dim mismatch**: handled by learning the projection over the *flattened* per-token KV vector (`W` is `[src_heads·src_head_dim, tgt_heads·tgt_head_dim]`), which subsumes the paper's block projection when head grids align. Assumptions (position-aligned calibration pairs, compatible RoPE conventions, 1:1 layer correspondence) are documented in `mapper.rs`.
- **Conservative gate**: decision is on the *worst* layer, not the mean — one badly-mapped layer corrupts downstream attention; a false veto only costs the re-prefill we'd have paid anyway. Non-finite scores are an automatic veto.
- **Ridge regularization** (default λ=1e-4) keeps the normal equations solvable when calibration tokens barely cover the source dimension.

## Test results

`cargo test -p ruvllm --features kv-migration kv_migration`:

```
running 7 tests
test kv_migration::tests::mlp_mapper_stub_returns_not_implemented ... ok
test kv_migration::tests::layer_count_mismatch_is_rejected ... ok
test kv_migration::tests::quality_gate_vetoes_mismatched_mapping ... ok
test kv_migration::tests::from_flat_roundtrip_matches_stride_layout ... ok
test kv_migration::tests::known_linear_transform_is_recovered_by_fit ... ok
test kv_migration::tests::identity_family_mapping_recovers_cache_exactly ... ok
test kv_migration::tests::dimension_mismatch_mapping_produces_correct_shapes ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1588 filtered out
```

`cargo check -p ruvllm` (without the feature) passes — no default-build impact.

## Out of scope (follow-ups under WP13 / ADR-314)

- `MlpKvMapper` implementation (nonlinear fallback for the degrading pairs, +37pp HellaSwag in the paper)
- Wiring into `serving/kv_cache_manager.rs` / `paged_attention.rs` serving paths
- Reproducing the paper's 2.7–25× re-prefill speedup on real same-family model pairs (ADR-314 acceptance bar)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)