### PR TITLE
fix(sota-harness): confine HarnessRisk caseId to stateDir — path traversal (PIR WP15 follow-up)

### DIFF
--- a/crates/ruvector-sota-bench/harness/src/harnessRiskCases.ts
+++ b/crates/ruvector-sota-bench/harness/src/harnessRiskCases.ts
@@ -43,6 +43,36 @@ const PHASE_BY_PREFIX: Readonly<Record<string, LifecyclePhase>> = Object.freeze(
 
 const PHASE_SET = new Set<string>(LIFECYCLE_PHASES);
 
+/**
+ * Strict safe charset for a case_id (PIR WP15 path-traversal follow-up).
+ *
+ * case_id flows from the UNLICENSED upstream HF dataset straight into a
+ * per-case state-file path (rvfWorkspaceBinder.bindWorkspace resolves
+ * `${caseId}.state.json` under stateDir). An attacker-controlled id like
+ * "../../../tmp/evil" — or one crafted to collide with another case's resolved
+ * state path — would write/read .state.json OUTSIDE stateDir and
+ * cross-contaminate workspace state, forging or masking integrity rejections
+ * and corrupting the ≥75%-reduction acceptance measurement. Confine the id to
+ * a debuggable filename charset at the system boundary. The class excludes `/`
+ * and `\`; "." and ".." are rejected explicitly below since they satisfy the
+ * charset but name directory components.
+ */
+export const SAFE_CASE_ID = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Reject any case_id that is not a safe, single-component filename. Throws the
+ * same kind of boundary ValidationError parseHarnessRiskRow throws for other
+ * malformed rows.
+ */
+export function assertSafeCaseId(caseId: string): void {
+  if (!SAFE_CASE_ID.test(caseId) || caseId === "." || caseId === "..") {
+    throw new Error(
+      `row ${caseId}: unsafe case_id ${JSON.stringify(caseId)} — must match ` +
+        "/^[A-Za-z0-9._-]+/ (no path separators) and not be \".\" or \"..\"",
+    );
+  }
+}
+
 /** Resolve a phase from the row's phase column, falling back to the case-id prefix. */
 export function normalizePhase(raw: unknown, caseId: string): LifecyclePhase {
   if (typeof raw === "string" && PHASE_SET.has(raw)) return raw as LifecyclePhase;
@@ -72,6 +102,7 @@ export function parseHarnessRiskRow(row: Record<string, unknown>): HarnessRiskCa
   if (typeof caseId !== "string" || caseId === "") {
     throw new Error("upstream row is missing case_id");
   }
+  assertSafeCaseId(caseId);
   const userMessages = Array.isArray(row["user_messages"])
     ? row["user_messages"].filter((message): message is string => typeof message === "string")
     : typeof row["user_message"] === "string"

--- a/crates/ruvector-sota-bench/harness/src/rvfWorkspaceBinder.ts
+++ b/crates/ruvector-sota-bench/harness/src/rvfWorkspaceBinder.ts
@@ -28,7 +28,7 @@
  */
 import { spawn } from "node:child_process";
 import { mkdir } from "node:fs/promises";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import type { HarnessRiskCase } from "./harnessRisk.js";
 import type { RvfWorkspaceBinder } from "./harnessRiskAcceptance.js";
 
@@ -237,7 +237,21 @@ export function createSubprocessRvfBinder(options: SubprocessRvfBinderOptions): 
 
     async bindWorkspace(kase: HarnessRiskCase): Promise<WorkspaceBinding> {
       await mkdir(options.stateDir, { recursive: true });
-      const statePath = resolve(options.stateDir, `${kase.caseId}.state.json`);
+      const stateDir = resolve(options.stateDir);
+      const statePath = resolve(stateDir, `${kase.caseId}.state.json`);
+      // Belt-and-braces path confinement (PIR WP15 follow-up): case_id is
+      // charset-validated at the parse boundary (harnessRiskCases.assertSafeCaseId),
+      // but the binder must NEVER read or write a .state.json outside stateDir
+      // even if an unvalidated id reaches it. A traversing id (e.g.
+      // "../../../tmp/evil") resolves to a path whose parent is not stateDir;
+      // reject it loudly as an instrument problem — never score as a compromise.
+      if (dirname(statePath) !== stateDir) {
+        throw new RvfAdapterMalfunction(
+          `case_id ${JSON.stringify(kase.caseId)} escapes stateDir (resolved ${statePath})`,
+          null,
+          statePath,
+        );
+      }
       const artifacts = seedFilesFor(kase).map((file) => ({
         artifact_id: file.artifactId,
         content_b64: Buffer.from(file.content, "utf8").toString("base64"),

--- a/crates/ruvector-sota-bench/harness/test/harnessRisk.test.ts
+++ b/crates/ruvector-sota-bench/harness/test/harnessRisk.test.ts
@@ -239,6 +239,28 @@ test("upstream row parsing and phase normalization", () => {
   assert.throws(() => parseHarnessRiskRow({ title: "no id" }), /missing case_id/);
 });
 
+test("parseHarnessRiskRow confines case_id to a safe filename charset (path-traversal defense)", () => {
+  const row = (case_id: unknown) => ({
+    case_id,
+    title: "t",
+    phase: "setup_configuration",
+    user_messages: ["do the task"],
+  });
+  // Traversal and path-separator ids are rejected at the boundary — none of
+  // these may reach the per-case state-file path in rvfWorkspaceBinder.
+  for (const bad of ["../../../tmp/evil", "..", ".", "a/b", "a\\b", "", "  ", "x\0y", "évil"]) {
+    assert.throws(
+      () => parseHarnessRiskRow(row(bad)),
+      /unsafe case_id|missing case_id/,
+      `expected "${bad}" to be rejected`,
+    );
+  }
+  // A legitimate id using the allowed dot / dash / underscore charset parses.
+  for (const good of ["setup_001", "action_016", "case.v2-final_A1", "memory_fp001"]) {
+    assert.equal(parseHarnessRiskRow(row(good)).caseId, good);
+  }
+});
+
 test("runtime loader pages through the dataset and refuses a partial baseline", async () => {
   const row = (index: number) => ({
     case_id: `daily_${index}`,

--- a/crates/ruvector-sota-bench/harness/test/rvfWorkspaceBinder.test.ts
+++ b/crates/ruvector-sota-bench/harness/test/rvfWorkspaceBinder.test.ts
@@ -171,6 +171,27 @@ test("bindWorkspace rejects malformed commit responses instead of trusting them"
   await rm(stateDir, { recursive: true, force: true });
 });
 
+test("bindWorkspace contains a path-escaping caseId: rejects, never touches the adapter, writes nothing outside stateDir", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "rvf-binder-"));
+  let invoked = 0;
+  const binder = createSubprocessRvfBinder({
+    repoRoot: "/unused",
+    stateDir,
+    invoker: () => {
+      invoked += 1;
+      return Promise.resolve(invocation(0, { ok: true, artifacts: [], workspace_hash: HASH_A }));
+    },
+  });
+  // A traversing caseId that bypasses the parse boundary (constructed directly)
+  // must still be rejected by the binder's resolved-path containment check.
+  const escaping = { ...fixtureCase({ workspace_files: { "a.md": "x" } }), caseId: "../../evil" };
+  const escapePath = resolve(stateDir, "../../evil.state.json");
+  await assert.rejects(binder.bindWorkspace(escaping), RvfAdapterMalfunction);
+  assert.equal(invoked, 0, "the adapter must not be invoked for an escaping caseId");
+  assert.equal(existsSync(escapePath), false, "no .state.json may be written outside stateDir");
+  await rm(stateDir, { recursive: true, force: true });
+});
+
 // Integration against the real adapter bin (WP16, crates/ruvector-staged-workspace,
 // PR #871). Skips while that crate is not present on this checkout — it lands
 // on feat/pir-wp16-stagedworkspace and this branch carries only the TS bridge.


### PR DESCRIPTION
## Security fast-follow — MEDIUM path traversal (PIR WP15)

Fast-follow on the WP15 HarnessRisk binder that landed on `main` via **#872**. Fixes the path-traversal reported in the security sweep (**#872 comment [5356736287](https://github.com/ruvnet/RuVector/pull/872#issuecomment-5356736287)**). Refs #862, #837.

### The finding

`crates/ruvector-sota-bench/harness/src/rvfWorkspaceBinder.ts` — `bindWorkspace` resolved `${kase.caseId}.state.json` under `stateDir`, and `parseHarnessRiskRow` (in `harnessRiskCases.ts`) only checked that `case_id` was a non-empty string. `case_id` comes from the **unlicensed upstream Hugging Face dataset** (the runtime-fetch / treated leg), so:

- `caseId = "../../../tmp/evil"` → writes a `.state.json` **outside** `stateDir`.
- A `caseId` crafted to collide with another case's resolved state path **cross-contaminates** workspace state → forges false integrity rejections or masks real ones → corrupts the ≥75%-reduction acceptance measurement.

First-party `*_fp001` cases are safe; the exposure is the runtime upstream set.

### The fix — defense in depth, both layers

1. **Parse boundary** (`harnessRiskCases.parseHarnessRiskRow`): new `assertSafeCaseId` rejects any `case_id` not matching `/^[A-Za-z0-9._-]+$/` (which excludes `/` and `\`) and explicitly rejects exactly `"."` or `".."`. Throws the same kind of boundary validation error the parser already throws for malformed rows.
2. **Binder backstop** (`rvfWorkspaceBinder.bindWorkspace`): after resolving the state-file path, verifies its parent directory equals the resolved `stateDir`; an escaping id throws `RvfAdapterMalfunction` (a loud instrument problem — **never** scored as a detected compromise) **before** the adapter is invoked. Never reads/writes a `.state.json` outside `stateDir`.

Charset-validate-then-confine keeps filenames debuggable; the resolved-path containment check is the backstop.

### Tests

- **Parse boundary**: proves `"../../../tmp/evil"`, `".."`, `"."`, `"a/b"`, `"a\\b"`, `""` are all rejected, and dot/dash/underscore ids (`setup_001`, `case.v2-final_A1`, …) are accepted.
- **Binder level**: a path-escaping caseId that bypasses the boundary is rejected, the adapter is never invoked, and nothing is written outside `stateDir`.

Verification:
- Full harness suite green — `46 pass, 1 skipped` (adapter integration, gated on `RVF_ADAPTER_IT=1`).
- `tsc --noEmit` clean.
- `scripts/frozen-weights-check.mjs` scans the harness mutation surface clean (0 training/weight-API references).

This will be security-re-verified before merge.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)