### PR TITLE
fix(ruvector): make @metaharness packages optional per ADR-150 invariant; align sota-bench harness pins (PIR WP0a)

### DIFF
--- a/crates/ruvector-sota-bench/harness/package-lock.json
+++ b/crates/ruvector-sota-bench/harness/package-lock.json
@@ -8,15 +8,15 @@
       "name": "@ruvector/sota-metaharness",
       "version": "0.1.0",
       "dependencies": {
-        "@metaharness/darwin": "0.8.0",
-        "@metaharness/flywheel": "0.1.7",
-        "@metaharness/harness": "0.1.0",
-        "@metaharness/redblue": "0.1.4",
-        "@metaharness/router": "0.3.2",
-        "@metaharness/weight-eft": "0.1.1",
-        "@metaharness/workspace-lens": "0.1.1",
-        "@metaharness/workspace-probe": "0.1.1",
-        "metaharness": "0.4.2"
+        "@metaharness/darwin": "^0.9.1",
+        "@metaharness/flywheel": "^0.1.10",
+        "@metaharness/harness": "^0.2.0",
+        "@metaharness/redblue": "^0.1.6",
+        "@metaharness/router": "^0.4.0",
+        "@metaharness/weight-eft": "^0.1.1",
+        "@metaharness/workspace-lens": "^0.1.2",
+        "@metaharness/workspace-probe": "^0.1.1",
+        "metaharness": "^0.4.7"
       },
       "bin": {
         "ruvector-metaharness": "dist/src/cli.js"
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@metaharness/darwin": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@metaharness/darwin/-/darwin-0.8.0.tgz",
-      "integrity": "sha512-Pgefr/es0Btofh7GxQrOAg/i43ZKcLUfeD9rndOAkpA8s3ZYohSmfLerJLNsGOOKc2eTvmmauljl8QEVmKC2dw==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@metaharness/darwin/-/darwin-0.9.2.tgz",
+      "integrity": "sha512-UaAikvfaowvXO97ivNubXRdXEDbvBl28XCDbyTv979vbzPiOoHWdPpS3XPHq/D9VG+wCtK9BpS3PXm340EkYSQ==",
       "license": "MIT",
       "bin": {
         "metaharness-darwin": "dist/cli.js"
@@ -42,24 +42,24 @@
       }
     },
     "node_modules/@metaharness/flywheel": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@metaharness/flywheel/-/flywheel-0.1.7.tgz",
-      "integrity": "sha512-am7dROkjyS1Zkms3TOcn2LVHjwMLQXPJ6Pu1aP55q40vWJLRONGdGvnrcBL/VhMFqjQrVB57lmSn2E+s5CSZwA==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@metaharness/flywheel/-/flywheel-0.1.10.tgz",
+      "integrity": "sha512-yrLXDXNdf4jKqHlW6QZw3Cy5T0eMMjjaPqn1XB717/Xx/y0Iv9R03W0OhMEiR/kfqMNebRBW1fi6D7inStEyqA==",
       "license": "MIT"
     },
     "node_modules/@metaharness/harness": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@metaharness/harness/-/harness-0.1.0.tgz",
-      "integrity": "sha512-KegYx/q8qXlnaSYP0l5hgNPn8iNMl6a2eONqPi68FXd1w1jt7NswJJlt2/Ftl3Sum8qAEchxH1ZJOYFWTvJxTA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/harness/-/harness-0.2.0.tgz",
+      "integrity": "sha512-j/NLHqgPNre4qTTExvjCjh4/HgmhnVZPSQUfj06dyrlkpXCMFJ2abdPrl5yuFfzBMU0wnfFnFY2qQHQnBlAreg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@metaharness/redblue": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@metaharness/redblue/-/redblue-0.1.4.tgz",
-      "integrity": "sha512-JaAk6bs3xA7Ks5RnAcZoxI3WfzpYL+Bk262SCI07w82BDOA7C6VxwGM63F7b86lRTKUVjTEnSqf7QZ3uyElT/g==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@metaharness/redblue/-/redblue-0.1.6.tgz",
+      "integrity": "sha512-cnQTOcPVetgz/XoYBdW5carkl48wBJsvBbJ7ntmelFtRu/8N5ARhSXnebEY+05SWaNm8lqij/gxZx2FqNCQWJg==",
       "license": "MIT",
       "bin": {
         "metaharness-redblue": "dist/cli/index.js",
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/@metaharness/router": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@metaharness/router/-/router-0.3.2.tgz",
-      "integrity": "sha512-LQElU6mUrWd3ffJ5bwoonEIgw7oFQZpwZaehffyl/Pg+iozpRjIBPEXdb4uTOBnKH+yPiTEWKc+h9AiZr9Os9w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/router/-/router-0.4.0.tgz",
+      "integrity": "sha512-VOfjHM7AMWwDH41AAMHOHFbH1r898xJqhqyE3G/r8OAxxrMgujX2SZsYkj/eXfBEmoPMhDVRkuO2abxvzCgEUA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -84,6 +84,15 @@
         "@ruvector/tiny-dancer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@metaharness/turn-credit": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/turn-credit/-/turn-credit-0.1.0.tgz",
+      "integrity": "sha512-A752c0eEYEVodBB8HLOaSvcUMA65TX6/Cru2apZ7EE7aL2FSO74GFbgFWPo85bgqgNuMjhHkl/kG+lkC0TunNA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@metaharness/weight-eft": {
@@ -99,9 +108,9 @@
       }
     },
     "node_modules/@metaharness/workspace-lens": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@metaharness/workspace-lens/-/workspace-lens-0.1.1.tgz",
