### PR TITLE
fix(workspace): add orphan crates to workspace, add membership guard (PIR #859)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,22 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
+  workspace-membership:
+    name: Workspace membership guard
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '20'
+
+      - name: Check crates/ for orphan crates (PIR #859)
+        run: node scripts/workspace-check.mjs
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-22.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8788,6 +8788,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruvector-agent-memory"
+version = "0.1.0"
+dependencies = [
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "ruvector-attention"
 version = "2.3.0"
 dependencies = [
@@ -8923,6 +8930,14 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "ruvector-bet4-ivf-bench"
+version = "0.1.0"
+dependencies = [
+ "rand 0.8.6",
+ "ruvector-rairs",
 ]
 
 [[package]]
@@ -10718,6 +10733,13 @@ dependencies = [
 [[package]]
 name = "ruvector-temporal-tensor"
 version = "2.3.0"
+
+[[package]]
+name = "ruvector-temporal-tensor-wasm"
+version = "2.3.0"
+dependencies = [
+ "ruvector-temporal-tensor",
+]
 
 [[package]]
 name = "ruvector-timesfm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,28 @@ exclude = ["external/ruqu", "external/rvdna", "examples/OSpipe", "examples/rvf",
     # rvforge-reader: Tauri v2 desktop app (ADR-289). Standalone workspace —
     # the webview/bundler dependency graph and its feature unification are
     # app-specific and would be paid for by every `cargo build --workspace`.
-    "crates/rvforge-reader"]
+    "crates/rvforge-reader",
+    # agentic-robotics family: excluded: does not build — see #859. The six
+    # crates were authored against a different workspace root: they inherit
+    # workspace.package keys this root does not define (description, homepage,
+    # documentation, keywords, categories), reference workspace deps this root
+    # does not declare (zenoh, rustdds, cdr, hdrhistogram), and pin internal
+    # path deps at 0.1.x while version.workspace would make them 2.3.0 —
+    # cargo metadata fails at manifest parse before any code is compiled.
+    "crates/agentic-robotics-core",
+    "crates/agentic-robotics-rt",
+    "crates/agentic-robotics-embedded",
+    "crates/agentic-robotics-mcp",
+    "crates/agentic-robotics-node",
+    "crates/agentic-robotics-benchmarks",
+    # excluded: does not build — see #859. 51 compile errors: API drift
+    # against ruvector-attention 2.x plus a missing bincode dependency.
+    "crates/ruvector-attention-cli",
+    # excluded: does not build — see #859. 11 compile errors: API drift
+    # against ruvector-sparse-inference (SparseModel is now an enum without
+    # forward_embedding/sparsity_statistics/encode; serde derives were
+    # dropped from InferenceConfig/ModelMetadata).
+    "crates/ruvector-sparse-inference-wasm"]
 members = [
     "crates/ruvector-bounded-rag",
     "crates/ruvector-temporal-coherence",
@@ -302,6 +323,16 @@ members = [
     "crates/ruvector-streaming-qng",
     # Entropy-adaptive ANN beam search: live Shannon entropy gates beam width (ADR-303)
     "crates/ruvector-entropy-ann",
+    # PIR #859 workspace-membership sweep: these crates were dangling —
+    # present under crates/ but neither in members nor exclude, so their
+    # tests and lints never ran in CI.
+    "crates/ruvector-bet4-ivf-bench",
+    "crates/ruvector-hnsw-repair",
+    "crates/ruvector-temporal-tensor-wasm",
+    # Also added mid-list by PR #858 (TARL ledger). Cargo tolerates duplicate
+    # member entries (see the two ruvector-nervous-system lines above), so
+    # merge order does not matter; whichever PR lands second can drop one.
+    "crates/ruvector-agent-memory",
 ]
 resolver = "2"
 

--- a/scripts/workspace-check.mjs
+++ b/scripts/workspace-check.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * workspace-check.mjs - Workspace-membership guard (PIR #859).
+ *
+ * Fails (exit 1) if any crates/⋆⋆/Cargo.toml is in the implicit-orphan state:
+ * neither a root workspace member, nor covered by the root `exclude` list,
+ * nor a workspace root of its own (or nested under one). Orphan crates are
+ * invisible to `cargo test --workspace` — their tests silently never run,
+ * which is how 12 crates accumulated before #859.
+ *
+ * The root workspace deliberately uses literal `members` entries (no
+ * `crates/*` glob): membership stays an explicit, reviewable decision, and
+ * this script is the backstop that makes silent orphaning impossible.
+ *
+ * Zero dependencies. Usage:
+ *   node scripts/workspace-check.mjs
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { join, resolve, relative, dirname, sep } from 'path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+// --- Parse the root manifest's members/exclude arrays (tolerant, no TOML dep) ---
+
+function parseStringArray(toml, key) {
+  const m = toml.match(new RegExp(`^${key}\\s*=\\s*\\[`, 'm'));
+  if (!m) return [];
+  let i = m.index + m[0].length;
+  const out = [];
+  while (i < toml.length && toml[i] !== ']') {
+    const ch = toml[i];
+    if (ch === '#') {
+      // comment: skip to end of line
+      while (i < toml.length && toml[i] !== '\n') i++;
+    } else if (ch === '"') {
+      const end = toml.indexOf('"', i + 1);
+      if (end === -1) throw new Error(`unterminated string in ${key}`);
+      out.push(toml.slice(i + 1, end));
+      i = end + 1;
+    } else {
+      i++;
+    }
+  }
+  return out;
+}
+
+const rootToml = readFileSync(join(ROOT, 'Cargo.toml'), 'utf8');
+const members = parseStringArray(rootToml, 'members');
+const excludes = parseStringArray(rootToml, 'exclude');
+
+// --- Matching helpers ---
+
+// Cargo path globs: `*` matches a single path segment.
+function globToRegex(pattern) {
+  const escaped = pattern
+    .split('*')
+    .map((part) => part.replace(/[.+^${}()|[\]\\?]/g, '\\$&'))
+    .join('[^/]+');
+  return new RegExp(`^${escaped}$`);
+}
+
+const memberMatchers = members.map(globToRegex);
+const excludeMatchers = excludes.map(globToRegex);
+
+function isMember(rel) {
+  return memberMatchers.some((re) => re.test(rel));
+}
+
+// An excluded directory covers everything beneath it (cargo semantics:
+// excluding a path removes it and its contents from workspace discovery).
+function isExcluded(rel) {
+  return excludeMatchers.some((re) => {
+    if (re.test(rel)) return true;
+    const parts = rel.split('/');
+    for (let n = 1; n < parts.length; n++) {
+      if (re.test(parts.slice(0, n).join('/'))) return true;
+    }
+    return false;
+  });
+}
+
+function hasOwnWorkspace(manifestPath) {
+  const toml = readFileSync(manifestPath, 'utf8');
+  return /^\s*\[workspace([\].])/m.test(toml);
+}
+
+// --- Walk crates/ for every Cargo.toml ---
+
+const SKIP_DIRS = new Set(['target', 'node_modules', '.git', 'pkg']);
+
+function findManifests(dir, acc) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) findManifests(join(dir, entry.name), acc);
+    } else if (entry.name === 'Cargo.toml') {
+      acc.push(join(dir, entry.name));
+    }
+  }
+  return acc;
+}
+
+const manifests = findManifests(join(ROOT, 'crates'), []);
+
+// Directories (relative, /-separated) whose Cargo.toml declares [workspace].
+const workspaceRoots = new Set(
+  manifests
+    .filter(hasOwnWorkspace)
+    .map((p) => relative(ROOT, dirname(p)).split(sep).join('/')),
+);
+
+function underOwnWorkspace(relDir) {
+  const parts = relDir.split('/');
+  for (let n = 1; n <= parts.length; n++) {
+    if (workspaceRoots.has(parts.slice(0, n).join('/'))) return true;
+  }
+  return false;
+}
+
+// --- Classify ---
+
+const orphans = [];
+for (const manifest of manifests) {
+  const relDir = relative(ROOT, dirname(manifest)).split(sep).join('/');
+  if (isMember(relDir)) continue;
+  if (isExcluded(relDir)) continue;
+  if (underOwnWorkspace(relDir)) continue;
+  orphans.push(relDir);
+}
+
+// Sanity: stale members pointing at nothing are cargo's problem, but flag
+// them here too since we already parsed the list.
+const staleMembers = members.filter(
+  (m) => !m.includes('*') && !existsSync(join(ROOT, m, 'Cargo.toml')),
+);
+
+if (orphans.length === 0 && staleMembers.length === 0) {
+  console.log(
+    `workspace-check: OK — ${manifests.length} manifests under crates/, ` +
+      `${members.length} members, ${excludes.length} excludes, 0 orphans.`,
+  );
+  process.exit(0);
+}
+
+if (orphans.length > 0) {
+  console.error(
+    `workspace-check: FAIL — ${orphans.length} orphan crate(s) under crates/ ` +
+      `(Cargo.toml present, but not a workspace member, not excluded, and not ` +
+      `its own workspace root):\n`,
+  );
+  for (const o of orphans.sort()) console.error(`  ${o}`);
+  console.error(
+    `\nFix: add each path to \`members\` in the root Cargo.toml (preferred — ` +
+      `its tests then run in CI), or to \`exclude\` with a comment stating why ` +
+      `(see #859).`,
+  );
+}
+
+if (staleMembers.length > 0) {
+  console.error(
+    `workspace-check: FAIL — ${staleMembers.length} member entr${
+      staleMembers.length === 1 ? 'y' : 'ies'
+    } with no Cargo.toml on disk:\n`,
+  );
+  for (const s of staleMembers.sort()) console.error(`  ${s}`);
+}
+
+process.exit(1);


### PR DESCRIPTION
Closes #859. Part of the PIR program (#837).

12 crates under `crates/` had a `Cargo.toml` but were neither workspace members nor excluded — the implicit-orphan state where tests silently never run in CI. `ruvector-agent-memory` is the instance PR #858 tripped over; this PR sweeps the class.

## Disposition (12 orphans)

| Crate | Disposition | Notes |
|---|---|---|
| `ruvector-agent-memory` | **member** | `cargo check` + 12 tests green. Also added by PR #858 — Cargo tolerates duplicate member entries, so the two Cargo.toml edits merge cleanly in either order; whichever lands second can drop one. |
| `ruvector-bet4-ivf-bench` | **member** | checks green; no unit tests (bench crate) |
| `ruvector-hnsw-repair` | **member** | checks green; no unit tests |
| `ruvector-temporal-tensor-wasm` | **member** | checks green; no unit tests |
| `agentic-robotics-core` | **exclude** | authored against a different workspace root: inherits `workspace.package` keys this root does not define (`description`, `homepage`, …) and workspace deps it does not declare (`zenoh`, `rustdds`, `cdr`, `hdrhistogram`); `cargo metadata` fails at manifest parse |
| `agentic-robotics-rt` | **exclude** | same family/root mismatch |
| `agentic-robotics-embedded` | **exclude** | same |
| `agentic-robotics-mcp` | **exclude** | same |
| `agentic-robotics-node` | **exclude** | same |
| `agentic-robotics-benchmarks` | **exclude** | same |
| `ruvector-attention-cli` | **exclude** | 51 compile errors: API drift vs `ruvector-attention` 2.x + missing `bincode` dep |
| `ruvector-sparse-inference-wasm` | **exclude** | 11 compile errors: API drift vs `ruvector-sparse-inference` (`SparseModel` is now an enum without the methods the wasm shim calls; serde derives dropped from config types) |

Every exclude entry carries a `# excluded: does not build — see #859` comment in `Cargo.toml`. The 10 previously excluded and 3 own-`[workspace]` crates are untouched.

## Guard

`scripts/workspace-check.mjs` (zero-dep Node) fails when any `crates/**/Cargo.toml` is neither a member, nor covered by `exclude`, nor under its own `[workspace]` — and also flags `members` entries with no manifest on disk. Wired into **Workspace CI** as a fast Node-only job.

Verified: passes on this tree (254 manifests, 215 members, 32 excludes, 0 orphans); fails with exit 1 when a synthetic `crates/zz-orphan-sim` orphan is dropped in (simulation not committed).

## Glob decision (explicit, per acceptance criteria)

Kept literal `members` entries — no `crates/*` glob. A glob would flip the default to opt-out, but with 39 non-member manifests under `crates/` the exclude list would grow large and membership would stop being a reviewable decision. The guard closes the silent-orphan gap the glob would have closed, without changing build scope.

## npm/packages check

The gap exists in a different form: root `package.json` `workspaces` lists only 4 `crates/*` NAPI wrapper dirs; none of the 56 `npm/packages/*` packages are npm workspaces. They are installed/published independently (e.g. `ruvector-npm-ci.yml` runs with `--no-workspaces` deliberately), so this looks intentional rather than an orphan bug — but nothing guards it. Noted on #859 rather than changed here.

## Verification run

- `cargo metadata --format-version 1` — OK
- `cargo check -p` each of the 4 added crates — clean
- `cargo test -p` each of the 4 added crates — 12 passed, 0 failed
- exclusion claims re-verified by temporarily re-adding `ruvector-attention-cli` / `ruvector-sparse-inference-wasm` as members: 51 and 11 compile errors reproduced; `crates/agentic-robotics-core` manifest-parse failure reproduced

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_012Jib2gQyJpqCoo2xYAbb4X