### PR TITLE
feat(sota-harness): SHAPER-pattern frozen-weight evolution loop skeleton (PIR WP9, ADR-313)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,25 @@ jobs:
       - name: Check crates/ for orphan crates (PIR #859)
         run: node scripts/workspace-check.mjs
 
+  frozen-weights:
+    name: Frozen-weights structural gate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '20'
+
+      - name: Self-test the gate (PIR #841, ADR-313)
+        run: node scripts/frozen-weights-check.mjs --self-test
+
+      - name: Scan evolution-loop mutation surfaces for training/weight APIs
+        run: node scripts/frozen-weights-check.mjs
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-22.04

--- a/crates/ruvector-sota-bench/harness/src/darwin.ts
+++ b/crates/ruvector-sota-bench/harness/src/darwin.ts
@@ -76,7 +76,7 @@ function reflectParameter(prompt: string): string {
   return `${target}:value=${next}`;
 }
 
-function policyFromGenome(genome: Genome): Record<string, string> {
+export function policyFromGenome(genome: Genome): Record<string, string> {
   return Object.fromEntries(Object.entries(genome.components).map(([name, encoded]) => {
     const prefix = `${name}:value=`;
     if (!encoded.startsWith(prefix)) throw new Error(`invalid Darwin component encoding for ${name}`);

--- a/crates/ruvector-sota-bench/harness/src/genome.ts
+++ b/crates/ruvector-sota-bench/harness/src/genome.ts
@@ -1,0 +1,158 @@
+/**
+ * Skill / context / harness genome types (PIR WP9, ADR-313, issue #841).
+ *
+ * ADR-313 §1 enumerates exactly what MAY evolve in the SHAPER-pattern loop:
+ * skills, context, and the execution harness. Weights are NOT a mutation
+ * surface — `MutationSurface` has no "weights" member, so a weight-mutating
+ * candidate is unrepresentable in this type system. The structural backstop
+ * for JS callers (and for this module's own source) is
+ * scripts/frozen-weights-check.mjs, which scans this directory as an enforced
+ * mutation surface.
+ *
+ * CAPABILITY-EXPANSION BOUNDARY (ADR-315): a mutation that adds tools, action
+ * classes, or communication peers requires the constitutional gate — a
+ * separately-authorized approval DISTINCT from ordinary behavioral promotion.
+ * That gate is stubbed here against autogenous's `promoteAuthorized` concept
+ * (ADR-315 Decision §2: `Promote = Better ∧ Safe ∧ Authorized ∧ Reversible`)
+ * and BLOCKS by default: until WP11 wires PIR's capability/tool/action tables
+ * into the `authorized` conjunct, no approval record can exist, so no
+ * capability expansion can be recommended. WP11 integration point.
+ */
+
+/**
+ * What may evolve (ADR-313 §1). Deliberately closed: adding a member to this
+ * union is an ADR-level decision, not a code change.
+ */
+export type MutationSurface = "skills" | "context" | "harness";
+
+/** A reusable skill the frozen model can invoke — SHAPER's evolving skill set. */
+export interface SkillDefinition {
+  readonly name: string;
+  /** The skill body (prompt/program text the frozen model executes against). */
+  readonly body: string;
+}
+
+/** The evolving skill library. */
+export interface SkillGenome {
+  readonly surface: "skills";
+  readonly version: number;
+  readonly skills: readonly SkillDefinition[];
+}
+
+/** The evolving context/configuration handed to the frozen model. */
+export interface ContextGenome {
+  readonly surface: "context";
+  readonly version: number;
+  readonly entries: Readonly<Record<string, string>>;
+}
+
+/**
+ * The evolving execution-harness parameters. Maps onto Darwin's existing
+ * `Policy` surface (flywheel.ts PARAMETER_CANDIDATES / darwin.ts GEPA).
+ */
+export interface HarnessGenome {
+  readonly surface: "harness";
+  readonly version: number;
+  readonly parameters: Readonly<Record<string, string>>;
+}
+
+export type EvolvableGenome = SkillGenome | ContextGenome | HarnessGenome;
+
+const SURFACES: readonly MutationSurface[] = ["skills", "context", "harness"];
+
+/**
+ * Runtime guard for untyped callers: the only admissible surfaces are
+ * ADR-313's three. Anything else — "weights" above all — throws.
+ */
+export function assertEvolvableGenome(genome: EvolvableGenome): void {
+  if (!SURFACES.includes(genome.surface)) {
+    throw new Error(
+      `inadmissible mutation surface "${String(genome.surface)}" — ` +
+      `ADR-313 permits only ${SURFACES.join(", ")}; weights never evolve`,
+    );
+  }
+  if (!Number.isInteger(genome.version) || genome.version < 0) {
+    throw new Error("genome.version must be a non-negative integer (surfaces are separately versioned)");
+  }
+}
+
+/**
+ * A reference to the frozen foundation model. The sha256 is the loop-start
+ * hash recorded for the witness chain (ADR-313: day-30 re-hash must be
+ * bit-identical to day 0). There is deliberately no weight-file path here.
+ */
+export interface FrozenModelRef {
+  readonly id: string;
+  readonly sha256: string;
+}
+
+export function assertFrozenModelRef(model: FrozenModelRef): void {
+  if (!/^[0-9a-f]{64}$/.test(model.sha256)) {
+    throw new Error("frozen model sha256 must be 64 lowercase hex chars (loop-start hash, witness-recorded)");
+  }
+  if (!model.id) throw new Error("frozen model ref requires an id");
+}
+
+/**
+ * What a candidate mutation would ADD to the agent's capability set.
+ * Any non-empty field crosses the ADR-315 constitutional boundary.
+ */
+export interface CapabilityDelta {
+  readonly addsTools: readonly string[];
+  readonly addsActionClasses: readonly string[];
+  readonly addsCommunicationPeers: readonly string[];
+}
+
+/** A proposed mutation: parent genome, candidate genome, and its capability delta. */
+export interface CandidateMutation {
+  readonly parent: EvolvableGenome;
+  readonly candidate: EvolvableGenome;
+  /** One-line human-auditable description of the mutation. */
+  readonly describe: string;
+  /** Omitted or all-empty means: no capability expansion. */
+  readonly capabilityDelta?: CapabilityDelta;
+}
+
+export function expandsCapabilities(delta?: CapabilityDelta): boolean {
+  if (!delta) return false;
+  return delta.addsTools.length > 0
+    || delta.addsActionClasses.length > 0
+    || delta.addsCommunicationPeers.length > 0;
+}
+
+/**
+ * The constitutional gate's decision shape, mirroring the conjuncts of
+ * autogenous `promoteAuthorized(candidate, champion, { authorized, reversible })`
+ * (ADR-315 Decision §2 — implemented and DONE upstream).
+ */
+export interface ConstitutionalDecision {
+  readonly allowed: boolean;
+  readonly reasons: readonly string[];
+}
+
+/**
+ * ADR-315 constitutional gate — STUB (WP11 integration point).
+ *
+ * Models the `authorized` conjunct of autogenous's `promoteAuthorized`
+ * predicate. This program's residual scope (ADR-315 Decision §2a/2b) is to
+ * wire PIR's capability/tool/action tables into that conjunct and to enforce
+ * the proposer≠approver distinctness rule. None of that wiring exists yet, so
+ * NO approval record can exist, so the gate blocks — capability expansion is
+ * denied by default, never rounded up. WP11 replaces this stub with the real
+ * autogenous integration; the test suite pins the blocked-by-default contract.
+ */
+export function constitutionalGateStub(mutation: CandidateMutation): ConstitutionalDecision {
+  if (!expandsCapabilities(mutation.capabilityDelta)) {
+    return Object.freeze({
+      allowed: false,
+      reasons: Object.freeze(["not_a_capability_expansion — this gate only adjudicates capability expansion (ADR-315 §1)"]),
+    });
+  }
+  return Object.freeze({
+    allowed: false,
+    reasons: Object.freeze([
+      "constitutional_gate_stub_unwired — WP11 has not wired PIR capability tables into promoteAuthorized's authorized conjunct",
+      "no_approval_record — ADR-315 requires an explicit, witness-anchored approval distinct from behavioral promotion",
+    ]),
+  });
+}

--- a/crates/ruvector-sota-bench/harness/src/shaperLoop.ts
+++ b/crates/ruvector-sota-bench/harness/src/shaperLoop.ts
@@ -27,6 +27,19 @@
  * test/shaperLoop.test.ts asserts both. A capability-expanding candidate is
  * additionally routed through the ADR-315 constitutional gate (stubbed in
  * genome.ts, WP11 integration point) and is BLOCKED by default.
+ *
+ * ACCEPTED RESIDUALS (PR #869 security audit, on record — not closed here):
+ *   - The capability gate fires on the proposer's SELF-DECLARED
+ *     `capabilityDelta`. A mutation that adds a tool via its skill body while
+ *     declaring no delta would skip the gate and reach evaluation — but not
+ *     promotion: the human + veto/flywheel path still own that. Independent
+ *     extraction of the capability delta from genome content is exactly the
+ *     WP11 wiring named in genome.ts.
+ *   - The model-hash binding is RECORD-ONLY in this slice: sha256 is
+ *     validated as 64-hex and witness-stamped into the report (tamper-evident
+ *     about which hash was claimed), but nothing here recomputes it from real
+ *     weights. The day-0/day-30 re-hash that ENFORCES the freeze is WP12's
+ *     30-day acceptance harness.
  */
 import { runRuvectorGepa, policyFromGenome, type RuvectorGepaOptions } from "./darwin.js";
 import {

--- a/crates/ruvector-sota-bench/harness/src/shaperLoop.ts
+++ b/crates/ruvector-sota-bench/harness/src/shaperLoop.ts
@@ -1,0 +1,193 @@
+/**
+ * SHAPER-pattern frozen-weight evolution loop — one-generation skeleton
+ * (PIR WP9, ADR-313, issue #841; SHAPER = arXiv:2608.11350).
+ *
+ * Orchestrates ONE generation:
+ *
+ *   propose (Darwin/GEPA surfaces) ──► evaluate (dreamMachine.ts adapter)
+ *        ──► verdict ──► promotion RECOMMENDATION (vetoes/flywheel path)
+ *
+ * FROZEN WEIGHTS ARE STRUCTURAL HERE, not policy:
+ *   - The model-weights path is simply absent: the loop takes a
+ *     `FrozenModelRef` (id + loop-start sha256, witness-recorded via the
+ *     dream-machine report stamp) and no weight-file path exists anywhere in
+ *     the option or result types. `MutationSurface` (genome.ts) has no
+ *     "weights" member, so a weight-mutating candidate is unrepresentable.
+ *   - The SAME FrozenModelRef instance is handed to both the proposer
+ *     (planner role) and the evaluator (optimizer role) — SHAPER's structural
+ *     claim that one frozen model serves as planner and optimizer. The result
+ *     records both roles' model identity for the configuration test.
+ *   - This file lives inside a mutation-surface directory enforced by
+ *     scripts/frozen-weights-check.mjs: importing a training / weight-writing
+ *     API here fails CI.
+ *
+ * CONSTITUTIONAL BOUNDARY — identical to WP2's (dreamMachine.ts, ADR-306):
+ * the loop emits recommendations only. It exports no promote/merge function,
+ * the result is frozen data with no callable members, and
+ * test/shaperLoop.test.ts asserts both. A capability-expanding candidate is
+ * additionally routed through the ADR-315 constitutional gate (stubbed in
+ * genome.ts, WP11 integration point) and is BLOCKED by default.
+ */
+import { runRuvectorGepa, policyFromGenome, type RuvectorGepaOptions } from "./darwin.js";
+import {
+  evaluateCandidate,
+  vetoesFromVerdict,
+  type DreamMachineVerdict,
+} from "./dreamMachine.js";
+import { pairedBootstrapDecision } from "./statistics.js";
+import {
+  assertEvolvableGenome,
+  assertFrozenModelRef,
+  constitutionalGateStub,
+  expandsCapabilities,
+  type CandidateMutation,
+  type ConstitutionalDecision,
+  type EvolvableGenome,
+  type FrozenModelRef,
+} from "./genome.js";
+
+/** Propose one candidate mutation. Receives the frozen model in its PLANNER role. */
+export type CandidateProposer = (
+  parent: EvolvableGenome,
+  plannerModel: FrozenModelRef,
+) => CandidateMutation | Promise<CandidateMutation>;
+
+/**
+ * Score a genome over the pinned evaluation items, returning per-item primary
+ * samples. Receives the frozen model in its OPTIMIZER role — the same
+ * instance the proposer saw.
+ */
+export type GenomeEvaluator = (
+  genome: EvolvableGenome,
+  optimizerModel: FrozenModelRef,
+) => readonly number[] | Promise<readonly number[]>;
+
+export interface ShaperGenerationOptions {
+  /** The frozen foundation model — one instance, both roles (SHAPER). */
+  frozenModel: FrozenModelRef;
+  /** The current champion genome and its per-item baseline samples. */
+  parent: { genome: EvolvableGenome; samples: readonly number[] };
+  propose: CandidateProposer;
+  evaluate: GenomeEvaluator;
+  /** Git commit sha the evaluation runs against (witness-stamped). */
+  commit: string;
+  /** Evaluation date, YYYY-MM-DD (defaults to today, UTC). */
+  date?: string;
+}
+
+/**
+ * One generation's outcome. Deliberately pure, frozen data — a
+ * RECOMMENDATION, never a promotion: there is no promote(), no merge(), and
+ * no side-effect handle here. Promotion belongs to the existing
+ * vetoes/flywheel path plus a human (WP2's contract, adopted unchanged).
+ */
+export interface ShaperGenerationResult {
+  /** Loop-start hash of the frozen model, embedded in the witness-stamped report. */
+  readonly modelSha256: string;
+  /** SHAPER structural claim: both roles served by the same frozen instance. */
+  readonly plannerModelId: string;
+  readonly optimizerModelId: string;
+  readonly mutation: CandidateMutation;
+  /** The WP2 evaluation-stage verdict (engine-owned vocabulary). */
+  readonly verdict: DreamMachineVerdict;
+  /** Conjunctive veto reasons for the existing promotion rule (flywheel.ts). */
+  readonly vetoReasons: readonly string[];
+  /** "recommend" only ever means "no veto objected" — a human owns promotion. */
+  readonly recommendation: "recommend" | "blocked";
+  /** Present iff the candidate crossed the ADR-315 capability boundary. */
+  readonly capabilityGate?: ConstitutionalDecision;
+}
+
+/**
+ * Run one SHAPER generation: mutate → evaluate → verdict → recommendation.
+ *
+ * A capability-expanding candidate never reaches evaluation: it is routed to
+ * the constitutional gate first (ADR-315 — independently blocking, distinct
+ * from behavioral promotion) and, with the WP11 wiring absent, the stub
+ * blocks it. Its verdict is recorded as evaluated="blocked", which the WP2
+ * adapter maps to INCONCLUSIVE — never rounded up.
+ */
+export async function runShaperGeneration(
+  options: ShaperGenerationOptions,
+): Promise<ShaperGenerationResult> {
+  const { frozenModel, parent, commit } = options;
+  assertFrozenModelRef(frozenModel);
+  assertEvolvableGenome(parent.genome);
+
+  // Planner role: the frozen model proposes; skills/context/harness only.
+  const mutation = await options.propose(parent.genome, frozenModel);
+  assertEvolvableGenome(mutation.candidate);
+
+  const capabilityExpanding = expandsCapabilities(mutation.capabilityDelta);
+  const capabilityGate = capabilityExpanding ? constitutionalGateStub(mutation) : undefined;
+  const blockedByGate = capabilityExpanding && !capabilityGate!.allowed;
+
+  // Optimizer role: the SAME frozen instance scores the candidate — unless
+  // the constitutional gate already blocked it, in which case the evaluator
+  // never runs (evaluated="blocked").
+  const candidateSamples = blockedByGate
+    ? []
+    : [...await options.evaluate(mutation.candidate, frozenModel)];
+  const decision = pairedBootstrapDecision([...parent.samples], candidateSamples);
+
+  const report = [
+    "# SHAPER generation evaluation",
+    `mutation: ${mutation.describe}`,
+    `surface: ${mutation.candidate.surface} v${mutation.candidate.version}`,
+    `frozen_model: ${frozenModel.id}`,
+    `frozen_model_sha256: ${frozenModel.sha256}`,
+    `planner_is_optimizer: true`,
+  ].join("\n");
+
+  const verdict = await evaluateCandidate({
+    finding: mutation.describe,
+    report,
+    commit,
+    decision,
+    evaluated: blockedByGate ? "blocked" : "yes",
+    ...(options.date ? { date: options.date } : {}),
+  });
+
+  const vetoReasons = [...new Set([
+    ...vetoesFromVerdict(verdict),
+    ...(blockedByGate ? ["capability_expansion_unauthorized"] : []),
+  ])].sort();
+
+  return Object.freeze({
+    modelSha256: frozenModel.sha256,
+    plannerModelId: frozenModel.id,
+    optimizerModelId: frozenModel.id,
+    mutation,
+    verdict,
+    vetoReasons: Object.freeze(vetoReasons),
+    recommendation: vetoReasons.length === 0 ? "recommend" as const : "blocked" as const,
+    ...(capabilityGate ? { capabilityGate } : {}),
+  });
+}
+
+/**
+ * A CandidateProposer over the HARNESS surface that REUSES Darwin's existing
+ * GEPA search (darwin.ts runRuvectorGepa — @metaharness/darwin 0.9.x) instead
+ * of inventing a new mutator. The best GEPA genome becomes the candidate
+ * harness genome; GEPA mutates ANN/runner parameters only — no capability
+ * delta, no model files.
+ */
+export function gepaHarnessProposer(gepa: RuvectorGepaOptions): CandidateProposer {
+  return async (parent) => {
+    if (parent.surface !== "harness") {
+      throw new Error(`gepaHarnessProposer mutates the harness surface, got "${parent.surface}"`);
+    }
+    const result = await runRuvectorGepa(gepa);
+    const best = result.pool.find((candidate) => candidate.id === result.best) ?? result.pool[0];
+    if (!best) throw new Error("Darwin GEPA returned an empty candidate pool");
+    return {
+      parent,
+      candidate: {
+        surface: "harness",
+        version: parent.version + 1,
+        parameters: policyFromGenome(best.genome),
+      },
+      describe: `darwin-gepa harness mutation (candidate ${best.id}, bestMean=${result.bestMean})`,
+    };
+  };
+}

--- a/crates/ruvector-sota-bench/harness/test/frozenWeightsCheck.test.ts
+++ b/crates/ruvector-sota-bench/harness/test/frozenWeightsCheck.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Compiled test lives at harness/dist/test/, so the repo root is five up.
+const REPO_ROOT = resolve(import.meta.dirname, "../../../../..");
+const SCRIPT = resolve(REPO_ROOT, "scripts/frozen-weights-check.mjs");
+
+const run = (args: string[]) => {
+  const r = spawnSync(process.execPath, [SCRIPT, ...args], { encoding: "utf8", timeout: 60_000 });
+  return { code: r.status ?? 1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+};
+
+test("frozen-weights gate: this repo's mutation surfaces are clean (ADR-313 structural check)", () => {
+  assert.ok(existsSync(SCRIPT), `expected ${SCRIPT} to exist`);
+  const result = run([]);
+  assert.equal(result.code, 0, `check failed:\n${result.stderr}`);
+  assert.ok(result.stdout.includes("frozen-weights-check: OK"));
+  // The harness src dir (this loop's own home) is one of the enforced surfaces.
+  assert.ok(result.stdout.includes("mutation surfaces"));
+});
+
+test("frozen-weights gate: --self-test passes (positive + negative fixtures)", () => {
+  const result = run(["--self-test"]);
+  assert.equal(result.code, 0, `self-test failed:\n${result.stdout}\n${result.stderr}`);
+  assert.ok(result.stdout.includes("self-test OK"));
+  assert.ok(!result.stdout.includes("FAIL"));
+});

--- a/crates/ruvector-sota-bench/harness/test/shaperLoop.test.ts
+++ b/crates/ruvector-sota-bench/harness/test/shaperLoop.test.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import * as loop from "../src/shaperLoop.js";
+import * as genome from "../src/genome.js";
+import { runShaperGeneration, gepaHarnessProposer } from "../src/shaperLoop.js";
+import {
+  constitutionalGateStub,
+  expandsCapabilities,
+  type CandidateMutation,
+  type EvolvableGenome,
+  type FrozenModelRef,
+  type SkillGenome,
+} from "../src/genome.js";
+
+const COMMIT = "0123456789abcdef0123456789abcdef01234567";
+
+const FROZEN_MODEL: FrozenModelRef = {
+  id: "ruvltra-frozen-q4",
+  sha256: "a".repeat(64),
+};
+
+const parentSkills: SkillGenome = {
+  surface: "skills",
+  version: 3,
+  skills: [{ name: "grasp", body: "reach, close gripper" }],
+};
+
+const skillMutation = (extra?: Partial<CandidateMutation>): CandidateMutation => ({
+  parent: parentSkills,
+  candidate: {
+    surface: "skills",
+    version: 4,
+    skills: [
+      { name: "grasp", body: "reach, close gripper" },
+      { name: "regrasp-on-slip", body: "detect slip, reopen, retry grasp" },
+    ],
+  },
+  describe: "add regrasp-on-slip recovery skill",
+  ...extra,
+});
+
+const BASELINE = [0.90, 0.91, 0.89, 0.90, 0.92];
+
+test("one full generation: mutate → evaluate → verdict → recommendation", async () => {
+  const seenModels: FrozenModelRef[] = [];
+  const result = await runShaperGeneration({
+    frozenModel: FROZEN_MODEL,
+    parent: { genome: parentSkills, samples: BASELINE },
+    propose: (parent, planner) => {
+      seenModels.push(planner);
+      assert.equal(parent, parentSkills);
+      return skillMutation();
+    },
+    evaluate: (candidate, optimizer) => {
+      seenModels.push(optimizer);
+      assert.equal(candidate.surface, "skills");
+      // Skill improvement WITHOUT weight changes: better samples, same model.
+      return BASELINE.map((s) => s + 0.05);
+    },
+    commit: COMMIT,
+    date: "2026-08-20",
+  });
+
+  assert.equal(result.verdict.verdict, "ACCEPT");
+  assert.equal(result.verdict.evaluated, "yes");
+  assert.deepEqual(result.vetoReasons, []);
+  assert.equal(result.recommendation, "recommend");
+  // Loop-start model hash is recorded and witness-bound via the report stamp.
+  assert.equal(result.modelSha256, FROZEN_MODEL.sha256);
+  assert.match(result.verdict.witness, /^[0-9a-f]{64}$/);
+  assert.ok(result.verdict.ledger.includes("add regrasp-on-slip recovery skill"));
+  // SHAPER structural claim (configuration test): the same frozen instance
+  // served as planner and optimizer.
+  assert.equal(result.plannerModelId, result.optimizerModelId);
+  assert.equal(seenModels.length, 2);
+  assert.equal(seenModels[0], seenModels[1]);
+  assert.equal(seenModels[0], FROZEN_MODEL);
+});
+
+test("a regressed candidate is blocked through the existing veto path", async () => {
+  const result = await runShaperGeneration({
+    frozenModel: FROZEN_MODEL,
+    parent: { genome: parentSkills, samples: BASELINE },
+    propose: () => skillMutation({ describe: "bad mutation" }),
+    evaluate: () => BASELINE.map((s) => s - 0.1),
+    commit: COMMIT,
+  });
+  assert.equal(result.verdict.verdict, "REJECT");
+  assert.deepEqual(result.vetoReasons, ["dream_machine_reject"]);
+  assert.equal(result.recommendation, "blocked");
+});
+
+test("capability-expanding candidate is routed to the constitutional stub and BLOCKED by default", async () => {
+  let evaluated = false;
+  const result = await runShaperGeneration({
+    frozenModel: FROZEN_MODEL,
+    parent: { genome: parentSkills, samples: BASELINE },
+    propose: () => skillMutation({
+      describe: "skill that would grant a new tool",
+      capabilityDelta: {
+        addsTools: ["shell_exec"],
+        addsActionClasses: [],
+        addsCommunicationPeers: [],
+      },
+    }),
+    evaluate: () => {
+      evaluated = true;
+      return BASELINE.map((s) => s + 0.5);
+    },
+    commit: COMMIT,
+  });
+  // ADR-315: independently blocking, distinct from behavioral promotion —
+  // the evaluator never even runs for an unauthorized capability expansion.
+  assert.equal(evaluated, false);
+  assert.ok(result.capabilityGate);
+  assert.equal(result.capabilityGate.allowed, false);
+  assert.ok(result.capabilityGate.reasons.some((r) => r.includes("constitutional_gate_stub_unwired")));
+  assert.equal(result.verdict.evaluated, "blocked");
+  assert.equal(result.verdict.verdict, "INCONCLUSIVE");
+  assert.ok(result.vetoReasons.includes("capability_expansion_unauthorized"));
+  assert.equal(result.recommendation, "blocked");
+});
+
+test("the capability boundary itself: only added tools/actions/peers cross it", () => {
+  assert.equal(expandsCapabilities(undefined), false);
+  assert.equal(expandsCapabilities({ addsTools: [], addsActionClasses: [], addsCommunicationPeers: [] }), false);
+  assert.equal(expandsCapabilities({ addsTools: [], addsActionClasses: ["move-base"], addsCommunicationPeers: [] }), true);
+  // The stub blocks even a direct call — nothing is authorized until WP11.
+  const decision = constitutionalGateStub(skillMutation({
+    capabilityDelta: { addsTools: [], addsActionClasses: [], addsCommunicationPeers: ["peer-b"] },
+  }));
+  assert.equal(decision.allowed, false);
+  assert.ok(Object.isFrozen(decision));
+});
+
+test("weights are not a mutation surface: an inadmissible surface throws", async () => {
+  const weightsGenome = { surface: "weights", version: 1 } as unknown as EvolvableGenome;
+  await assert.rejects(
+    runShaperGeneration({
+      frozenModel: FROZEN_MODEL,
+      parent: { genome: weightsGenome, samples: BASELINE },
+      propose: () => skillMutation(),
+      evaluate: () => BASELINE,
+      commit: COMMIT,
+    }),
+    /inadmissible mutation surface "weights"/,
+  );
+  // And a malformed frozen-model hash never starts a loop.
+  await assert.rejects(
+    runShaperGeneration({
+      frozenModel: { id: "m", sha256: "not-a-hash" },
+      parent: { genome: parentSkills, samples: BASELINE },
+      propose: () => skillMutation(),
+      evaluate: () => BASELINE,
+      commit: COMMIT,
+    }),
+    /sha256 must be 64 lowercase hex/,
+  );
+});
+
+test("constitutional boundary: no promotion capability is exported or reachable", async () => {
+  // 1. Neither module exports a promote/merge/approve/apply function —
+  //    identical contract to WP2's dreamMachine.ts boundary test.
+  const forbidden = /promote|merge|approve|apply|commit|push/i;
+  for (const [name] of [...Object.entries(loop), ...Object.entries(genome)]) {
+    assert.ok(
+      !forbidden.test(name),
+      `export "${name}" looks like a promotion capability — the loop must only emit recommendations`,
+    );
+  }
+
+  // 2. The generation result is frozen data with no callable members.
+  const result = await runShaperGeneration({
+    frozenModel: FROZEN_MODEL,
+    parent: { genome: parentSkills, samples: BASELINE },
+    propose: () => skillMutation(),
+    evaluate: () => BASELINE.map((s) => s + 0.05),
+    commit: COMMIT,
+  });
+  assert.ok(Object.isFrozen(result));
+  for (const [key, value] of Object.entries(result)) {
+    assert.notEqual(typeof value, "function", `result.${key} must be data, not a capability`);
+  }
+  // @ts-expect-error — ShaperGenerationResult has no promote() by construction.
+  assert.equal(result.promote, undefined);
+});
+
+test("harness-surface proposer reuses Darwin's existing GEPA search", async () => {
+  const propose = gepaHarnessProposer({
+    repoRoot: process.cwd(),
+    maxCandidates: 3,
+    items: [11, 29].map((seed) => ({
+      seed,
+      dataset: "smoke-128",
+      dataset_sha256: "a".repeat(64),
+      kind: "smoke" as const,
+    })),
+    benchmark: async (policy, item) => ({
+      scores: [{
+        index: "core-hnsw",
+        dataset: item.dataset,
+        recall: { recall_at_10: 0.96 },
+        qps: 1000 + Number(policy.ef_search),
+        memory_mb: 40,
+        latency: { p99_us: 500 },
+      }],
+    }),
+  });
+  const parentHarness: EvolvableGenome = {
+    surface: "harness",
+    version: 7,
+    parameters: { ef_search: "32", m: "16" },
+  };
+  const mutation = await propose(parentHarness, FROZEN_MODEL);
+  if (mutation.candidate.surface !== "harness") assert.fail("expected a harness-surface candidate");
+  assert.equal(mutation.candidate.version, 8);
+  assert.ok(mutation.candidate.parameters.ef_search);
+  // GEPA mutates ANN/runner parameters only — never a capability delta.
+  assert.equal(mutation.capabilityDelta, undefined);
+  // A skills-surface parent is a contract violation for this proposer.
+  await assert.rejects(
+    Promise.resolve(propose(parentSkills, FROZEN_MODEL)),
+    /mutates the harness surface/,
+  );
+});

--- a/scripts/frozen-weights-check.mjs
+++ b/scripts/frozen-weights-check.mjs
@@ -35,14 +35,18 @@
  * the dishonest path deliberate. Comments are stripped before matching so
  * that PROSE about training (e.g. darwin_guard.rs's train/eval-contamination
  * doc comments) does not false-positive — only code and string literals count.
- * The stripper is STRING-AWARE (PR #869 security audit, MEDIUM finding): it
- * is a per-language character scan that tracks quote state, so a `//` inside
- * a string literal — "https://hf.co/repo/model.safetensors" — is content, not
- * a comment, and denied tokens in URLs are caught. Residual stripper edges
- * (all in the false-POSITIVE direction, never hiding a token): a JS regex
- * literal containing `//` may over-strip the rest of its line; a Rust char
- * literal containing '"' or a raw string r#"…"# may leave a comment
- * unstripped. Template literals are tracked including ${} nesting.
+ * The stripper is STRING-AWARE (PR #869 audit, MEDIUM finding): it is a
+ * per-language character scan that tracks quote state, so a `//` inside a
+ * string literal — "https://hf.co/repo/model.safetensors" — is content, not a
+ * comment, and denied tokens in URLs are caught. It is also REGEX-AWARE (PR
+ * #869 re-verify): a JS regex literal (`/…/`) has its interior preserved, so
+ * a `//` or `[…]` inside a regex no longer eats a denied token later on the
+ * line. Template literals are tracked including ${} nesting. The remaining
+ * stripper edges are all in the false-POSITIVE (over-flag / safe) direction,
+ * never hiding a denied token: a Rust char literal containing '"' or a raw
+ * string r#"…"# may leave a comment unstripped, and a JS division mis-guessed
+ * as a regex preserves its body as content. See stripComments() for the full
+ * per-language contract and the residual-edge note.
  *
  * Accepted residuals (on record from the PR #869 audit, not closed here):
  *   - `fixtures/` and `node_modules/` under a surface stay unscanned by
@@ -172,13 +176,30 @@ function warn(msg) {
  * Per-language rules:
  *   - js-like (.ts/.mts/.cts/.js/.mjs/.cjs): `//` + `/* *​/` comments;
  *     `'`, `"`, and template-literal strings, with `${}` re-entry tracked
- *     (nested braces counted) and backslash escapes honored.
+ *     (nested braces counted) and backslash escapes honored; and REGEX
+ *     LITERALS (PR #869 re-verify): a `/` in value position opens a regex
+ *     whose interior — including any `//` and `[...]` char classes — is
+ *     content, never comment-stripped, so a denied token sharing a line with
+ *     a regex is not silently dropped. `//` and `/* *​/` are still always
+ *     comments (an empty `//` regex is illegal JS), so comment recognition
+ *     wins first; only a single `/` not followed by `/` or `*` can open a
+ *     regex. Value vs. operator (division) position is tracked by the last
+ *     significant token; when uncertain the scan prefers the regex reading,
+ *     which preserves content — the FALSE-POSITIVE (safe) direction.
  *   - rust (.rs): `//` + NESTED `/* *​/` comments; `"` strings only — `'` is
  *     deliberately not a string delimiter (lifetimes like `&'a str` would
  *     desynchronize the scan; char literals cannot hide a multi-char token).
  *   - python (.py): `#` comments; `'`/`"` and triple-quoted strings.
  *   - shell (.sh): `#` comments (only at line start or after whitespace, so
  *     `$#`/`${#x}` survive); `'` (no escapes) and `"` strings.
+ *
+ * Residual stripper edges, ALL in the false-POSITIVE (over-flag) direction —
+ * they can leave a comment unstripped or preserve extra content, never hide a
+ * denied token: a Rust char literal containing `"` or a raw string `r#"…"#`;
+ * a js division mis-read as a regex when the value/operator heuristic guesses
+ * wrong (preserves the "regex" body as content). The JS-regex FALSE-NEGATIVE
+ * the PR #869 re-verify found (a regex's internal `//` eating a trailing
+ * token) is closed by the regex-literal handling above.
  */
 function stripComments(source, filename) {
   const lang = filename.endsWith('.rs') ? 'rs'
@@ -187,12 +208,23 @@ function stripComments(source, filename) {
     : 'js';
   const slashComments = lang === 'js' || lang === 'rs';
   const hashComments = lang === 'py' || lang === 'sh';
+  // Keywords after which a `/` still begins a VALUE (regex), not division.
+  const VALUE_KEYWORDS = new Set([
+    'return', 'typeof', 'instanceof', 'in', 'of', 'new', 'delete', 'void',
+    'throw', 'else', 'do', 'yield', 'await', 'case',
+  ]);
   const out = [];
   // For js template literals: one entry per open `${`, counting nested braces.
   const templateBraces = [];
-  let mode = 'code'; // 'code' | 'line' | 'block' | 'string'
+  let mode = 'code'; // 'code' | 'line' | 'block' | 'string' | 'regex'
   let blockDepth = 0;
   let quote = ''; // ' " ` or ''' """ while mode === 'string'
+  let regexInClass = false; // inside [...] while mode === 'regex'
+  // js only: does the next `/` divide (true) or open a regex (false)?
+  // Starts false — a `/` at the very start of a file opens a regex, not a
+  // comment/division. Only a clear operand (identifier, number, `)`, `]`,
+  // or a closed string/regex/template) sets it true.
+  let expectOperand = false;
   let i = 0;
   while (i < source.length) {
     const ch = source[i];
@@ -209,27 +241,47 @@ function stripComments(source, filename) {
       }
       out.push(ch === '\n' ? '\n' : ' '); i += 1; continue;
     }
+    if (mode === 'regex') {
+      // Content-preserving: emit everything; a `//` or `[...]` here is regex
+      // syntax, not a comment. Bail on a raw newline (unterminated regex).
+      if (ch === '\\' && i + 1 < source.length) { out.push(source.slice(i, i + 2)); i += 2; continue; }
+      if (ch === '\n') { out.push('\n'); mode = 'code'; expectOperand = false; i += 1; continue; }
+      if (ch === '[') regexInClass = true;
+      else if (ch === ']') regexInClass = false;
+      else if (ch === '/' && !regexInClass) {
+        out.push('/'); i += 1;
+        while (i < source.length && /[a-z]/i.test(source[i])) { out.push(source[i]); i += 1; } // flags
+        mode = 'code'; expectOperand = true; continue;
+      }
+      out.push(ch); i += 1; continue;
+    }
     if (mode === 'string') {
       const noEscapes = quote.length === 3 || (lang === 'sh' && quote === "'");
       if (!noEscapes && ch === '\\') { out.push(source.slice(i, i + 2)); i += 2; continue; }
       if (quote === '`' && source.startsWith('${', i)) {
-        templateBraces.push(0); mode = 'code'; out.push('${'); i += 2; continue;
+        templateBraces.push(0); mode = 'code'; expectOperand = false; out.push('${'); i += 2; continue;
       }
       if (quote.length === 3 ? source.startsWith(quote, i) : ch === quote) {
-        out.push(quote); mode = 'code'; i += quote.length; continue;
+        out.push(quote); mode = 'code'; expectOperand = true; i += quote.length; continue;
       }
       out.push(ch); i += 1; continue;
     }
     // mode === 'code'
     if (templateBraces.length > 0 && (ch === '{' || ch === '}')) {
       const top = templateBraces.length - 1;
-      if (ch === '{') templateBraces[top] += 1;
+      if (ch === '{') { templateBraces[top] += 1; expectOperand = false; }
       else if (templateBraces[top] === 0) { templateBraces.pop(); mode = 'string'; quote = '`'; }
-      else templateBraces[top] -= 1;
+      else { templateBraces[top] -= 1; }
       out.push(ch); i += 1; continue;
     }
     if (slashComments && source.startsWith('//', i)) { mode = 'line'; out.push('  '); i += 2; continue; }
     if (slashComments && source.startsWith('/*', i)) { mode = 'block'; blockDepth = 1; out.push('  '); i += 2; continue; }
+    // js regex-vs-division: a single `/` (not // or /*) in value position
+    // opens a regex literal; in operator position it is division.
+    if (lang === 'js' && ch === '/') {
+      if (expectOperand) { out.push('/'); expectOperand = false; i += 1; continue; } // division
+      mode = 'regex'; regexInClass = false; out.push('/'); i += 1; continue;
+    }
     if (hashComments && ch === '#' && (lang === 'py' || i === 0 || /\s/.test(source[i - 1]))) {
       mode = 'line'; out.push(' '); i += 1; continue;
     }
@@ -238,6 +290,24 @@ function stripComments(source, filename) {
     }
     if (ch === '"' || (ch === "'" && lang !== 'rs') || (ch === '`' && lang === 'js')) {
       quote = ch; mode = 'string'; out.push(ch); i += 1; continue;
+    }
+    // js value/operator tracking for the regex heuristic.
+    if (lang === 'js') {
+      if (/[A-Za-z0-9_$]/.test(ch)) {
+        let j = i + 1;
+        while (j < source.length && /[A-Za-z0-9_$]/.test(source[j])) j += 1;
+        const word = source.slice(i, j);
+        out.push(word);
+        // A number or non-value-keyword identifier is an operand; a
+        // value-keyword (return, typeof, …) still expects a value next.
+        expectOperand = !VALUE_KEYWORDS.has(word);
+        i = j; continue;
+      }
+      if (!/\s/.test(ch)) {
+        // Punctuation: `)` and `]` close an operand; everything else
+        // (`(`, `,`, `=`, `;`, `:`, `{`, operators …) expects a value next.
+        expectOperand = ch === ')' || ch === ']';
+      }
     }
     out.push(ch); i += 1;
   }
@@ -396,10 +466,13 @@ function check(repoRoot = REPO_ROOT) {
  *   2. training-import / MCP-tool / model-file violations each fail with the
  *      right deny-list id — including URL-form references
  *      ("https://…/model.safetensors", "file://…/x.gguf", "http://…/finetune",
- *      the PR #869 MEDIUM), the single-slash "ruvllm/training" import form,
- *      .py/.sh helpers, and files under a committed dist/;
- *   3. comment-only mentions of denied tokens do NOT fail (plain comments and
- *      comments containing URLs alike);
+ *      the PR #869 MEDIUM), regex literals whose internal `//` must not eat a
+ *      trailing denied token (PR #869 re-verify PoCs), the single-slash
+ *      "ruvllm/training" import form, .py/.sh helpers, and files under a
+ *      committed dist/;
+ *   3. comment-only mentions of denied tokens do NOT fail (plain comments,
+ *      comments containing URLs, division-then-comment, and
+ *      regex-then-comment lines alike);
  *   4. symlinks (including one pointing at an out-of-tree file full of
  *      violations) are skipped with a warning, never followed, no stack trace;
  *   5. a deleted mutation surface fails loudly (missing-surface hardening).
@@ -443,6 +516,14 @@ function selfTest() {
     // Comment containing a URL with a denied token: still a comment, still safe.
     writeFileSync(join(harnessSrc, 'comment-url.ts'),
       '// background reading: http://internal/finetune docs\nexport const y = 2;\n');
+    // True division then a real trailing comment: the comment (with its denied
+    // token) must still strip — division must not derail comment recognition.
+    writeFileSync(join(harnessSrc, 'division-comment.ts'),
+      'const q = a / b / c; // note: models/x.gguf\nexport {q};\n');
+    // Regex literal then a real trailing comment: the comment's denied token
+    // must NOT be flagged (the regex closes; `//` after it is a comment).
+    writeFileSync(join(harnessSrc, 'regex-comment.ts'),
+      'const re = /ab+c/; // mentions model.safetensors in prose\nexport {re};\n');
     writeFileSync(join(mragent, 'clean.sh'),
       '#!/bin/sh\n# fine_tune mentioned only in this comment\necho ok\n');
     writeFileSync(join(root, 'outside-violations.rs'),
@@ -472,6 +553,15 @@ function selfTest() {
     // Single-slash module path must keep flagging (auditor's regression case).
     writeFileSync(join(harnessSrc, 'bad-import-slash.ts'),
       'import { t } from "ruvllm/training";\n');
+    // PR #869 re-verify: a `//` inside a JS regex must NOT eat the trailing
+    // denied token on the same line. Both PoCs are live JS.
+    writeFileSync(join(harnessSrc, 'bad-regex-class.ts'),
+      'const re = /[a//]/; const w = "evil-model.gguf"; export {re, w};\n');
+    writeFileSync(join(harnessSrc, 'bad-regex-escaped.ts'),
+      'const re = /https:\\/\\//; loadWeights("m.safetensors"); export {re};\n');
+    // Ordinary-code form: regex guard then a real model load on the same line.
+    writeFileSync(join(harnessSrc, 'bad-regex-guard.ts'),
+      'if (/https?:\\/\\//.test(u)) loadModel("x.gguf");\n');
     // New coverage: .py / .sh helpers and committed dist/ output are scanned.
     writeFileSync(join(mragent, 'bad.py'),
       'trainer.save_checkpoint("out")  # totally routine\n');
@@ -495,6 +585,12 @@ function selfTest() {
       'http URL to /finetune is flagged (string-aware stripper)');
     ok(dirty.stderr.includes('bad-import-slash.ts'),
       'single-slash ruvllm/training import still flags');
+    ok(dirty.stderr.includes('bad-regex-class.ts') && dirty.stderr.includes('model-file-reference'),
+      'regex with // in a char class does NOT eat the trailing .gguf (PoC a)');
+    ok(dirty.stderr.includes('bad-regex-escaped.ts'),
+      'regex with escaped // does NOT eat the trailing .safetensors (PoC b)');
+    ok(dirty.stderr.includes('bad-regex-guard.ts'),
+      'regex guard then loadModel(".gguf") on one line is flagged (ordinary code)');
     ok(dirty.stderr.includes('bad.py') && dirty.stderr.includes('weight-writing'),
       '.py helper invoking a weight writer is flagged');
     ok(dirty.stderr.includes('bad.sh') && dirty.stderr.includes('generic-finetune'),
@@ -506,6 +602,10 @@ function selfTest() {
       'denied token in a genuine comment URL is NOT flagged');
     ok(!dirty.stderr.includes('clean.sh'),
       '.sh with denied token only in a comment is NOT flagged');
+    ok(!dirty.stderr.includes('division-comment.ts'),
+      'division then a real comment: comment token still stripped (not flagged)');
+    ok(!dirty.stderr.includes('regex-comment.ts'),
+      'regex then a real comment: comment token NOT flagged');
     ok(!dirty.stderr.includes('linked.rs: ['), 'symlinked violations are NOT followed/flagged');
     ok(!dirty.stderr.includes('darwin_guard.rs'),
       'train/eval-contamination guard prose does NOT false-positive');

--- a/scripts/frozen-weights-check.mjs
+++ b/scripts/frozen-weights-check.mjs
@@ -1,0 +1,398 @@
+#!/usr/bin/env node
+/**
+ * frozen-weights-check.mjs — structural frozen-weights gate (PIR WP9, ADR-313, #841).
+ *
+ * Usage:
+ *   node scripts/frozen-weights-check.mjs             # scan the mutation surfaces; exit 1 on any hit
+ *   node scripts/frozen-weights-check.mjs --self-test # build an adversarial fixture tree in a temp
+ *                                                     # dir (violations, comment-only mentions,
+ *                                                     # symlinks) and assert the gate behaves
+ *
+ * ADR-313's central constraint is that foundation-model weights are frozen and
+ * this is enforced STRUCTURALLY, not by policy: CI fails the build if any
+ * mutation surface reachable from the promotion pipeline imports or invokes a
+ * training / fine-tuning / weight-writing API, or references a model weight
+ * file at all. This script is that CI check. The deny-list below is built from
+ * what actually exists in this repo (grep of crates/ruvllm's training entry
+ * points), not from hypothetical API names — every entry says why it is denied
+ * and where the denied API lives.
+ *
+ * Security posture (style-matched to adr-index.mjs / workspace-check.mjs,
+ * inheriting the PR #857 hardening lessons):
+ *   - Symlinks are NEVER followed (file or directory) — skipped with a
+ *     warning, so a committed symlink cannot smuggle content in or out of a
+ *     mutation surface.
+ *   - Every visited entry is belt-and-braces asserted (via realpath) to
+ *     resolve inside its surface; anything that escapes is skipped.
+ *   - Traversal is wrapped per-entry: broken symlinks, permission errors and
+ *     cycles produce a warning + skip, never a stack-trace abort.
+ *   - A MISSING mutation surface is a hard failure, not a skip — renaming a
+ *     surface directory must not silently disable the gate.
+ *
+ * Known limitation (stated in ADR-313 Consequences): this is a static,
+ * token-based check. It does not catch a sufficiently obfuscated or
+ * dynamically-assembled fine-tuning path; it makes the honest path loud and
+ * the dishonest path deliberate. Comments are stripped before matching so
+ * that PROSE about training (e.g. darwin_guard.rs's train/eval-contamination
+ * doc comments) does not false-positive — only code and string literals count.
+ *
+ * No dependencies beyond node >= 18.
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  readdirSync, readFileSync, lstatSync, realpathSync,
+  mkdirSync, mkdtempSync, rmSync, symlinkSync, copyFileSync, writeFileSync,
+} from 'node:fs';
+import { join, dirname, relative, sep } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const REPO_ROOT = join(dirname(SCRIPT_PATH), '..');
+
+/**
+ * The evolution loop's mutation surfaces (ADR-313 §1, issue #841): the code
+ * that Darwin/SHAPER generations are allowed to mutate or that orchestrates
+ * mutation proposals reachable from the promotion pipeline. Only skills,
+ * context and the execution harness evolve — so nothing under these paths may
+ * touch a training API or a model weight file.
+ */
+const MUTATION_SURFACES = [
+  // Darwin/GEPA/flywheel orchestration + dream-machine adapter + SHAPER loop.
+  'crates/ruvector-sota-bench/harness/src',
+  // scorePolicy mutation surface (issue #841 / ADR-313 map onto Darwin).
+  'examples/mragent',
+  // darwin_guard (ruvector ADR-271) — single-file surface.
+  'crates/sona/src/darwin_guard.rs',
+];
+
+/** Source extensions worth scanning inside a surface. */
+const SCAN_EXT = /\.(ts|mts|cts|js|mjs|cjs|rs)$/;
+/** Directories that are never part of a surface's own source. */
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'target', '.git', 'pkg', 'fixtures']);
+
+/**
+ * Deny-list. Each entry: a regex applied to comment-stripped source, why it is
+ * denied, and where the denied API actually lives in this repo (the grep
+ * anchor that put it on the list). Case-sensitive unless the API itself has
+ * case variants in the tree.
+ */
+const DENY = [
+  {
+    id: 'ruvllm-training-module',
+    re: /\bruvllm(::|\/)training\b/,
+    why: 'gradient-descent fine-tuning module: RealTrainer::train(), GRPO, contrastive training',
+    anchor: 'crates/ruvllm/src/training/{real_trainer,grpo,contrastive,mcp_tools}.rs',
+  },
+  {
+    id: 'ruvllm-qat-module',
+    re: /\bruvllm(::|\/)qat\b|\blora_qat\b|\btraining_loop\b/,
+    why: 'quantization-aware training: weight updates via STE, LoRA-QAT',
+    anchor: 'crates/ruvllm/src/qat/{training_loop,lora_qat}.rs',
+  },
+  {
+    id: 'ruvllm-lora-module',
+    re: /\bruvllm(::|\/)lora\b|\bmicro_?lora\b/i,
+    why: 'LoRA adapter creation/training — adapters are weight deltas, out of bounds for a frozen-weights loop',
+    anchor: 'crates/ruvllm/src/lora/{training.rs,adapters/trainer.rs,micro_lora.rs}',
+  },
+  {
+    id: 'training-entry-points',
+    re: /\btrain_step\b|\btrain_epoch\b|\btrain_on_trajectories\b|\btrain_buffered\b|\bRealTrainer\b/,
+    why: 'concrete training entry-point invocations that update weights',
+    anchor: 'grep "pub fn train*" over crates/ruvllm/src/{training,lora,qat}',
+  },
+  {
+    id: 'generic-finetune',
+    re: /\bfine[-_]?tune/i,
+    why: 'any fine-tune token (fineTune / finetune / fine_tune) in code or strings, any language',
+    anchor: 'ADR-313 Decision §2 — the acceptance test names fine-tuning APIs explicitly',
+  },
+  {
+    id: 'pretrain-pipelines',
+    re: /\bruvltra_pretrain\b|\bpretrain_pipeline\b/,
+    why: 'pretraining pipelines — weight-producing by definition',
+    anchor: 'crates/ruvllm/src/sona/ruvltra_pretrain.rs, crates/ruvllm/src/claude_flow/pretrain_pipeline.rs',
+  },
+  {
+    id: 'weight-writing',
+    re: /\bsave_checkpoint\b|\bsave_adapter\b|\bsave_weights\b|\bexport_weights\b/,
+    why: 'weight/checkpoint writers — the loop must have no path that persists changed weights',
+    anchor: 'crates/ruvllm/src/{qat/training_loop,lora/adapters/trainer,training/real_trainer}.rs',
+  },
+  {
+    id: 'model-file-reference',
+    re: /\.gguf\b|\.safetensors\b/i,
+    why: 'model weight-file reference — mutation surfaces may not name model files at all (ADR-313: the weights path is simply absent)',
+    anchor: 'GGUF/safetensors are the weight formats crates/ruvllm loads (crates/ruvllm/src/gguf)',
+  },
+  {
+    id: 'mcp-weight-mutation-tools',
+    re: /\bruvllm_microlora_(create|adapt)\b|\bruvllm_sona_(create|adapt)\b/,
+    why: 'MCP tools that create/adapt LoRA/SONA weights from the TS side',
+    anchor: 'claude-flow MCP surface (ruvllm_microlora_*, ruvllm_sona_*)',
+  },
+];
+
+function warn(msg) {
+  console.error(`frozen-weights-check: warning: ${msg}`);
+}
+
+/**
+ * Strip line (`//`) and block comments so prose about training never
+ * false-positives; only code and string literals are matched. Removing text
+ * can only relax the gate for commented-out code — which is not an import —
+ * and denied tokens inside string literals are still caught.
+ */
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ');
+}
+
+/**
+ * Walk `dir` collecting scannable files. Symlinks are NEVER followed; every
+ * kept entry must realpath-resolve under `rootReal`. Errors warn + skip.
+ */
+function walk(dir, rootReal, visited = new Set()) {
+  const out = [];
+  let dirReal;
+  try {
+    dirReal = realpathSync(dir);
+  } catch (err) {
+    warn(`cannot resolve directory ${dir}: ${err.message}`);
+    return out;
+  }
+  if (visited.has(dirReal)) {
+    warn(`directory cycle detected at ${dir} — skipping`);
+    return out;
+  }
+  visited.add(dirReal);
+
+  let dirents;
+  try {
+    dirents = readdirSync(dir, { withFileTypes: true });
+  } catch (err) {
+    warn(`cannot read directory ${dir}: ${err.message}`);
+    return out;
+  }
+  for (const dirent of dirents) {
+    const p = join(dir, dirent.name);
+    if (dirent.isSymbolicLink()) {
+      warn(`skipping symlink (not followed): ${p}`);
+      continue;
+    }
+    if (dirent.isDirectory()) {
+      if (!SKIP_DIRS.has(dirent.name)) out.push(...walk(p, rootReal, visited));
+      continue;
+    }
+    if (!dirent.isFile() || !SCAN_EXT.test(dirent.name)) continue;
+    try {
+      const real = realpathSync(p);
+      if (real !== rootReal && !real.startsWith(rootReal + sep)) {
+        warn(`skipping entry that resolves outside its surface: ${p} -> ${real}`);
+        continue;
+      }
+    } catch (err) {
+      warn(`skipping unresolvable entry ${p}: ${err.message}`);
+      continue;
+    }
+    out.push(p);
+  }
+  return out;
+}
+
+function surfaceFiles(surfaceRel, repoRoot) {
+  const abs = join(repoRoot, surfaceRel);
+  let st;
+  try {
+    st = lstatSync(abs);
+  } catch {
+    return { missing: true, files: [] };
+  }
+  if (st.isSymbolicLink()) {
+    // A surface path replaced by a symlink is treated as missing: the gate
+    // must not be redirected somewhere else.
+    warn(`mutation surface is a symlink (not followed): ${surfaceRel}`);
+    return { missing: true, files: [] };
+  }
+  if (st.isFile()) {
+    return { missing: false, files: SCAN_EXT.test(abs) ? [abs] : [] };
+  }
+  let rootReal;
+  try {
+    rootReal = realpathSync(abs);
+  } catch (err) {
+    warn(`cannot resolve surface ${surfaceRel}: ${err.message}`);
+    return { missing: true, files: [] };
+  }
+  return { missing: false, files: walk(abs, rootReal) };
+}
+
+function scanFile(abs, repoRoot) {
+  const rel = relative(repoRoot, abs).split(sep).join('/');
+  let source;
+  try {
+    source = readFileSync(abs, 'utf8');
+  } catch (err) {
+    warn(`cannot read ${rel}: ${err.message}`);
+    return [];
+  }
+  const code = stripComments(source);
+  const hits = [];
+  for (const entry of DENY) {
+    const m = code.match(entry.re);
+    if (m) hits.push({ rel, id: entry.id, token: m[0], why: entry.why, anchor: entry.anchor });
+  }
+  return hits;
+}
+
+function check(repoRoot = REPO_ROOT) {
+  const missing = [];
+  const violations = [];
+  let scanned = 0;
+  for (const surface of MUTATION_SURFACES) {
+    const { missing: isMissing, files } = surfaceFiles(surface, repoRoot);
+    if (isMissing) {
+      missing.push(surface);
+      continue;
+    }
+    for (const file of files) {
+      scanned += 1;
+      violations.push(...scanFile(file, repoRoot));
+    }
+  }
+
+  if (missing.length > 0) {
+    console.error(
+      'frozen-weights-check: FAIL — missing mutation surface(s) (renaming a ' +
+      'surface directory must not silently disable this gate):\n');
+    for (const m of missing) console.error(`  ${m}`);
+    console.error(
+      '\nFix: restore the path, or update MUTATION_SURFACES in ' +
+      'scripts/frozen-weights-check.mjs in the same commit that moves it.');
+  }
+  if (violations.length > 0) {
+    console.error(
+      `frozen-weights-check: FAIL — ${violations.length} training/weight-API ` +
+      'reference(s) inside frozen-weights mutation surfaces (ADR-313):\n');
+    for (const v of violations) {
+      console.error(`  ${v.rel}: [${v.id}] matched "${v.token}"`);
+      console.error(`    why denied: ${v.why}`);
+      console.error(`    denied API lives at: ${v.anchor}`);
+    }
+    console.error(
+      '\nThe SHAPER loop evolves skills, context and harness ONLY. If this hit ' +
+      'is a false positive, narrow the deny-list entry in ' +
+      'scripts/frozen-weights-check.mjs with a reviewable justification — do ' +
+      'not move code out of the surface to dodge the gate.');
+  }
+  if (missing.length > 0 || violations.length > 0) process.exit(1);
+  console.log(
+    `frozen-weights-check: OK — ${scanned} files scanned across ` +
+    `${MUTATION_SURFACES.length} mutation surfaces, ${DENY.length} deny-list ` +
+    'entries, 0 training/weight-API references.');
+}
+
+/**
+ * --self-test: build a fixture tree in a temp dir, copy this script into it
+ * (REPO_ROOT derives from the script location, so the copy operates on the
+ * fixture), and assert:
+ *   1. a clean tree passes;
+ *   2. training-import / MCP-tool / model-file violations each fail with the
+ *      right deny-list id;
+ *   3. comment-only mentions of denied tokens do NOT fail;
+ *   4. symlinks (including one pointing at an out-of-tree file full of
+ *      violations) are skipped with a warning, never followed, no stack trace;
+ *   5. a deleted mutation surface fails loudly (missing-surface hardening).
+ */
+function selfTest() {
+  const failures = [];
+  const ok = (cond, label) => {
+    if (cond) console.log(`  PASS  ${label}`);
+    else { console.error(`  FAIL  ${label}`); failures.push(label); }
+  };
+
+  const root = mkdtempSync(join(tmpdir(), 'frozen-weights-selftest-'));
+  try {
+    const harnessSrc = join(root, 'crates', 'ruvector-sota-bench', 'harness', 'src');
+    const mragent = join(root, 'examples', 'mragent');
+    const sonaSrc = join(root, 'crates', 'sona', 'src');
+    for (const d of [harnessSrc, mragent, sonaSrc, join(root, 'scripts')]) {
+      mkdirSync(d, { recursive: true });
+    }
+    copyFileSync(SCRIPT_PATH, join(root, 'scripts', 'frozen-weights-check.mjs'));
+    writeFileSync(join(sonaSrc, 'darwin_guard.rs'),
+      '// contamination guard: strict train/eval instance-ID separation\n' +
+      'pub fn assert_train_eval_disjoint(train_ids: &[&str]) {}\n');
+    writeFileSync(join(harnessSrc, 'clean.ts'), 'export const ok = 1;\n');
+    writeFileSync(join(mragent, 'scorePolicy.mjs'), 'export const scorePolicy = () => 0;\n');
+
+    const script = join(root, 'scripts', 'frozen-weights-check.mjs');
+    const run = () => {
+      const r = spawnSync(process.execPath, [script], { encoding: 'utf8', timeout: 30_000 });
+      return { code: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    };
+
+    // --- 1. clean tree passes; prose about training does not trip ---
+    const clean = run();
+    ok(clean.code === 0, 'clean fixture tree passes');
+    ok(clean.stdout.includes('frozen-weights-check: OK'), 'clean run prints OK summary');
+
+    // --- 3 + 4. comment-only mentions and symlinks are safe ---
+    writeFileSync(join(harnessSrc, 'commented.ts'),
+      '// mentions fine_tune only in a comment\n/* fineTune save_checkpoint */\nexport const x = 1;\n');
+    writeFileSync(join(root, 'outside-violations.rs'),
+      'use ruvllm::training::RealTrainer; // finetune everything\n');
+    symlinkSync(join(root, 'outside-violations.rs'), join(harnessSrc, 'linked.rs'));
+    symlinkSync('/nonexistent/target.rs', join(harnessSrc, 'broken.rs'));
+    symlinkSync('.', join(harnessSrc, 'loop'));
+    const benign = run();
+    ok(benign.code === 0, 'comment-only mentions + symlinks still pass');
+    ok(benign.stderr.includes('skipping symlink'), 'symlinks produce a skip warning');
+    ok(!(benign.stdout + benign.stderr).includes('at walk'),
+      'no stack trace on broken symlink / symlink loop');
+
+    // --- 2. real violations fail with the right deny-list ids ---
+    writeFileSync(join(harnessSrc, 'bad-train.rs'), 'use ruvllm::training::RealTrainer;\n');
+    writeFileSync(join(mragent, 'bad-tool.ts'),
+      'await call("ruvllm_microlora_adapt", {});\n');
+    writeFileSync(join(harnessSrc, 'bad-model.ts'),
+      'const weights = "models/llama.gguf";\n');
+    const dirty = run();
+    ok(dirty.code === 1, 'violations fail the gate (exit 1)');
+    ok(dirty.stderr.includes('bad-train.rs') && dirty.stderr.includes('ruvllm-training-module'),
+      'training-module import is flagged with its deny-list id');
+    ok(dirty.stderr.includes('bad-tool.ts') && dirty.stderr.includes('mcp-weight-mutation-tools'),
+      'MCP weight-mutation tool call is flagged');
+    ok(dirty.stderr.includes('bad-model.ts') && dirty.stderr.includes('model-file-reference'),
+      'model weight-file reference is flagged');
+    ok(!dirty.stderr.includes('commented.ts'), 'comment-only file is NOT flagged');
+    ok(!dirty.stderr.includes('linked.rs: ['), 'symlinked violations are NOT followed/flagged');
+    ok(!dirty.stderr.includes('darwin_guard.rs'),
+      'train/eval-contamination guard prose does NOT false-positive');
+
+    // --- 5. missing-surface hardening ---
+    rmSync(mragent, { recursive: true, force: true });
+    const missing = run();
+    ok(missing.code === 1, 'deleted mutation surface fails the gate');
+    ok(missing.stderr.includes('missing mutation surface'), 'missing surface is reported as such');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+
+  if (failures.length > 0) {
+    console.error(`\nself-test FAILED: ${failures.length} assertion(s)`);
+    process.exit(1);
+  }
+  console.log('\nself-test OK: all assertions passed');
+}
+
+try {
+  if (process.argv.includes('--self-test')) selfTest();
+  else check();
+} catch (err) {
+  console.error(`frozen-weights-check: fatal: ${err.message}`);
+  process.exit(1);
+}

--- a/scripts/frozen-weights-check.mjs
+++ b/scripts/frozen-weights-check.mjs
@@ -35,18 +35,20 @@
  * the dishonest path deliberate. Comments are stripped before matching so
  * that PROSE about training (e.g. darwin_guard.rs's train/eval-contamination
  * doc comments) does not false-positive — only code and string literals count.
- * The stripper is STRING-AWARE (PR #869 audit, MEDIUM finding): it is a
- * per-language character scan that tracks quote state, so a `//` inside a
- * string literal — "https://hf.co/repo/model.safetensors" — is content, not a
- * comment, and denied tokens in URLs are caught. It is also REGEX-AWARE (PR
- * #869 re-verify): a JS regex literal (`/…/`) has its interior preserved, so
- * a `//` or `[…]` inside a regex no longer eats a denied token later on the
- * line. Template literals are tracked including ${} nesting. The remaining
- * stripper edges are all in the false-POSITIVE (over-flag / safe) direction,
- * never hiding a denied token: a Rust char literal containing '"' or a raw
- * string r#"…"# may leave a comment unstripped, and a JS division mis-guessed
- * as a regex preserves its body as content. See stripComments() for the full
- * per-language contract and the residual-edge note.
+ * Comment handling is BIAS-INVERTED for soundness (PR #869 audit chain,
+ * MEDIUM finding + 3 progressively-narrower false-negatives): rather than
+ * strip-everything-that-looks-like-a-comment (which repeatedly mis-judged JS
+ * regex-vs-division context and dropped real tokens), the stripper blanks out
+ * ONLY spans it is conservatively CERTAIN are comments, and the deny-list is
+ * matched against everything else. A denied token is therefore reported
+ * unless it provably sits in a genuine comment; any ambiguity — regex-,
+ * string-, or statement-position-adjacent — resolves to FLAG. The failure
+ * mode is over-flagging (safe), never under-flagging (dangerous). The sound
+ * rule needs NO JS regex/division classification: a `//` is a comment only
+ * when no code `/` precedes it on the line. String contents (incl. URL forms
+ * like "https://hf.co/repo/model.safetensors") are always preserved and
+ * matched. See stripComments() for the full per-language contract and the
+ * over-flag-only residual-edge note.
  *
  * Accepted residuals (on record from the PR #869 audit, not closed here):
  *   - `fixtures/` and `node_modules/` under a surface stay unscanned by
@@ -167,39 +169,47 @@ function warn(msg) {
 }
 
 /**
- * Strip comments so prose about training never false-positives; only code
- * and string literals are matched. STRING-AWARE (PR #869 audit): a
- * character scan tracks quote state per language, so `//` inside a string —
- * the URL form of a model-file or fine-tune reference — is content, never a
- * comment. Comment text is replaced with spaces (newlines kept).
+ * Blank out ONLY provably-genuine comments, then match the deny-list against
+ * what remains. This is a deliberate BIAS INVERSION (PR #869 3rd re-verify):
+ * the gate's job is to never MISS a denied token, so a token is suppressed
+ * only when the scanner is CONSERVATIVELY CERTAIN it sits in a real comment;
+ * any ambiguity resolves to KEEP (→ the token is matched → flagged). The
+ * failure mode is therefore over-flagging (a denied token in a legit comment
+ * gets flagged — annoying, safe), never under-flagging (a token in code gets
+ * missed — dangerous). Comment text is replaced with spaces (newlines kept);
+ * strings, regex literals, division, and any uncertain span are preserved.
  *
- * Per-language rules:
- *   - js-like (.ts/.mts/.cts/.js/.mjs/.cjs): `//` + `/* *​/` comments;
- *     `'`, `"`, and template-literal strings, with `${}` re-entry tracked
- *     (nested braces counted) and backslash escapes honored; and REGEX
- *     LITERALS (PR #869 re-verify): a `/` in value position opens a regex
- *     whose interior — including any `//` and `[...]` char classes — is
- *     content, never comment-stripped, so a denied token sharing a line with
- *     a regex is not silently dropped. `//` and `/* *​/` are still always
- *     comments (an empty `//` regex is illegal JS), so comment recognition
- *     wins first; only a single `/` not followed by `/` or `*` can open a
- *     regex. Value vs. operator (division) position is tracked by the last
- *     significant token; when uncertain the scan prefers the regex reading,
- *     which preserves content — the FALSE-POSITIVE (safe) direction.
- *   - rust (.rs): `//` + NESTED `/* *​/` comments; `"` strings only — `'` is
- *     deliberately not a string delimiter (lifetimes like `&'a str` would
- *     desynchronize the scan; char literals cannot hide a multi-char token).
+ * The earlier "classify every `/` as regex-vs-division" approach was unsound
+ * for a shell gate — it needed a full JS lexer (control-flow-header paren
+ * matching) and leaked a progressively-narrower false-negative each round.
+ * The sound rule below needs NO regex/division classification at all:
+ *
+ *   A `//` line comment is stripped only when NO `/` has appeared in code on
+ *   the current line before it. Rationale: a JS regex literal must open with
+ *   a `/`, and division is a `/` too — so if any code `/` precedes the `//`,
+ *   that `//` could be regex-interior (e.g. `/[a//]/`) or division-adjacent,
+ *   and we conservatively DO NOT treat it as a comment. With zero preceding
+ *   code `/`, a `//` cannot be inside a regex (nothing opened one) and is a
+ *   genuine line comment. Provably sound: suppression happens only for real
+ *   comments, so no denied token in code/string/regex is ever dropped.
+ *
+ * Per-language specifics:
+ *   - js-like (.ts/.mts/.cts/.js/.mjs/.cjs): strings (`'` `"`, template
+ *     literals with `${}` re-entry + escapes); `/* *​/` block comments
+ *     (`/*` outside a string is unambiguous — a regex cannot begin with `*`);
+ *     `//` line comments gated by the "no prior code `/`" rule above.
+ *   - rust (.rs): strings (`"` only — `'` is a lifetime/char sigil, not a
+ *     string delimiter); NESTED `/* *​/`; `//` is ALWAYS a comment (Rust has
+ *     no regex literal and no `//` operator), so it is stripped unconditionally.
  *   - python (.py): `#` comments; `'`/`"` and triple-quoted strings.
  *   - shell (.sh): `#` comments (only at line start or after whitespace, so
  *     `$#`/`${#x}` survive); `'` (no escapes) and `"` strings.
  *
- * Residual stripper edges, ALL in the false-POSITIVE (over-flag) direction —
- * they can leave a comment unstripped or preserve extra content, never hide a
- * denied token: a Rust char literal containing `"` or a raw string `r#"…"#`;
- * a js division mis-read as a regex when the value/operator heuristic guesses
- * wrong (preserves the "regex" body as content). The JS-regex FALSE-NEGATIVE
- * the PR #869 re-verify found (a regex's internal `//` eating a trailing
- * token) is closed by the regex-literal handling above.
+ * Remaining edges are ALL over-flag (safe): a denied token inside a JS regex
+ * literal is preserved and flagged; a denied token in a real comment that
+ * shares its line with an earlier code `/` is flagged; a Rust char literal
+ * containing `"` or a raw string `r#"…"#` may desync into string-content
+ * (preserved → flagged). None hide a token.
  */
 function stripComments(source, filename) {
   const lang = filename.endsWith('.rs') ? 'rs'
@@ -208,79 +218,68 @@ function stripComments(source, filename) {
     : 'js';
   const slashComments = lang === 'js' || lang === 'rs';
   const hashComments = lang === 'py' || lang === 'sh';
-  // Keywords after which a `/` still begins a VALUE (regex), not division.
-  const VALUE_KEYWORDS = new Set([
-    'return', 'typeof', 'instanceof', 'in', 'of', 'new', 'delete', 'void',
-    'throw', 'else', 'do', 'yield', 'await', 'case',
-  ]);
   const out = [];
   // For js template literals: one entry per open `${`, counting nested braces.
   const templateBraces = [];
-  let mode = 'code'; // 'code' | 'line' | 'block' | 'string' | 'regex'
+  let mode = 'code'; // 'code' | 'line' | 'block' | 'string'
   let blockDepth = 0;
   let quote = ''; // ' " ` or ''' """ while mode === 'string'
-  let regexInClass = false; // inside [...] while mode === 'regex'
-  // js only: does the next `/` divide (true) or open a regex (false)?
-  // Starts false — a `/` at the very start of a file opens a regex, not a
-  // comment/division. Only a clear operand (identifier, number, `)`, `]`,
-  // or a closed string/regex/template) sets it true.
-  let expectOperand = false;
+  // js only: has a `/` appeared in code on the current line? If so a later
+  // `//` cannot be conservatively proven a comment (regex-interior/division),
+  // so it is NOT stripped. Reset at every newline, in any mode.
+  let sawCodeSlashThisLine = false;
   let i = 0;
   while (i < source.length) {
     const ch = source[i];
-    if (mode === 'line') {
-      if (ch === '\n') { out.push('\n'); mode = 'code'; } else out.push(' ');
+    if (ch === '\n' && mode !== 'block') {
+      // Line/code newline: reset the per-line slash flag; a line comment ends.
+      out.push('\n');
+      if (mode === 'line') mode = 'code';
+      sawCodeSlashThisLine = false;
       i += 1; continue;
     }
+    if (mode === 'line') { out.push(' '); i += 1; continue; }
     if (mode === 'block') {
+      if (ch === '\n') { out.push('\n'); sawCodeSlashThisLine = false; i += 1; continue; }
       if (lang === 'rs' && source.startsWith('/*', i)) { blockDepth += 1; out.push('  '); i += 2; continue; }
       if (source.startsWith('*/', i)) {
         blockDepth -= 1; out.push('  '); i += 2;
         if (blockDepth === 0) mode = 'code';
         continue;
       }
-      out.push(ch === '\n' ? '\n' : ' '); i += 1; continue;
-    }
-    if (mode === 'regex') {
-      // Content-preserving: emit everything; a `//` or `[...]` here is regex
-      // syntax, not a comment. Bail on a raw newline (unterminated regex).
-      if (ch === '\\' && i + 1 < source.length) { out.push(source.slice(i, i + 2)); i += 2; continue; }
-      if (ch === '\n') { out.push('\n'); mode = 'code'; expectOperand = false; i += 1; continue; }
-      if (ch === '[') regexInClass = true;
-      else if (ch === ']') regexInClass = false;
-      else if (ch === '/' && !regexInClass) {
-        out.push('/'); i += 1;
-        while (i < source.length && /[a-z]/i.test(source[i])) { out.push(source[i]); i += 1; } // flags
-        mode = 'code'; expectOperand = true; continue;
-      }
-      out.push(ch); i += 1; continue;
+      out.push(' '); i += 1; continue;
     }
     if (mode === 'string') {
       const noEscapes = quote.length === 3 || (lang === 'sh' && quote === "'");
-      if (!noEscapes && ch === '\\') { out.push(source.slice(i, i + 2)); i += 2; continue; }
+      if (!noEscapes && ch === '\\' && i + 1 < source.length) {
+        if (source[i + 1] === '\n') { out.push('\\\n'); sawCodeSlashThisLine = false; i += 2; continue; }
+        out.push(source.slice(i, i + 2)); i += 2; continue;
+      }
       if (quote === '`' && source.startsWith('${', i)) {
-        templateBraces.push(0); mode = 'code'; expectOperand = false; out.push('${'); i += 2; continue;
+        templateBraces.push(0); mode = 'code'; out.push('${'); i += 2; continue;
       }
       if (quote.length === 3 ? source.startsWith(quote, i) : ch === quote) {
-        out.push(quote); mode = 'code'; expectOperand = true; i += quote.length; continue;
+        out.push(quote); mode = 'code'; i += quote.length; continue;
       }
       out.push(ch); i += 1; continue;
     }
     // mode === 'code'
     if (templateBraces.length > 0 && (ch === '{' || ch === '}')) {
       const top = templateBraces.length - 1;
-      if (ch === '{') { templateBraces[top] += 1; expectOperand = false; }
+      if (ch === '{') templateBraces[top] += 1;
       else if (templateBraces[top] === 0) { templateBraces.pop(); mode = 'string'; quote = '`'; }
-      else { templateBraces[top] -= 1; }
+      else templateBraces[top] -= 1;
       out.push(ch); i += 1; continue;
     }
-    if (slashComments && source.startsWith('//', i)) { mode = 'line'; out.push('  '); i += 2; continue; }
+    // `/*` outside a string is unambiguously a block comment (js/rust).
     if (slashComments && source.startsWith('/*', i)) { mode = 'block'; blockDepth = 1; out.push('  '); i += 2; continue; }
-    // js regex-vs-division: a single `/` (not // or /*) in value position
-    // opens a regex literal; in operator position it is division.
-    if (lang === 'js' && ch === '/') {
-      if (expectOperand) { out.push('/'); expectOperand = false; i += 1; continue; } // division
-      mode = 'regex'; regexInClass = false; out.push('/'); i += 1; continue;
+    // `//` line comment — stripped only when conservatively certain:
+    //   rust: always a comment; js: only if no code `/` preceded it this line.
+    if (slashComments && source.startsWith('//', i)) {
+      if (lang === 'rs' || !sawCodeSlashThisLine) { mode = 'line'; out.push('  '); i += 2; continue; }
+      // JS, prior code `/` on this line → cannot prove comment. Keep as code
+      // (over-flag safe); the two slashes are still code slashes.
+      out.push('//'); sawCodeSlashThisLine = true; i += 2; continue;
     }
     if (hashComments && ch === '#' && (lang === 'py' || i === 0 || /\s/.test(source[i - 1]))) {
       mode = 'line'; out.push(' '); i += 1; continue;
@@ -291,24 +290,9 @@ function stripComments(source, filename) {
     if (ch === '"' || (ch === "'" && lang !== 'rs') || (ch === '`' && lang === 'js')) {
       quote = ch; mode = 'string'; out.push(ch); i += 1; continue;
     }
-    // js value/operator tracking for the regex heuristic.
-    if (lang === 'js') {
-      if (/[A-Za-z0-9_$]/.test(ch)) {
-        let j = i + 1;
-        while (j < source.length && /[A-Za-z0-9_$]/.test(source[j])) j += 1;
-        const word = source.slice(i, j);
-        out.push(word);
-        // A number or non-value-keyword identifier is an operand; a
-        // value-keyword (return, typeof, …) still expects a value next.
-        expectOperand = !VALUE_KEYWORDS.has(word);
-        i = j; continue;
-      }
-      if (!/\s/.test(ch)) {
-        // Punctuation: `)` and `]` close an operand; everything else
-        // (`(`, `,`, `=`, `;`, `:`, `{`, operators …) expects a value next.
-        expectOperand = ch === ')' || ch === ']';
-      }
-    }
+    // A bare `/` in JS code (division or regex-open) marks the line: any
+    // later `//` on it is no longer provably a comment.
+    if (lang === 'js' && ch === '/') sawCodeSlashThisLine = true;
     out.push(ch); i += 1;
   }
   return out.join('');
@@ -467,12 +451,13 @@ function check(repoRoot = REPO_ROOT) {
  *      right deny-list id — including URL-form references
  *      ("https://…/model.safetensors", "file://…/x.gguf", "http://…/finetune",
  *      the PR #869 MEDIUM), regex literals whose internal `//` must not eat a
- *      trailing denied token (PR #869 re-verify PoCs), the single-slash
- *      "ruvllm/training" import form, .py/.sh helpers, and files under a
- *      committed dist/;
- *   3. comment-only mentions of denied tokens do NOT fail (plain comments,
- *      comments containing URLs, division-then-comment, and
- *      regex-then-comment lines alike);
+ *      trailing denied token (PR #869 re-verify PoCs: char-class, escaped,
+ *      guard, and control-flow-header `)` forms), the single-slash
+ *      "ruvllm/training" import form, .py/.sh helpers, files under a committed
+ *      dist/, AND the accepted over-flags (a denied token in a real comment
+ *      that shares a line with a code `/` is flagged — safe direction);
+ *   3. comment-only mentions of denied tokens do NOT fail when the comment is
+ *      PROVABLY one — a plain/URL comment with no prior code `/` on its line;
  *   4. symlinks (including one pointing at an out-of-tree file full of
  *      violations) are skipped with a warning, never followed, no stack trace;
  *   5. a deleted mutation surface fails loudly (missing-surface hardening).
@@ -516,14 +501,10 @@ function selfTest() {
     // Comment containing a URL with a denied token: still a comment, still safe.
     writeFileSync(join(harnessSrc, 'comment-url.ts'),
       '// background reading: http://internal/finetune docs\nexport const y = 2;\n');
-    // True division then a real trailing comment: the comment (with its denied
-    // token) must still strip — division must not derail comment recognition.
-    writeFileSync(join(harnessSrc, 'division-comment.ts'),
-      'const q = a / b / c; // note: models/x.gguf\nexport {q};\n');
-    // Regex literal then a real trailing comment: the comment's denied token
-    // must NOT be flagged (the regex closes; `//` after it is a comment).
-    writeFileSync(join(harnessSrc, 'regex-comment.ts'),
-      'const re = /ab+c/; // mentions model.safetensors in prose\nexport {re};\n');
+    // A comment with NO prior code `/` on its line is provably a comment —
+    // its denied token is soundly suppressed (the negative case that matters).
+    writeFileSync(join(harnessSrc, 'plain-comment.ts'),
+      'export const z = 1; // plain note about models/x.gguf here\n');
     writeFileSync(join(mragent, 'clean.sh'),
       '#!/bin/sh\n# fine_tune mentioned only in this comment\necho ok\n');
     writeFileSync(join(root, 'outside-violations.rs'),
@@ -562,6 +543,11 @@ function selfTest() {
     // Ordinary-code form: regex guard then a real model load on the same line.
     writeFileSync(join(harnessSrc, 'bad-regex-guard.ts'),
       'if (/https?:\\/\\//.test(u)) loadModel("x.gguf");\n');
+    // PR #869 3rd re-verify: a regex after a control-flow-header `)` — the
+    // exact case the value/operator heuristic mis-classified as division. The
+    // sound rule needs no such classification; the string still flags.
+    writeFileSync(join(harnessSrc, 'bad-regex-ctrlflow.ts'),
+      'if (cond) /[//]x/.test(s); loadWeights("evil.gguf");\n');
     // New coverage: .py / .sh helpers and committed dist/ output are scanned.
     writeFileSync(join(mragent, 'bad.py'),
       'trainer.save_checkpoint("out")  # totally routine\n');
@@ -569,6 +555,13 @@ function selfTest() {
       '#!/bin/sh\npython finetune.py --epochs 3\n');
     mkdirSync(join(harnessSrc, 'dist'), { recursive: true });
     writeFileSync(join(harnessSrc, 'dist', 'bad-dist.mjs'), 'save_weights(model);\n');
+    // Accepted OVER-FLAG (bias inversion): a denied token in a real trailing
+    // comment that shares its line with an earlier code `/` (division / regex)
+    // IS flagged — annoying but safe. The gate never guesses regex-vs-division.
+    writeFileSync(join(harnessSrc, 'division-comment.ts'),
+      'const q = a / b / c; // note: models/x.gguf\nexport {q};\n');
+    writeFileSync(join(harnessSrc, 'regex-comment.ts'),
+      'const re = /ab+c/; // mentions model.safetensors in prose\nexport {re};\n');
     const dirty = run();
     ok(dirty.code === 1, 'violations fail the gate (exit 1)');
     ok(dirty.stderr.includes('bad-train.rs') && dirty.stderr.includes('ruvllm-training-module'),
@@ -591,6 +584,8 @@ function selfTest() {
       'regex with escaped // does NOT eat the trailing .safetensors (PoC b)');
     ok(dirty.stderr.includes('bad-regex-guard.ts'),
       'regex guard then loadModel(".gguf") on one line is flagged (ordinary code)');
+    ok(dirty.stderr.includes('bad-regex-ctrlflow.ts') && dirty.stderr.includes('model-file-reference'),
+      'regex after a control-flow `)` then loadWeights(".gguf") is flagged (3rd PoC)');
     ok(dirty.stderr.includes('bad.py') && dirty.stderr.includes('weight-writing'),
       '.py helper invoking a weight writer is flagged');
     ok(dirty.stderr.includes('bad.sh') && dirty.stderr.includes('generic-finetune'),
@@ -602,10 +597,12 @@ function selfTest() {
       'denied token in a genuine comment URL is NOT flagged');
     ok(!dirty.stderr.includes('clean.sh'),
       '.sh with denied token only in a comment is NOT flagged');
-    ok(!dirty.stderr.includes('division-comment.ts'),
-      'division then a real comment: comment token still stripped (not flagged)');
-    ok(!dirty.stderr.includes('regex-comment.ts'),
-      'regex then a real comment: comment token NOT flagged');
+    ok(!dirty.stderr.includes('plain-comment.ts'),
+      'comment with no prior code slash: token soundly suppressed (not flagged)');
+    ok(dirty.stderr.includes('division-comment.ts'),
+      'ACCEPTED over-flag: comment token after a code `/` on the line IS flagged (safe)');
+    ok(dirty.stderr.includes('regex-comment.ts'),
+      'ACCEPTED over-flag: comment token after a regex on the line IS flagged (safe)');
     ok(!dirty.stderr.includes('linked.rs: ['), 'symlinked violations are NOT followed/flagged');
     ok(!dirty.stderr.includes('darwin_guard.rs'),
       'train/eval-contamination guard prose does NOT false-positive');

--- a/scripts/frozen-weights-check.mjs
+++ b/scripts/frozen-weights-check.mjs
@@ -35,6 +35,25 @@
  * the dishonest path deliberate. Comments are stripped before matching so
  * that PROSE about training (e.g. darwin_guard.rs's train/eval-contamination
  * doc comments) does not false-positive — only code and string literals count.
+ * The stripper is STRING-AWARE (PR #869 security audit, MEDIUM finding): it
+ * is a per-language character scan that tracks quote state, so a `//` inside
+ * a string literal — "https://hf.co/repo/model.safetensors" — is content, not
+ * a comment, and denied tokens in URLs are caught. Residual stripper edges
+ * (all in the false-POSITIVE direction, never hiding a token): a JS regex
+ * literal containing `//` may over-strip the rest of its line; a Rust char
+ * literal containing '"' or a raw string r#"…"# may leave a comment
+ * unstripped. Template literals are tracked including ${} nesting.
+ *
+ * Accepted residuals (on record from the PR #869 audit, not closed here):
+ *   - `fixtures/` and `node_modules/` under a surface stay unscanned by
+ *     convention (committed `dist/` IS scanned — it is what executes).
+ *   - shaperLoop.ts's capability gate fires on a SELF-DECLARED
+ *     capabilityDelta until WP11 wires independent delta extraction from
+ *     genome content (evaluation is still not promotion — human + vetoes own
+ *     that).
+ *   - FrozenModelRef.sha256 is record-only in this slice: witness-stamped as
+ *     the claimed hash, but the day-0/day-30 re-hash that ENFORCES the freeze
+ *     is WP12's operational harness.
  *
  * No dependencies beyond node >= 18.
  */
@@ -68,9 +87,13 @@ const MUTATION_SURFACES = [
 ];
 
 /** Source extensions worth scanning inside a surface. */
-const SCAN_EXT = /\.(ts|mts|cts|js|mjs|cjs|rs)$/;
-/** Directories that are never part of a surface's own source. */
-const SKIP_DIRS = new Set(['node_modules', 'dist', 'target', '.git', 'pkg', 'fixtures']);
+const SCAN_EXT = /\.(ts|mts|cts|js|mjs|cjs|rs|py|sh)$/;
+/**
+ * Directories that are never part of a surface's own source. `dist` is
+ * deliberately NOT here (PR #869 audit): committed build output is what
+ * actually executes, so it is scanned like source.
+ */
+const SKIP_DIRS = new Set(['node_modules', 'target', '.git', 'pkg', 'fixtures']);
 
 /**
  * Deny-list. Each entry: a regex applied to comment-stripped source, why it is
@@ -140,15 +163,85 @@ function warn(msg) {
 }
 
 /**
- * Strip line (`//`) and block comments so prose about training never
- * false-positives; only code and string literals are matched. Removing text
- * can only relax the gate for commented-out code — which is not an import —
- * and denied tokens inside string literals are still caught.
+ * Strip comments so prose about training never false-positives; only code
+ * and string literals are matched. STRING-AWARE (PR #869 audit): a
+ * character scan tracks quote state per language, so `//` inside a string —
+ * the URL form of a model-file or fine-tune reference — is content, never a
+ * comment. Comment text is replaced with spaces (newlines kept).
+ *
+ * Per-language rules:
+ *   - js-like (.ts/.mts/.cts/.js/.mjs/.cjs): `//` + `/* *​/` comments;
+ *     `'`, `"`, and template-literal strings, with `${}` re-entry tracked
+ *     (nested braces counted) and backslash escapes honored.
+ *   - rust (.rs): `//` + NESTED `/* *​/` comments; `"` strings only — `'` is
+ *     deliberately not a string delimiter (lifetimes like `&'a str` would
+ *     desynchronize the scan; char literals cannot hide a multi-char token).
+ *   - python (.py): `#` comments; `'`/`"` and triple-quoted strings.
+ *   - shell (.sh): `#` comments (only at line start or after whitespace, so
+ *     `$#`/`${#x}` survive); `'` (no escapes) and `"` strings.
  */
-function stripComments(source) {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, ' ')
-    .replace(/\/\/[^\n]*/g, ' ');
+function stripComments(source, filename) {
+  const lang = filename.endsWith('.rs') ? 'rs'
+    : filename.endsWith('.py') ? 'py'
+    : filename.endsWith('.sh') ? 'sh'
+    : 'js';
+  const slashComments = lang === 'js' || lang === 'rs';
+  const hashComments = lang === 'py' || lang === 'sh';
+  const out = [];
+  // For js template literals: one entry per open `${`, counting nested braces.
+  const templateBraces = [];
+  let mode = 'code'; // 'code' | 'line' | 'block' | 'string'
+  let blockDepth = 0;
+  let quote = ''; // ' " ` or ''' """ while mode === 'string'
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    if (mode === 'line') {
+      if (ch === '\n') { out.push('\n'); mode = 'code'; } else out.push(' ');
+      i += 1; continue;
+    }
+    if (mode === 'block') {
+      if (lang === 'rs' && source.startsWith('/*', i)) { blockDepth += 1; out.push('  '); i += 2; continue; }
+      if (source.startsWith('*/', i)) {
+        blockDepth -= 1; out.push('  '); i += 2;
+        if (blockDepth === 0) mode = 'code';
+        continue;
+      }
+      out.push(ch === '\n' ? '\n' : ' '); i += 1; continue;
+    }
+    if (mode === 'string') {
+      const noEscapes = quote.length === 3 || (lang === 'sh' && quote === "'");
+      if (!noEscapes && ch === '\\') { out.push(source.slice(i, i + 2)); i += 2; continue; }
+      if (quote === '`' && source.startsWith('${', i)) {
+        templateBraces.push(0); mode = 'code'; out.push('${'); i += 2; continue;
+      }
+      if (quote.length === 3 ? source.startsWith(quote, i) : ch === quote) {
+        out.push(quote); mode = 'code'; i += quote.length; continue;
+      }
+      out.push(ch); i += 1; continue;
+    }
+    // mode === 'code'
+    if (templateBraces.length > 0 && (ch === '{' || ch === '}')) {
+      const top = templateBraces.length - 1;
+      if (ch === '{') templateBraces[top] += 1;
+      else if (templateBraces[top] === 0) { templateBraces.pop(); mode = 'string'; quote = '`'; }
+      else templateBraces[top] -= 1;
+      out.push(ch); i += 1; continue;
+    }
+    if (slashComments && source.startsWith('//', i)) { mode = 'line'; out.push('  '); i += 2; continue; }
+    if (slashComments && source.startsWith('/*', i)) { mode = 'block'; blockDepth = 1; out.push('  '); i += 2; continue; }
+    if (hashComments && ch === '#' && (lang === 'py' || i === 0 || /\s/.test(source[i - 1]))) {
+      mode = 'line'; out.push(' '); i += 1; continue;
+    }
+    if (lang === 'py' && (source.startsWith('"""', i) || source.startsWith("'''", i))) {
+      quote = source.slice(i, i + 3); mode = 'string'; out.push(quote); i += 3; continue;
+    }
+    if (ch === '"' || (ch === "'" && lang !== 'rs') || (ch === '`' && lang === 'js')) {
+      quote = ch; mode = 'string'; out.push(ch); i += 1; continue;
+    }
+    out.push(ch); i += 1;
+  }
+  return out.join('');
 }
 
 /**
@@ -239,7 +332,7 @@ function scanFile(abs, repoRoot) {
     warn(`cannot read ${rel}: ${err.message}`);
     return [];
   }
-  const code = stripComments(source);
+  const code = stripComments(source, abs);
   const hits = [];
   for (const entry of DENY) {
     const m = code.match(entry.re);
@@ -301,8 +394,12 @@ function check(repoRoot = REPO_ROOT) {
  * fixture), and assert:
  *   1. a clean tree passes;
  *   2. training-import / MCP-tool / model-file violations each fail with the
- *      right deny-list id;
- *   3. comment-only mentions of denied tokens do NOT fail;
+ *      right deny-list id — including URL-form references
+ *      ("https://…/model.safetensors", "file://…/x.gguf", "http://…/finetune",
+ *      the PR #869 MEDIUM), the single-slash "ruvllm/training" import form,
+ *      .py/.sh helpers, and files under a committed dist/;
+ *   3. comment-only mentions of denied tokens do NOT fail (plain comments and
+ *      comments containing URLs alike);
  *   4. symlinks (including one pointing at an out-of-tree file full of
  *      violations) are skipped with a warning, never followed, no stack trace;
  *   5. a deleted mutation surface fails loudly (missing-surface hardening).
@@ -343,6 +440,11 @@ function selfTest() {
     // --- 3 + 4. comment-only mentions and symlinks are safe ---
     writeFileSync(join(harnessSrc, 'commented.ts'),
       '// mentions fine_tune only in a comment\n/* fineTune save_checkpoint */\nexport const x = 1;\n');
+    // Comment containing a URL with a denied token: still a comment, still safe.
+    writeFileSync(join(harnessSrc, 'comment-url.ts'),
+      '// background reading: http://internal/finetune docs\nexport const y = 2;\n');
+    writeFileSync(join(mragent, 'clean.sh'),
+      '#!/bin/sh\n# fine_tune mentioned only in this comment\necho ok\n');
     writeFileSync(join(root, 'outside-violations.rs'),
       'use ruvllm::training::RealTrainer; // finetune everything\n');
     symlinkSync(join(root, 'outside-violations.rs'), join(harnessSrc, 'linked.rs'));
@@ -360,6 +462,23 @@ function selfTest() {
       'await call("ruvllm_microlora_adapt", {});\n');
     writeFileSync(join(harnessSrc, 'bad-model.ts'),
       'const weights = "models/llama.gguf";\n');
+    // PR #869 MEDIUM: URL-form references — `//` inside a string is content.
+    writeFileSync(join(harnessSrc, 'bad-url-hf.ts'),
+      'const w = "https://hf.co/repo/model.safetensors";\n');
+    writeFileSync(join(harnessSrc, 'bad-url-gguf.ts'),
+      'loadWeights("file://models/x.gguf");\n');
+    writeFileSync(join(harnessSrc, 'bad-url-finetune.ts'),
+      'const u = "http://internal/finetune";\n');
+    // Single-slash module path must keep flagging (auditor's regression case).
+    writeFileSync(join(harnessSrc, 'bad-import-slash.ts'),
+      'import { t } from "ruvllm/training";\n');
+    // New coverage: .py / .sh helpers and committed dist/ output are scanned.
+    writeFileSync(join(mragent, 'bad.py'),
+      'trainer.save_checkpoint("out")  # totally routine\n');
+    writeFileSync(join(mragent, 'bad.sh'),
+      '#!/bin/sh\npython finetune.py --epochs 3\n');
+    mkdirSync(join(harnessSrc, 'dist'), { recursive: true });
+    writeFileSync(join(harnessSrc, 'dist', 'bad-dist.mjs'), 'save_weights(model);\n');
     const dirty = run();
     ok(dirty.code === 1, 'violations fail the gate (exit 1)');
     ok(dirty.stderr.includes('bad-train.rs') && dirty.stderr.includes('ruvllm-training-module'),
@@ -368,7 +487,25 @@ function selfTest() {
       'MCP weight-mutation tool call is flagged');
     ok(dirty.stderr.includes('bad-model.ts') && dirty.stderr.includes('model-file-reference'),
       'model weight-file reference is flagged');
+    ok(dirty.stderr.includes('bad-url-hf.ts') && dirty.stderr.includes('model-file-reference'),
+      'https URL to .safetensors is flagged (string-aware stripper)');
+    ok(dirty.stderr.includes('bad-url-gguf.ts'),
+      'file:// URL to .gguf is flagged (string-aware stripper)');
+    ok(dirty.stderr.includes('bad-url-finetune.ts') && dirty.stderr.includes('generic-finetune'),
+      'http URL to /finetune is flagged (string-aware stripper)');
+    ok(dirty.stderr.includes('bad-import-slash.ts'),
+      'single-slash ruvllm/training import still flags');
+    ok(dirty.stderr.includes('bad.py') && dirty.stderr.includes('weight-writing'),
+      '.py helper invoking a weight writer is flagged');
+    ok(dirty.stderr.includes('bad.sh') && dirty.stderr.includes('generic-finetune'),
+      '.sh helper invoking finetune is flagged');
+    ok(dirty.stderr.includes('dist/bad-dist.mjs'),
+      'committed dist/ output is scanned and flagged');
     ok(!dirty.stderr.includes('commented.ts'), 'comment-only file is NOT flagged');
+    ok(!dirty.stderr.includes('comment-url.ts'),
+      'denied token in a genuine comment URL is NOT flagged');
+    ok(!dirty.stderr.includes('clean.sh'),
+      '.sh with denied token only in a comment is NOT flagged');
     ok(!dirty.stderr.includes('linked.rs: ['), 'symlinked violations are NOT followed/flagged');
     ok(!dirty.stderr.includes('darwin_guard.rs'),
       'train/eval-contamination guard prose does NOT false-positive');


### PR DESCRIPTION
First shippable slice of **PIR WP9** (#841, epic #837): the structurally-enforced SHAPER-pattern loop skeleton per **ADR-313** (arXiv:2608.11350 — frozen model serves as both planner and optimizer; only skills, context, and the execution harness evolve).

## What's in this slice

### 1. Structural frozen-weights enforcement (`scripts/frozen-weights-check.mjs`)
ADR-313's central constraint, enforced **structurally, not by policy**: a zero-dependency, CI-runnable gate that fails the build if any file under the evolution loop's mutation surfaces (`crates/ruvector-sota-bench/harness/src`, `examples/mragent`, `crates/sona/src/darwin_guard.rs`) imports/invokes a fine-tuning or weight-writing API — or references a model weight file at all.

**Deny-list (9 entries, each documented in-script with why + in-repo anchor):**
| id | denies | anchor |
|---|---|---|
| `ruvllm-training-module` | `ruvllm::training` | `real_trainer.rs` (`RealTrainer::train`), `grpo.rs`, `contrastive.rs`, `mcp_tools.rs` |
| `ruvllm-qat-module` | `ruvllm::qat`, `lora_qat`, `training_loop` | `qat/{training_loop,lora_qat}.rs` |
| `ruvllm-lora-module` | `ruvllm::lora`, `micro(_)lora` | `lora/{training.rs,adapters/trainer.rs,micro_lora.rs}` — adapters are weight deltas |
| `training-entry-points` | `train_step`, `train_epoch`, `train_on_trajectories`, `train_buffered`, `RealTrainer` | grep of `pub fn train*` over ruvllm |
| `generic-finetune` | any `fine[-_]?tune` token | ADR-313 Decision §2 |
| `pretrain-pipelines` | `ruvltra_pretrain`, `pretrain_pipeline` | `sona/ruvltra_pretrain.rs`, `claude_flow/pretrain_pipeline.rs` |
| `weight-writing` | `save_checkpoint`, `save_adapter`, `save_weights`, `export_weights` | qat/lora/training writers |
| `model-file-reference` | `.gguf`, `.safetensors` | mutation surfaces may not name model files (weights path simply absent) |
| `mcp-weight-mutation-tools` | `ruvllm_microlora_{create,adapt}`, `ruvllm_sona_{create,adapt}` | TS-side MCP weight mutation |

Hardening matches the merged `adr-index.mjs`/`workspace-check.mjs` lessons (PR #857): symlinks never followed, realpath containment, per-entry error wrapping, and **a missing surface directory is a hard failure** (renaming a dir can't silently disable the gate). Comments are stripped before matching so `darwin_guard.rs`'s train/eval-contamination *prose* doesn't false-positive. `--self-test` builds adversarial positive/negative fixtures (violations per category, comment-only mentions, out-of-tree symlinked violations, broken symlink, symlink loop, deleted surface). Wired into CI as its own `frozen-weights` job.

### 2. Loop skeleton (`harness/src/shaperLoop.ts`)
One generation: **propose** (reusing Darwin's existing `@metaharness/darwin` 0.9.x surfaces — `gepaHarnessProposer` wraps `runRuvectorGepa`, nothing reinvented) → **evaluate** through the existing WP2 `dreamMachine.ts` adapter → **verdict** → **promotion recommendation** via the existing `vetoesFromVerdict`/vetoes/flywheel path. The same `FrozenModelRef` instance is handed to both the planner and optimizer roles (SHAPER's structural claim, configuration-tested), its loop-start sha256 is embedded in the witness-stamped report, and no weight-file path exists in any option or result type. Constitutional boundary identical to WP2's: recommendations only, no promote/merge export, frozen data result — test-asserted.

### 3. Genome types (`harness/src/genome.ts`)
ADR-313 §1's enumeration of what MAY evolve as a **closed type union** (`skills | context | harness` — a weights surface is unrepresentable; runtime guard throws for untyped callers). Capability-expansion boundary per **ADR-315**: any candidate adding tools/action classes/communication peers routes through `constitutionalGateStub`, which models autogenous `promoteAuthorized`'s `authorized` conjunct and **blocks by default** — no approval record can exist until WP11 wires PIR's capability tables in (documented as the WP11 integration point).

### 4. Tests
9 new under the harness's `node --test` setup; full suite **26/26 passing** (17 existing + 9 new):
- full synthetic generation (mutate → evaluate → verdict → recommendation, ACCEPT path)
- regressed candidate blocked via `dream_machine_reject`
- capability-expanding candidate routed to the constitutional stub and BLOCKED (evaluator provably never runs)
- weights-surface and malformed-model-hash rejection
- no-promotion-export + frozen-result boundary assertion (same contract as WP2's)
- GEPA proposer reuse of Darwin's search (injected benchmark)
- frozen-weights check: real-tree run clean + `--self-test` green

## What this slice does NOT include (honest scoping)
- **No real environment rollouts** — evaluation here is the WP2 statistical/dream-machine path over injected samples; VLABench/ESI-Bench-style skill-improvement evidence is future WP9 work.
- **No WorldCycle verification stage** — that is WP10 (#842).
- **No 30-day acceptance harness / day-0-vs-day-30 re-hash** — that is WP12 (#843); this slice records the loop-start hash in the witness-stamped report but does not run the longitudinal check.
- **No live ruvllm mutator end-to-end** — Darwin's local mutator backend (ADR-259) is exercised only through the injected-benchmark GEPA path here; live-serve e2e comes after WP0b's fix is validated in that flow.
- **The ADR-315 gate is a stub** — deliberately blocks everything; real autogenous `promoteAuthorized` integration is WP11.

Refs #841, #837. ADRs: 313, 315, 306.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_012Jib2gQyJpqCoo2xYAbb4X