-      "integrity": "sha512-BkEdTvjD2PEhkGTCmtTIPnoeaOsxvzFtsFEAurwVKlVOu4hQetHeXDfiyAYheWg8Cp4fcGcr7E5MO1ptQveQ2g==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@metaharness/workspace-lens/-/workspace-lens-0.1.2.tgz",
+      "integrity": "sha512-Bfkj40rGZeBch4sQH/ma6zlY6dI+2AQfpTS/6AmPUE6/54H8Y04aBH5HPYfL0yBZ0lD/CeLViwFphT0PaiJ1mQ==",
       "license": "MIT"
     },
     "node_modules/@metaharness/workspace-probe": {
@@ -505,14 +514,15 @@
       }
     },
     "node_modules/metaharness": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/metaharness/-/metaharness-0.4.2.tgz",
-      "integrity": "sha512-h94B47zBEuNEfKLFMZMV/fRnXBrkwV6L8kMukgioB/9621k6Lm6s2lR2gBKl3BAT1sfN/DYqhsqAJc+6H5PTGQ==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/metaharness/-/metaharness-0.4.7.tgz",
+      "integrity": "sha512-oRbzFPry3bu2gC6+QoLsTbZmzAeNKjjl0gDhxO5p4++azuop9HKWUmw3Urb+uPfCX1IhVsVvjABGQ1VIB3Fbkg==",
       "license": "MIT",
       "dependencies": {
-        "@metaharness/darwin": "^0.2.2",
+        "@metaharness/darwin": "^0.9.1",
         "@metaharness/flywheel": "^0.1.1",
-        "@metaharness/redblue": "^0.1.1",
+        "@metaharness/redblue": "^0.1.6",
+        "@metaharness/turn-credit": "^0.1.0",
         "@metaharness/weight-eft": "^0.1.0",
         "kolorist": "^1.8.0",
         "prompts": "^2.4.2"
@@ -534,18 +544,6 @@
         "@metaharness/kernel": {
           "optional": true
         }
-      }
-    },
-    "node_modules/metaharness/node_modules/@metaharness/darwin": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@metaharness/darwin/-/darwin-0.2.8.tgz",
-      "integrity": "sha512-B8tF7IrrSxwKS6fEPEL6N2Juth9WWn+hppLUtUYPTJ2vcHzzZPIg2cS5T9qTyNNuANlTSWnQHnvzlfvYdGNfeQ==",
-      "license": "MIT",
-      "bin": {
-        "metaharness-darwin": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/mimic-fn": {

--- a/crates/ruvector-sota-bench/harness/package.json
+++ b/crates/ruvector-sota-bench/harness/package.json
@@ -16,15 +16,15 @@
     "doctor": "npm run build && node dist/src/cli.js doctor"
   },
   "dependencies": {
-    "@metaharness/darwin": "0.8.0",
-    "@metaharness/flywheel": "0.1.7",
-    "@metaharness/harness": "0.1.0",
-    "@metaharness/redblue": "0.1.4",
-    "@metaharness/router": "0.3.2",
-    "@metaharness/weight-eft": "0.1.1",
-    "@metaharness/workspace-lens": "0.1.1",
-    "@metaharness/workspace-probe": "0.1.1",
-    "metaharness": "0.4.2"
+    "@metaharness/darwin": "^0.9.1",
+    "@metaharness/flywheel": "^0.1.10",
+    "@metaharness/harness": "^0.2.0",
+    "@metaharness/redblue": "^0.1.6",
+    "@metaharness/router": "^0.4.0",
+    "@metaharness/weight-eft": "^0.1.1",
+    "@metaharness/workspace-lens": "^0.1.2",
+    "@metaharness/workspace-probe": "^0.1.1",
+    "metaharness": "^0.4.7"
   },
   "devDependencies": {
     "@types/node": "22.15.30",

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -2085,61 +2085,14 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@metaharness/darwin": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@metaharness/darwin/-/darwin-0.8.0.tgz",
-      "integrity": "sha512-Pgefr/es0Btofh7GxQrOAg/i43ZKcLUfeD9rndOAkpA8s3ZYohSmfLerJLNsGOOKc2eTvmmauljl8QEVmKC2dw==",
-      "license": "MIT",
-      "bin": {
-        "metaharness-darwin": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@metaharness/flywheel": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@metaharness/flywheel/-/flywheel-0.1.7.tgz",
-      "integrity": "sha512-am7dROkjyS1Zkms3TOcn2LVHjwMLQXPJ6Pu1aP55q40vWJLRONGdGvnrcBL/VhMFqjQrVB57lmSn2E+s5CSZwA==",
-      "license": "MIT"
-    },
-    "node_modules/@metaharness/harness": {
+    "node_modules/@metaharness/turn-credit": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@metaharness/harness/-/harness-0.1.0.tgz",
-      "integrity": "sha512-KegYx/q8qXlnaSYP0l5hgNPn8iNMl6a2eONqPi68FXd1w1jt7NswJJlt2/Ftl3Sum8qAEchxH1ZJOYFWTvJxTA==",
+      "resolved": "https://registry.npmjs.org/@metaharness/turn-credit/-/turn-credit-0.1.0.tgz",
+      "integrity": "sha512-A752c0eEYEVodBB8HLOaSvcUMA65TX6/Cru2apZ7EE7aL2FSO74GFbgFWPo85bgqgNuMjhHkl/kG+lkC0TunNA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@metaharness/redblue": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@metaharness/redblue/-/redblue-0.1.4.tgz",
-      "integrity": "sha512-JaAk6bs3xA7Ks5RnAcZoxI3WfzpYL+Bk262SCI07w82BDOA7C6VxwGM63F7b86lRTKUVjTEnSqf7QZ3uyElT/g==",
-      "license": "MIT",
-      "bin": {
-        "metaharness-redblue": "dist/cli/index.js",
-        "redblue": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@metaharness/router": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@metaharness/router/-/router-0.3.2.tgz",
-      "integrity": "sha512-LQElU6mUrWd3ffJ5bwoonEIgw7oFQZpwZaehffyl/Pg+iozpRjIBPEXdb4uTOBnKH+yPiTEWKc+h9AiZr9Os9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@ruvector/tiny-dancer": "^0.1.21"
-      },
-      "peerDependenciesMeta": {
-        "@ruvector/tiny-dancer": {
-          "optional": true
-        }
       }
     },
     "node_modules/@metaharness/weight-eft": {
@@ -2147,6 +2100,7 @@
       "resolved": "https://registry.npmjs.org/@metaharness/weight-eft/-/weight-eft-0.1.1.tgz",
       "integrity": "sha512-GSg0APPAbRK93OzrzlE+R8hfEK+I5+Zhmh0Z28RC9Mk5/MjhPo3shqINO7ye8VPGYHIO4rars9FwCWbe/V4cEQ==",
       "license": "MIT",
+      "optional": true,
       "bin": {
         "weight-eft": "dist/cli.js"
       },
@@ -2158,13 +2112,15 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@metaharness/workspace-lens/-/workspace-lens-0.1.1.tgz",
       "integrity": "sha512-BkEdTvjD2PEhkGTCmtTIPnoeaOsxvzFtsFEAurwVKlVOu4hQetHeXDfiyAYheWg8Cp4fcGcr7E5MO1ptQveQ2g==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@metaharness/workspace-probe": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@metaharness/workspace-probe/-/workspace-probe-0.1.1.tgz",
       "integrity": "sha512-kHL7T16476a5obVunbZ2NYqK7YY/1qtZTaQC1KyXmFh/7dRNselqGAilawspuD86F9U1H/LMCDvchDj3Vh5duw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@metaharness/workspace-lens": "^0.1.0"
       },
@@ -3801,10 +3757,6 @@
       "resolved": "packages/spiking-neural",
       "link": true
     },
-    "node_modules/@ruvector/tiny-dancer": {
-      "resolved": "packages/tiny-dancer",
-      "link": true
-    },
     "node_modules/@ruvector/tiny-dancer-darwin-arm64": {
       "resolved": "packages/tiny-dancer-darwin-arm64",
       "link": true
@@ -3817,57 +3769,9 @@
       "resolved": "packages/tiny-dancer-linux-arm64-gnu",
       "link": true
     },
-    "node_modules/@ruvector/tiny-dancer-linux-arm64-musl": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@ruvector/tiny-dancer-linux-arm64-musl/-/tiny-dancer-linux-arm64-musl-0.1.22.tgz",
-      "integrity": "sha512-zqgcpms7l8MILxhkd65BfV4BlTTnqRaxRp56P9Qo9SYF/OV6LTUcUIO3d8BA+rrCvltCoEnU7+x+mCSfm2XEmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/@ruvector/tiny-dancer-linux-x64-gnu": {
       "resolved": "packages/tiny-dancer-linux-x64-gnu",
       "link": true
-    },
-    "node_modules/@ruvector/tiny-dancer-linux-x64-musl": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@ruvector/tiny-dancer-linux-x64-musl/-/tiny-dancer-linux-x64-musl-0.1.22.tgz",
-      "integrity": "sha512-aPSL6dLv7dlq/sAWd2pE9jPu2QNPLz1RQH+btnCf6r0nSC5K5SoMSmiwnIGrVR0DTkXtHgBOTZvf5ne1O+gctA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@ruvector/tiny-dancer-win32-arm64-msvc": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@ruvector/tiny-dancer-win32-arm64-msvc/-/tiny-dancer-win32-arm64-msvc-0.1.22.tgz",
-      "integrity": "sha512-fWOAlEQ/sF0Fs5vFjeMF5ktcOH4GPFwIJRNrdEbqv+jYnCHHHxNNoBY4UAwnfX8UqqyITSp+qnxcGw9+GeNXCw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
     },
     "node_modules/@ruvector/tiny-dancer-win32-x64-msvc": {
       "resolved": "packages/tiny-dancer-win32-x64-msvc",
@@ -10871,6 +10775,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10880,7 +10785,8 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
       "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/kuler": {
       "version": "2.0.0",
@@ -12984,6 +12890,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^3.0.3",
@@ -13990,6 +13897,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/slash": {
@@ -15515,6 +15423,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15532,6 +15441,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15549,6 +15459,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15566,6 +15477,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15583,6 +15495,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15600,6 +15513,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15617,6 +15531,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15634,6 +15549,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15651,6 +15567,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15668,6 +15585,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15685,6 +15603,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15702,6 +15621,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15719,6 +15639,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15736,6 +15657,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15753,6 +15675,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15770,6 +15693,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15787,6 +15711,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15804,6 +15729,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15821,6 +15747,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15838,6 +15765,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15855,6 +15783,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15872,6 +15801,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15889,6 +15819,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15906,6 +15837,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15923,6 +15855,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15940,6 +15873,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18146,9 +18080,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "os": [
         "linux"
@@ -18162,9 +18093,6 @@
       "version": "0.1.30",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "os": [
@@ -18462,14 +18390,6 @@
       "version": "0.2.41",
       "license": "MIT",
       "dependencies": {
-        "@metaharness/darwin": "0.8.0",
-        "@metaharness/flywheel": "0.1.7",
-        "@metaharness/harness": "0.1.0",
-        "@metaharness/redblue": "0.1.4",
-        "@metaharness/router": "0.3.2",
-        "@metaharness/weight-eft": "0.1.1",
-        "@metaharness/workspace-lens": "0.1.1",
-        "@metaharness/workspace-probe": "0.1.1",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@ruvector/attention": "^0.1.3",
         "@ruvector/core": "^0.1.25",
@@ -18477,7 +18397,6 @@
         "@ruvector/sona": "^0.1.4",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
-        "metaharness": "0.4.2",
         "ora": "^5.4.1"
       },
       "bin": {
@@ -18491,16 +18410,58 @@
         "node": ">=20.0.0"
       },
       "optionalDependencies": {
+        "@metaharness/darwin": "^0.9.1",
+        "@metaharness/flywheel": "^0.1.10",
+        "@metaharness/harness": "^0.2.0",
+        "@metaharness/redblue": "^0.1.6",
+        "@metaharness/router": "^0.4.0",
+        "@metaharness/weight-eft": "^0.1.1",
+        "@metaharness/workspace-lens": "^0.1.2",
+        "@metaharness/workspace-probe": "^0.1.1",
         "@ruvector/rvf": "^0.1.0",
-        "@ruvector/tiny-dancer": "^0.1.22"
+        "@ruvector/tiny-dancer": "^0.1.22",
+        "metaharness": "^0.4.7"
       },
       "peerDependencies": {
+        "@metaharness/darwin": ">=0.9.1",
+        "@metaharness/flywheel": ">=0.1.10",
+        "@metaharness/harness": ">=0.2.0",
+        "@metaharness/redblue": ">=0.1.6",
+        "@metaharness/router": ">=0.4.0",
+        "@metaharness/weight-eft": ">=0.1.1",
+        "@metaharness/workspace-lens": ">=0.1.2",
+        "@metaharness/workspace-probe": ">=0.1.1",
         "@ruvector/diskann": ">=0.1.0",
         "@ruvector/pi-brain": ">=0.1.0",
         "@ruvector/router": ">=0.1.0",
-        "@ruvector/ruvllm": ">=2.0.0"
+        "@ruvector/ruvllm": ">=2.0.0",
+        "metaharness": ">=0.4.7"
       },
       "peerDependenciesMeta": {
+        "@metaharness/darwin": {
+          "optional": true
+        },
+        "@metaharness/flywheel": {
+          "optional": true
+        },
+        "@metaharness/harness": {
+          "optional": true
+        },
+        "@metaharness/redblue": {
+          "optional": true
+        },
+        "@metaharness/router": {
+          "optional": true
+        },
+        "@metaharness/weight-eft": {
+          "optional": true
+        },
+        "@metaharness/workspace-lens": {
+          "optional": true
+        },
+        "@metaharness/workspace-probe": {
+          "optional": true
+        },
         "@ruvector/diskann": {
           "optional": true
         },
@@ -18511,6 +18472,9 @@
           "optional": true
         },
         "@ruvector/ruvllm": {
+          "optional": true
+        },
+        "metaharness": {
           "optional": true
         }
       }
@@ -18634,6 +18598,75 @@
         "typescript": ">=5.0.0"
       }
     },
+    "packages/ruvector/node_modules/@metaharness/darwin": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@metaharness/darwin/-/darwin-0.9.2.tgz",
+      "integrity": "sha512-UaAikvfaowvXO97ivNubXRdXEDbvBl28XCDbyTv979vbzPiOoHWdPpS3XPHq/D9VG+wCtK9BpS3PXm340EkYSQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "metaharness-darwin": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/ruvector/node_modules/@metaharness/flywheel": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@metaharness/flywheel/-/flywheel-0.1.10.tgz",
+      "integrity": "sha512-yrLXDXNdf4jKqHlW6QZw3Cy5T0eMMjjaPqn1XB717/Xx/y0Iv9R03W0OhMEiR/kfqMNebRBW1fi6D7inStEyqA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "packages/ruvector/node_modules/@metaharness/harness": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/harness/-/harness-0.2.0.tgz",
+      "integrity": "sha512-j/NLHqgPNre4qTTExvjCjh4/HgmhnVZPSQUfj06dyrlkpXCMFJ2abdPrl5yuFfzBMU0wnfFnFY2qQHQnBlAreg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/ruvector/node_modules/@metaharness/redblue": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@metaharness/redblue/-/redblue-0.1.6.tgz",
+      "integrity": "sha512-cnQTOcPVetgz/XoYBdW5carkl48wBJsvBbJ7ntmelFtRu/8N5ARhSXnebEY+05SWaNm8lqij/gxZx2FqNCQWJg==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "metaharness-redblue": "dist/cli/index.js",
+        "redblue": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/ruvector/node_modules/@metaharness/router": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/router/-/router-0.4.0.tgz",
+      "integrity": "sha512-VOfjHM7AMWwDH41AAMHOHFbH1r898xJqhqyE3G/r8OAxxrMgujX2SZsYkj/eXfBEmoPMhDVRkuO2abxvzCgEUA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@ruvector/tiny-dancer": "^0.1.21"
+      },
+      "peerDependenciesMeta": {
+        "@ruvector/tiny-dancer": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ruvector/node_modules/@metaharness/workspace-lens": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@metaharness/workspace-lens/-/workspace-lens-0.1.2.tgz",
+      "integrity": "sha512-Bfkj40rGZeBch4sQH/ma6zlY6dI+2AQfpTS/6AmPUE6/54H8Y04aBH5HPYfL0yBZ0lD/CeLViwFphT0PaiJ1mQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "packages/ruvector/node_modules/@ruvector/rvf": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/@ruvector/rvf/-/rvf-0.1.9.tgz",
@@ -18649,14 +18682,16 @@
       }
     },
     "packages/ruvector/node_modules/metaharness": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/metaharness/-/metaharness-0.4.2.tgz",
-      "integrity": "sha512-h94B47zBEuNEfKLFMZMV/fRnXBrkwV6L8kMukgioB/9621k6Lm6s2lR2gBKl3BAT1sfN/DYqhsqAJc+6H5PTGQ==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/metaharness/-/metaharness-0.4.7.tgz",
+      "integrity": "sha512-oRbzFPry3bu2gC6+QoLsTbZmzAeNKjjl0gDhxO5p4++azuop9HKWUmw3Urb+uPfCX1IhVsVvjABGQ1VIB3Fbkg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@metaharness/darwin": "^0.2.2",
+        "@metaharness/darwin": "^0.9.1",
         "@metaharness/flywheel": "^0.1.1",
-        "@metaharness/redblue": "^0.1.1",
+        "@metaharness/redblue": "^0.1.6",
+        "@metaharness/turn-credit": "^0.1.0",
         "@metaharness/weight-eft": "^0.1.0",
         "kolorist": "^1.8.0",
         "prompts": "^2.4.2"
@@ -18678,18 +18713,6 @@
         "@metaharness/kernel": {
           "optional": true
         }
-      }
-    },
-    "packages/ruvector/node_modules/metaharness/node_modules/@metaharness/darwin": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@metaharness/darwin/-/darwin-0.2.8.tgz",
-      "integrity": "sha512-B8tF7IrrSxwKS6fEPEL6N2Juth9WWn+hppLUtUYPTJ2vcHzzZPIg2cS5T9qTyNNuANlTSWnQHnvzlfvYdGNfeQ==",
-      "license": "MIT",
-      "bin": {
-        "metaharness-darwin": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "packages/ruvllm": {
@@ -18769,9 +18792,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "os": [
         "linux"
@@ -18785,9 +18805,6 @@
       "version": "2.0.1",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT OR Apache-2.0",
       "os": [
@@ -19279,6 +19296,7 @@
     "packages/spiking-neural": {
       "name": "@ruvector/spiking-neural",
       "version": "1.0.3",
+      "hasInstallScript": true,
       "license": "MIT",
       "bin": {
         "snn": "bin/cli.js",
@@ -19290,27 +19308,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "packages/tiny-dancer": {
-      "name": "@ruvector/tiny-dancer",
-      "version": "0.1.22",
-      "license": "MIT",
-      "devDependencies": {
-        "@napi-rs/cli": "^2.18.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "@ruvector/tiny-dancer-darwin-arm64": "0.1.22",
-        "@ruvector/tiny-dancer-darwin-x64": "0.1.22",
-        "@ruvector/tiny-dancer-linux-arm64-gnu": "0.1.22",
-        "@ruvector/tiny-dancer-linux-arm64-musl": "0.1.22",
-        "@ruvector/tiny-dancer-linux-x64-gnu": "0.1.22",
-        "@ruvector/tiny-dancer-linux-x64-musl": "0.1.22",
-        "@ruvector/tiny-dancer-win32-arm64-msvc": "0.1.22",
-        "@ruvector/tiny-dancer-win32-x64-msvc": "0.1.22"
       }
     },
     "packages/tiny-dancer-darwin-arm64": {
@@ -19347,9 +19344,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "os": [
         "linux"
@@ -19363,9 +19357,6 @@
       "version": "0.1.22",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "os": [

--- a/npm/packages/ruvector/package.json
+++ b/npm/packages/ruvector/package.json
@@ -12,7 +12,7 @@
     "verify-dist": "node scripts/verify-dist.js",
     "prepack": "npm run build && npm run verify-dist",
     "prepublishOnly": "npm run build && npm run verify-dist",
-    "test": "node test/integration.js && node test/metaharness-sdk.js && node test/cli-commands.js && node test/metaharness-cli.js && node test/db-workflow.js && node test/mcp-stdio.js && node test/metaharness-mcp.js && node test/sigterm-cleanup.js && node test/mcp-policy.js && node test/mcp-command-security.js && node test/mcp-handshake.js && node test/startup-budget.js"
+    "test": "node test/integration.js && node test/metaharness-sdk.js && node test/metaharness-optional-deps.js && node test/cli-commands.js && node test/metaharness-cli.js && node test/db-workflow.js && node test/mcp-stdio.js && node test/metaharness-mcp.js && node test/sigterm-cleanup.js && node test/mcp-policy.js && node test/mcp-command-security.js && node test/mcp-handshake.js && node test/startup-budget.js"
   },
   "keywords": [
     "vector",

--- a/npm/packages/ruvector/package.json
+++ b/npm/packages/ruvector/package.json
@@ -71,14 +71,6 @@
     "directory": "npm/packages/ruvector"
   },
   "dependencies": {
-    "@metaharness/darwin": "0.8.0",
-    "@metaharness/flywheel": "0.1.7",
-    "@metaharness/harness": "0.1.0",
-    "@metaharness/redblue": "0.1.4",
-    "@metaharness/router": "0.3.2",
-    "@metaharness/weight-eft": "0.1.1",
-    "@metaharness/workspace-lens": "0.1.1",
-    "@metaharness/workspace-probe": "0.1.1",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@ruvector/attention": "^0.1.3",
     "@ruvector/core": "^0.1.25",
@@ -86,12 +78,20 @@
     "@ruvector/sona": "^0.1.4",
     "chalk": "^4.1.2",
     "commander": "^11.1.0",
-    "metaharness": "0.4.2",
     "ora": "^5.4.1"
   },
   "optionalDependencies": {
+    "@metaharness/darwin": "^0.9.1",
+    "@metaharness/flywheel": "^0.1.10",
+    "@metaharness/harness": "^0.2.0",
+    "@metaharness/redblue": "^0.1.6",
+    "@metaharness/router": "^0.4.0",
+    "@metaharness/weight-eft": "^0.1.1",
+    "@metaharness/workspace-lens": "^0.1.2",
+    "@metaharness/workspace-probe": "^0.1.1",
     "@ruvector/rvf": "^0.1.0",
-    "@ruvector/tiny-dancer": "^0.1.22"
+    "@ruvector/tiny-dancer": "^0.1.22",
+    "metaharness": "^0.4.7"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",
@@ -107,12 +107,48 @@
     "LICENSE"
   ],
   "peerDependencies": {
+    "@metaharness/darwin": ">=0.9.1",
+    "@metaharness/flywheel": ">=0.1.10",
+    "@metaharness/harness": ">=0.2.0",
+    "@metaharness/redblue": ">=0.1.6",
+    "@metaharness/router": ">=0.4.0",
+    "@metaharness/weight-eft": ">=0.1.1",
+    "@metaharness/workspace-lens": ">=0.1.2",
+    "@metaharness/workspace-probe": ">=0.1.1",
     "@ruvector/diskann": ">=0.1.0",
     "@ruvector/pi-brain": ">=0.1.0",
     "@ruvector/router": ">=0.1.0",
-    "@ruvector/ruvllm": ">=2.0.0"
+    "@ruvector/ruvllm": ">=2.0.0",
+    "metaharness": ">=0.4.7"
   },
   "peerDependenciesMeta": {
+    "@metaharness/darwin": {
+      "optional": true
+    },
+    "@metaharness/flywheel": {
+      "optional": true
+    },
+    "@metaharness/harness": {
+      "optional": true
+    },
+    "@metaharness/redblue": {
+      "optional": true
+    },
+    "@metaharness/router": {
+      "optional": true
+    },
+    "@metaharness/weight-eft": {
+      "optional": true
+    },
+    "@metaharness/workspace-lens": {
+      "optional": true
+    },
+    "@metaharness/workspace-probe": {
+      "optional": true
+    },
+    "metaharness": {
+      "optional": true
+    },
     "@ruvector/pi-brain": {
       "optional": true
     },

--- a/npm/packages/ruvector/src/metaharness/index.ts
+++ b/npm/packages/ruvector/src/metaharness/index.ts
@@ -75,16 +75,18 @@ function loadPackage(name: string): Promise<Record<string, any>> {
   if (!pending) {
     pending = nativeImport(name).catch((error: any) => {
       if (error?.code === 'ERR_MODULE_NOT_FOUND' || error?.code === 'MODULE_NOT_FOUND') {
-        // Per the MetaHarness optional-dependency contract (METAHARNESS-README.md,
-        // attributed upstream to "ADR-150: MetaHarness Integration Surfaces"): the
-        // MetaHarness stack is an optionalDependency; ruvector must keep working
-        // without it, and callers of a MetaHarness-backed capability get a clear
-        // error naming the missing package.
+        // Per ruflo ADR-150 "MetaHarness Integration Surfaces"
+        // (ruflo/v3/docs/adr/ADR-150-metaharness-integration-surfaces.md, Implemented
+        // 2026-06-16; summarized locally in METAHARNESS-README.md): "@metaharness/*
+        // packages MUST appear in optionalDependencies or peerDependencies (optional),
+        // never in dependencies". ruvector must keep working without the MetaHarness
+        // stack, and callers of a MetaHarness-backed capability get a clear error
+        // naming the missing package.
         moduleCache.delete(name);
         const missing = new Error(
           `Optional MetaHarness package "${name}" is not installed. ` +
             `Run \`npm install ${name}\` to enable this capability; ` +
-            `ruvector itself works without it (see METAHARNESS-README.md).`,
+            `ruvector itself works without it (ruflo ADR-150, see METAHARNESS-README.md).`,
         );
         (missing as any).code = 'ERR_METAHARNESS_OPTIONAL_MISSING';
         (missing as any).cause = error;

--- a/npm/packages/ruvector/src/metaharness/index.ts
+++ b/npm/packages/ruvector/src/metaharness/index.ts
@@ -11,14 +11,14 @@ const nativeImport = new Function(
 ) as (specifier: string) => Promise<Record<string, any>>;
 
 export const METAHARNESS_VERSIONS = Object.freeze({
-  metaharness: '0.4.2',
-  darwin: '0.8.0',
-  flywheel: '0.1.7',
-  harness: '0.1.0',
-  router: '0.3.2',
-  redblue: '0.1.4',
+  metaharness: '0.4.7',
+  darwin: '0.9.2',
+  flywheel: '0.1.10',
+  harness: '0.2.0',
+  router: '0.4.0',
+  redblue: '0.1.6',
   weightEft: '0.1.1',
-  workspaceLens: '0.1.1',
+  workspaceLens: '0.1.2',
   workspaceProbe: '0.1.1',
 });
 
@@ -73,7 +73,25 @@ const moduleCache = new Map<string, Promise<Record<string, any>>>();
 function loadPackage(name: string): Promise<Record<string, any>> {
   let pending = moduleCache.get(name);
   if (!pending) {
-    pending = nativeImport(name);
+    pending = nativeImport(name).catch((error: any) => {
+      if (error?.code === 'ERR_MODULE_NOT_FOUND' || error?.code === 'MODULE_NOT_FOUND') {
+        // Per the MetaHarness optional-dependency contract (METAHARNESS-README.md,
+        // attributed upstream to "ADR-150: MetaHarness Integration Surfaces"): the
+        // MetaHarness stack is an optionalDependency; ruvector must keep working
+        // without it, and callers of a MetaHarness-backed capability get a clear
+        // error naming the missing package.
+        moduleCache.delete(name);
+        const missing = new Error(
+          `Optional MetaHarness package "${name}" is not installed. ` +
+            `Run \`npm install ${name}\` to enable this capability; ` +
+            `ruvector itself works without it (see METAHARNESS-README.md).`,
+        );
+        (missing as any).code = 'ERR_METAHARNESS_OPTIONAL_MISSING';
+        (missing as any).cause = error;
+        throw missing;
+      }
+      throw error;
+    });
     moduleCache.set(name, pending);
   }
   return pending;

--- a/npm/packages/ruvector/test/metaharness-optional-deps.js
+++ b/npm/packages/ruvector/test/metaharness-optional-deps.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * ruflo ADR-150 compliance guard (MetaHarness Integration Surfaces).
+ *
+ * Rule 2 (verbatim): "@metaharness/* packages MUST appear in optionalDependencies
+ * or peerDependencies (optional), never in dependencies".
+ * Rule 4: the package must keep working on an --ignore-optional install path.
+ *
+ * Part (a) parses package.json and asserts the manifest shape.
+ * Part (b) simulates a MetaHarness-less install: the compiled bridge is copied to a
+ * scratch directory with no reachable node_modules, so every lazy import() fails the
+ * way it would after `npm install --ignore-optional`, and the bridge must degrade
+ * gracefully with a clear error naming the missing optional package.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const META_PACKAGES = [
+  'metaharness',
+  '@metaharness/darwin',
+  '@metaharness/flywheel',
+  '@metaharness/harness',
+  '@metaharness/redblue',
+  '@metaharness/router',
+  '@metaharness/weight-eft',
+  '@metaharness/workspace-lens',
+  '@metaharness/workspace-probe',
+];
+
+function checkManifest() {
+  const manifestPath = path.join(__dirname, '..', 'package.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const dependencies = manifest.dependencies || {};
+  const optionalDependencies = manifest.optionalDependencies || {};
+  const peerDependencies = manifest.peerDependencies || {};
+  const peerDependenciesMeta = manifest.peerDependenciesMeta || {};
+
+  for (const name of META_PACKAGES) {
+    assert.ok(
+      !(name in dependencies),
+      `${name} must never be a hard dependency (ruflo ADR-150 rule 2)`,
+    );
+    const inOptional = name in optionalDependencies;
+    const inPeer = name in peerDependencies;
+    assert.ok(
+      inOptional || inPeer,
+      `${name} must be declared in optionalDependencies or peerDependencies (ruflo ADR-150 rule 2)`,
+    );
+    if (inPeer) {
+      assert.strictEqual(
+        peerDependenciesMeta[name] && peerDependenciesMeta[name].optional,
+        true,
+        `${name} peer dependency must be marked optional in peerDependenciesMeta (ruflo ADR-150 rule 2)`,
+      );
+    }
+  }
+  console.log(`  PASS  all ${META_PACKAGES.length} MetaHarness packages are optional-only in package.json`);
+}
+
+async function checkAbsenceDegradation() {
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'ruvector-adr150-'));
+  try {
+    // The bridge module is self-contained CJS; loading a copy from a directory with
+    // no node_modules on its resolution path makes every lazy import() fail exactly
+    // as it does on an --ignore-optional install.
+    const bridgeSource = path.join(__dirname, '..', 'dist', 'metaharness', 'index.js');
+    const bridgeCopy = path.join(scratch, 'metaharness-bridge.js');
+    fs.copyFileSync(bridgeSource, bridgeCopy);
+    const bridge = require(bridgeCopy);
+
+    const capabilities = await bridge.getMetaHarnessCapabilities();
+    assert.strictEqual(capabilities.length, META_PACKAGES.length);
+    assert.deepStrictEqual(
+      capabilities.filter((capability) => capability.available),
+      [],
+      'no MetaHarness capability may report available when the packages are absent',
+    );
+    console.log('  PASS  getMetaHarnessCapabilities degrades to available:false without MetaHarness');
+
+    await assert.rejects(
+      () =>
+        bridge.routeWithMetaHarness({
+          rows: [{ embedding: [1, 0], scores: { cheap: 0.95 } }],
+          prices: { cheap: 1 },
+          queryEmbedding: [1, 0],
+        }),
+      (error) =>
+        error.code === 'ERR_METAHARNESS_OPTIONAL_MISSING' &&
+        error.message.includes('@metaharness/router'),
+      'a MetaHarness-backed call must fail with a clear error naming the missing optional package',
+    );
+    console.log('  PASS  missing-package calls throw ERR_METAHARNESS_OPTIONAL_MISSING naming the package');
+  } finally {
+    fs.rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  console.log('\nruflo ADR-150 optional-dependency compliance guard');
+  console.log('-'.repeat(50));
+  checkManifest();
+  await checkAbsenceDegradation();
+  console.log('ADR-150 optional-dependency compliance checks passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Two related MetaHarness dependency fixes plus a CI-testable compliance guard:

1. The `ruvector` npm package declared the eight `@metaharness/*` packages plus `metaharness` itself as plain `dependencies`, so `npm i ruvector` force-installed the MetaHarness research stack. This violates **ruflo ADR-150 "MetaHarness Integration Surfaces"** (`ruflo/v3/docs/adr/ADR-150-metaharness-integration-surfaces.md`, Status: Implemented, 2026-06-16), rule 2 verbatim: *"@metaharness/* packages MUST appear in optionalDependencies or peerDependencies (optional), never in dependencies"* — the invariant summarized locally in METAHARNESS-README.md. (Note: this repo's own `docs/adr/ADR-150` is an unrelated pi-brain/Tailscale ADR.)
2. `crates/ruvector-sota-bench/harness` — the direct Darwin consumer — pinned the same nine packages at the old versions (darwin 0.8.0, flywheel 0.1.7, ...), leaving a version split against WP2's dream-machine integration (darwin 0.9.x / flywheel 0.1.10).

### Changes (`npm/packages/ruvector`)
- **package.json**: moved all nine MetaHarness packages from `dependencies` to `optionalDependencies`, and added them to `peerDependencies` with `peerDependenciesMeta: { optional: true }` — same pattern already used for `@ruvector/pi-brain` etc.
- **Version bumps to current published**: `@metaharness/darwin` 0.8.0 → ^0.9.1 (installs 0.9.2), `@metaharness/flywheel` 0.1.7 → ^0.1.10, `@metaharness/harness` 0.1.0 → ^0.2.0, `@metaharness/redblue` 0.1.4 → ^0.1.6, `@metaharness/router` 0.3.2 → ^0.4.0, `@metaharness/workspace-lens` 0.1.1 → ^0.1.2, `metaharness` 0.4.2 → ^0.4.7; `weight-eft` / `workspace-probe` already at latest (^0.1.1).
- **src/metaharness/index.ts**: updated `METAHARNESS_VERSIONS` to match, and wrapped module-not-found failures in the lazy CJS→ESM bridge with a clear error naming the missing optional package (`ERR_METAHARNESS_OPTIONAL_MISSING`) instead of a raw ESM resolution error, citing ruflo ADR-150. `getMetaHarnessCapabilities()` already degraded gracefully (reports `available: false`).
- **test/metaharness-optional-deps.js** (new, per ruflo ADR-150 rule 4 — package must work on an `--ignore-optional` install path): (a) parses package.json and asserts the nine MetaHarness names appear only in `optionalDependencies`/`peerDependencies` (optional), never in `dependencies`; (b) codifies the absence simulation — loads a copy of the compiled bridge from a scratch dir with no reachable `node_modules`, asserts all nine capabilities degrade to `available: false`, and that a MetaHarness-backed call rejects with `ERR_METAHARNESS_OPTIONAL_MISSING` naming the missing package. Wired into the chained `npm test` suite (now 13 files).
- **npm/package-lock.json**: regenerated resolutions for the moved/bumped packages.

### Changes (`crates/ruvector-sota-bench/harness`)
- **package.json + package-lock.json**: bumped all nine `@metaharness`/`metaharness` pins to the same targets as above (installed: darwin 0.9.2, flywheel 0.1.10, harness 0.2.0, redblue 0.1.6, router 0.4.0, workspace-lens 0.1.2, metaharness 0.4.7, weight-eft/workspace-probe 0.1.1). This package is **private**, so plain `dependencies` remain appropriate — only versions changed, no optionalDependencies restructure.

### Verification
**ruvector package** (`npm/packages/ruvector`):
- Full suite (13 chained test files incl. metaharness-sdk/cli/mcp and the new ADR-150 guard) passes with the bumped versions (exit 0).
- ADR-150 guard output: manifest shape asserted for all 9 packages; absence simulation confirms `require` of the bridge works without MetaHarness, capabilities report `available: false`, and direct calls throw the named error.
- `npm run build`, `verify-dist`, and a dist smoke `require` all pass.

**sota-bench harness** (`crates/ruvector-sota-bench/harness`) — exercises the deps directly:
- All 7 `node --test` files run (benchmark, darwin, flywheel, metrics, research, statistics, vetoes): **12 tests, 12 pass, 0 fail**, including `Darwin GEPA evaluates RuVector genomes on each pinned suite item` and `all pinned capability probes load` on the bumped versions.

Part of the PIR program (WP0a task slot; tracked as WP0b in the program plan).
Refs #837, #846

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)