### PR TITLE
feat(ruvllm): governed pipeline-shard placement planner (PIR WP20, ADR-323)

### DIFF
--- a/crates/ruvllm/Cargo.toml
+++ b/crates/ruvllm/Cargo.toml
@@ -139,6 +139,13 @@ quantize = []
 # existing builds.
 kv-migration = []
 
+# Governed pipeline-shard placement planner: assigns pipeline-stage shards to
+# heterogeneous fleet nodes subject to residency/trust/hardware/capacity hard
+# constraints, optimizing latency/cost within the feasible set
+# (arXiv:2608.19147, PIR WP20, ruvector ADR-323 — extends ADR-314). Default-OFF
+# so it cannot affect existing builds, mirroring the `kv-migration` gate.
+shard-placement = []
+
 # P5 Optimization: Optional routing metrics collection
 # Disable for production to avoid Instant::now() syscall overhead (~0.04-0.08µs)
 routing-metrics = []

--- a/crates/ruvllm/src/lib.rs
+++ b/crates/ruvllm/src/lib.rs
@@ -151,6 +151,8 @@ pub mod ruvector_integration;
 pub mod serving;
 pub mod session;
 pub mod session_index;
+#[cfg(feature = "shard-placement")]
+pub mod shard_placement;
 pub mod sona;
 pub mod speculative;
 pub mod tokenizer;

--- a/crates/ruvllm/src/shard_placement/mod.rs
+++ b/crates/ruvllm/src/shard_placement/mod.rs
@@ -1,0 +1,281 @@
+//! Governed Pipeline-Shard Placement (PIR WP20, ruvector ADR-323)
+//!
+//! This module implements the **governed placement planner** slice of
+//! ruvector ADR-323 (which extends ruvector ADR-314, the WP13 KV-cache
+//! cross-model migration also living in `crates/ruvllm`). It ports the
+//! *placement-governance* half of the pipeline-sharding pattern studied in:
+//!
+//! - **arXiv:2608.19147**, "Pre-Compiled Pipeline Shards for Distributed LLM
+//!   Inference on Intel AI PC Fleets" (submitted 2026-08-19). The paper
+//!   reports **two separate results**, which this program is required to keep
+//!   distinct (never conflated into one headline number):
+//!     1. **1.79× concurrent throughput** — abstract, verbatim: "a two-node
+//!        Llama 3.1 8B INT4 pipeline serves two concurrent users at 1.79x the
+//!        single-user throughput of the unsplit model on the same hardware."
+//!        This figure applies **only** to the two-node / Llama-3.1-8B-INT4
+//!        configuration.
+//!     2. **Four-node Lunar Lake, 70B, interactive single-user serving** — a
+//!        *separate* result (5.72 tok/s single-stream at 72.2% accept rate,
+//!        6.43 tok/s aggregate two-stream in the paper's full text). **No
+//!        1.79× figure is attached to this configuration.** The relevance to
+//!        this slice is purely the *feasibility* shape: a model whose shards
+//!        fit collectively across the fleet but not on any single node.
+//!
+//! ## What this slice is (and is not)
+//!
+//! Per ADR-323, the RuV-native contribution is **not** distributed inference
+//! itself but **governed placement**: deciding which pipeline stage (shard)
+//! runs on which fleet node, subject to inviolable governance constraints.
+//! This slice ships exactly that planner:
+//!
+//! - Model a set of [`ModelShard`]s (pipeline stages) and a set of
+//!   [`FleetNode`]s with governance attributes (residency zone, trust tier,
+//!   available memory, hardware capabilities, plus a latency/cost profile).
+//! - A [`planner::PlacementPlanner`] assigns shards → nodes subject to
+//!   **hard constraints** — data residency, trust tier, hardware capability,
+//!   and (cumulative) memory capacity — optimizing a latency/cost objective
+//!   *only among feasible placements*.
+//! - An infeasible placement is **rejected with a structured, specific
+//!   reason** ([`planner::PlacementRejection`]) — never silently placed on a
+//!   constraint-violating node.
+//!
+//! ### Deliberately deferred (follow-ups, honest scope)
+//!
+//! Real OpenVINO per-stage shard compilation (including the `beam_idx`-Gather
+//! / `IndirectKVCache` fusion detail), actual distributed execution and
+//! inter-node transport, speculative decoding on stateful sharded models, and
+//! live request-specific KV-state routing are **all out of scope for this
+//! slice** — they are the execution runtime ADR-323 governs, tracked as
+//! follow-up work. This slice is the placement **planner + governance policy**
+//! only.
+//!
+//! Node trust here is an input attribute ([`TrustTier`]); in production it is
+//! sourced from this program's witness chain (ADR-134 / ADR-312), and wiring
+//! that verification into the planner is likewise a deferred follow-up.
+//!
+//! Feature-gated behind `shard-placement` (default off), mirroring WP13's
+//! `kv-migration` gate, so it cannot affect the default `ruvllm` build.
+//!
+//! ## Preprint-reproduction rule
+//!
+//! The paper's 1.79× and 4-node/70B figures describe the source paper's own
+//! hardware, not this program's fleet. They are the *target shape* to
+//! reproduce internally, never numbers this program may cite as its own
+//! acceptance bar without independently measuring them (ADR-323 §Preprint-
+//! reproduction rule; ADR-306 promotion gating).
+
+pub mod planner;
+pub mod policy;
+
+#[cfg(test)]
+mod tests;
+
+pub use planner::{
+    ObjectiveWeights, PlacementPlan, PlacementPlanner, PlacementRejection, ShardAssignment,
+};
+pub use policy::{ConstraintViolation, GovernancePolicy, NodeViolation};
+
+use std::collections::BTreeSet;
+
+/// A data-residency zone (e.g. `"eu-west"`, `"us"`). A shard whose state is
+/// tagged for a zone must be placed on a node in that same zone.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ResidencyZone(pub String);
+
+impl ResidencyZone {
+    /// Construct a residency zone from anything string-like.
+    pub fn new(zone: impl Into<String>) -> Self {
+        Self(zone.into())
+    }
+
+    /// Borrow the zone identifier.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ResidencyZone {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A trust tier. **Higher is more trusted.** A shard requiring a minimum tier
+/// `T` may only be placed on a node whose tier is `>= T`.
+///
+/// In production the concrete tier of a node is derived from its witness /
+/// attestation status (ADR-134 / ADR-312); here it is a plain input attribute
+/// so the planner can be tested in isolation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TrustTier(pub u8);
+
+impl std::fmt::Display for TrustTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "T{}", self.0)
+    }
+}
+
+/// Stable identifier for a fleet node.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NodeId(pub String);
+
+impl NodeId {
+    /// Construct a node id.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// Borrow the identifier.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Stable identifier for a model shard (pipeline stage).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ShardId(pub String);
+
+impl ShardId {
+    /// Construct a shard id.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// Borrow the identifier.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ShardId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A node in a heterogeneous serving fleet, with the governance attributes the
+/// placement policy reasons over.
+#[derive(Debug, Clone)]
+pub struct FleetNode {
+    /// Stable node identifier.
+    pub id: NodeId,
+    /// Residency zone this node physically lives in.
+    pub residency_zone: ResidencyZone,
+    /// Trust tier this node currently satisfies (higher = more trusted).
+    pub trust_tier: TrustTier,
+    /// Memory available for hosting shards, in MB.
+    pub available_memory_mb: u64,
+    /// Hardware capability tags this node provides (e.g. `"int4"`, `"avx512"`,
+    /// `"npu"`). A shard is only eligible if the node provides *all* of the
+    /// shard's required capabilities.
+    pub capabilities: BTreeSet<String>,
+    /// Serving-latency contribution of this node, in milliseconds — an input
+    /// to the placement objective (lower is better).
+    pub latency_ms: f64,
+    /// Resource/compute cost of using this node — an input to the placement
+    /// objective (lower is better).
+    pub cost_units: f64,
+}
+
+impl FleetNode {
+    /// Construct a node with the mandatory governance attributes; latency and
+    /// cost default to `0.0` and capabilities to empty. Use the `with_*`
+    /// builders to set the objective/capability fields.
+    pub fn new(
+        id: impl Into<String>,
+        residency_zone: ResidencyZone,
+        trust_tier: TrustTier,
+        available_memory_mb: u64,
+    ) -> Self {
+        Self {
+            id: NodeId::new(id),
+            residency_zone,
+            trust_tier,
+            available_memory_mb,
+            capabilities: BTreeSet::new(),
+            latency_ms: 0.0,
+            cost_units: 0.0,
+        }
+    }
+
+    /// Set the node's latency/cost objective profile.
+    pub fn with_profile(mut self, latency_ms: f64, cost_units: f64) -> Self {
+        self.latency_ms = latency_ms;
+        self.cost_units = cost_units;
+        self
+    }
+
+    /// Add hardware capability tags this node provides.
+    pub fn with_capabilities<I, S>(mut self, caps: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.capabilities.extend(caps.into_iter().map(Into::into));
+        self
+    }
+}
+
+/// A model shard (one pipeline stage) with the governance requirements it
+/// imposes on any node that hosts it.
+#[derive(Debug, Clone)]
+pub struct ModelShard {
+    /// Stable shard identifier.
+    pub id: ShardId,
+    /// Position of this stage in the pipeline (0-based).
+    pub stage_index: usize,
+    /// Memory this shard requires, in MB.
+    pub required_memory_mb: u64,
+    /// Minimum trust tier a hosting node must satisfy.
+    pub min_trust_tier: TrustTier,
+    /// Residency constraint: `Some(zone)` pins the shard to nodes in `zone`;
+    /// `None` imposes no residency constraint.
+    pub residency: Option<ResidencyZone>,
+    /// Hardware capabilities a hosting node must provide (all of them).
+    pub required_capabilities: BTreeSet<String>,
+}
+
+impl ModelShard {
+    /// Construct a shard with no residency constraint, minimum trust tier
+    /// `TrustTier(0)`, and no required capabilities. Use the `with_*` builders
+    /// to tighten the governance requirements.
+    pub fn new(id: impl Into<String>, stage_index: usize, required_memory_mb: u64) -> Self {
+        Self {
+            id: ShardId::new(id),
+            stage_index,
+            required_memory_mb,
+            min_trust_tier: TrustTier(0),
+            residency: None,
+            required_capabilities: BTreeSet::new(),
+        }
+    }
+
+    /// Require a minimum trust tier of any hosting node.
+    pub fn with_min_trust(mut self, tier: TrustTier) -> Self {
+        self.min_trust_tier = tier;
+        self
+    }
+
+    /// Pin this shard to a residency zone.
+    pub fn with_residency(mut self, zone: ResidencyZone) -> Self {
+        self.residency = Some(zone);
+        self
+    }
+
+    /// Require hardware capabilities of any hosting node.
+    pub fn with_required_capabilities<I, S>(mut self, caps: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.required_capabilities
+            .extend(caps.into_iter().map(Into::into));
+        self
+    }
+}

--- a/crates/ruvllm/src/shard_placement/planner.rs
+++ b/crates/ruvllm/src/shard_placement/planner.rs
@@ -1,0 +1,347 @@
+//! The governed placement planner (PIR WP20, ruvector ADR-323).
+//!
+//! Given a set of pipeline-stage [`ModelShard`]s and a heterogeneous fleet of
+//! [`FleetNode`]s, [`PlacementPlanner::plan`] finds the **minimum
+//! latency/cost** assignment of shards → nodes that satisfies every hard
+//! governance constraint (residency, trust, hardware capability, and
+//! cumulative memory capacity), or **rejects** the request with a specific,
+//! structured [`PlacementRejection`] when no feasible assignment exists.
+//!
+//! ## Method
+//!
+//! Hard constraints are inviolable, so the planner first computes, per shard,
+//! the set of nodes that could ever host it (residency/trust/capability, plus
+//! per-shard memory fit on a node's full capacity). If any shard has *no*
+//! eligible node, the request is rejected immediately with a per-node reason.
+//!
+//! Cumulative memory capacity (one node hosting several shards) couples the
+//! choices, so the optimum is found by depth-first branch-and-bound over
+//! feasible complete assignments: candidate nodes are visited cheapest-first,
+//! a node's residual memory is decremented as shards are placed, and branches
+//! whose optimistic lower bound cannot beat the best complete assignment found
+//! so far are pruned. This yields the exact minimum-cost feasible placement
+//! for the small fleets this planner targets (a handful of stages across a
+//! handful of nodes), while still proving the governance property: an
+//! infeasible request is never silently satisfied on a violating node.
+
+use super::policy::{GovernancePolicy, NodeViolation};
+use super::{FleetNode, ModelShard, NodeId, ShardId};
+use std::collections::BTreeMap;
+
+/// Relative weighting of latency versus cost in the placement objective.
+/// Lower objective is better. Both default to `1.0`.
+#[derive(Debug, Clone, Copy)]
+pub struct ObjectiveWeights {
+    /// Weight applied to each node's `latency_ms`.
+    pub latency: f64,
+    /// Weight applied to each node's `cost_units`.
+    pub cost: f64,
+}
+
+impl Default for ObjectiveWeights {
+    fn default() -> Self {
+        Self {
+            latency: 1.0,
+            cost: 1.0,
+        }
+    }
+}
+
+/// A single shard-to-node assignment in a finished plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShardAssignment {
+    /// The placed shard.
+    pub shard: ShardId,
+    /// Its pipeline stage index.
+    pub stage_index: usize,
+    /// The node it was placed on.
+    pub node: NodeId,
+}
+
+/// A complete, governance-respecting placement of every shard.
+#[derive(Debug, Clone)]
+pub struct PlacementPlan {
+    /// One assignment per shard, in the order the shards were supplied.
+    pub assignments: Vec<ShardAssignment>,
+    /// Total latency/cost objective of this placement (lower is better).
+    pub total_objective: f64,
+    /// Memory consumed per node by this placement, in MB.
+    pub memory_used_mb: BTreeMap<NodeId, u64>,
+}
+
+impl PlacementPlan {
+    /// The node a given shard was placed on, if present in this plan.
+    pub fn node_for(&self, shard: &ShardId) -> Option<&NodeId> {
+        self.assignments
+            .iter()
+            .find(|a| &a.shard == shard)
+            .map(|a| &a.node)
+    }
+}
+
+/// Why a placement request could not be satisfied. A rejection is always
+/// returned instead of a plan that would violate a hard constraint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlacementRejection {
+    /// A shard has no individually-eligible node: every node in the fleet
+    /// violates at least one hard constraint for it. `violations` records each
+    /// node's (first) violation so the reason is specific and actionable.
+    NoEligibleNode {
+        /// The shard that cannot be placed anywhere.
+        shard: ShardId,
+        /// Per-node reasons (empty only when the fleet itself is empty).
+        violations: Vec<NodeViolation>,
+    },
+    /// Every shard is individually placeable, but no *complete* assignment fits
+    /// within the fleet's cumulative memory capacity (the shards collectively
+    /// exceed what the eligible nodes can jointly hold).
+    CapacityExhausted {
+        /// A shard the search could not fit given the others' placement.
+        shard: ShardId,
+        /// That shard's memory requirement, in MB.
+        required_mb: u64,
+        /// Total memory advertised across the fleet, in MB.
+        fleet_available_mb: u64,
+    },
+}
+
+impl std::fmt::Display for PlacementRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PlacementRejection::NoEligibleNode { shard, violations } => {
+                write!(
+                    f,
+                    "shard '{shard}' has no eligible node ({} candidate node(s) rejected): ",
+                    violations.len()
+                )?;
+                let joined = violations
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                f.write_str(&joined)
+            }
+            PlacementRejection::CapacityExhausted {
+                shard,
+                required_mb,
+                fleet_available_mb,
+            } => write!(
+                f,
+                "no feasible placement: shard '{shard}' ({required_mb} MB) does not fit given \
+                 cumulative fleet capacity ({fleet_available_mb} MB total across eligible nodes)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PlacementRejection {}
+
+/// The governed placement planner.
+#[derive(Debug, Clone)]
+pub struct PlacementPlanner {
+    weights: ObjectiveWeights,
+}
+
+impl Default for PlacementPlanner {
+    fn default() -> Self {
+        Self {
+            weights: ObjectiveWeights::default(),
+        }
+    }
+}
+
+impl PlacementPlanner {
+    /// Construct a planner with explicit objective weights.
+    pub fn new(weights: ObjectiveWeights) -> Self {
+        Self { weights }
+    }
+
+    /// Plan a placement of `shards` onto `nodes`.
+    ///
+    /// Returns the minimum-objective placement respecting all hard constraints,
+    /// or a [`PlacementRejection`] describing precisely why no feasible
+    /// placement exists. Shards are placed in the order supplied; the returned
+    /// `assignments` preserve that order.
+    pub fn plan(
+        &self,
+        shards: &[ModelShard],
+        nodes: &[FleetNode],
+    ) -> Result<PlacementPlan, PlacementRejection> {
+        // Trivially satisfiable: nothing to place.
+        if shards.is_empty() {
+            return Ok(PlacementPlan {
+                assignments: Vec::new(),
+                total_objective: 0.0,
+                memory_used_mb: BTreeMap::new(),
+            });
+        }
+
+        // Per-node objective cost (shard-independent in this model).
+        let node_cost: Vec<f64> = nodes
+            .iter()
+            .map(|n| self.weights.latency * n.latency_ms + self.weights.cost * n.cost_units)
+            .collect();
+
+        // Per-shard eligible-node lists (hard constraints against full node
+        // capacity), sorted cheapest-first for a deterministic optimal search.
+        let mut candidates: Vec<Vec<usize>> = Vec::with_capacity(shards.len());
+        for shard in shards {
+            let mut eligible: Vec<usize> = Vec::new();
+            for (ni, node) in nodes.iter().enumerate() {
+                if GovernancePolicy::is_eligible(shard, node).is_ok() {
+                    eligible.push(ni);
+                }
+            }
+            if eligible.is_empty() {
+                // Governance: reject with a specific per-node reason rather
+                // than placing the shard on any violating node.
+                let violations = nodes
+                    .iter()
+                    .map(|node| NodeViolation {
+                        node: node.id.clone(),
+                        // Safe: `is_eligible` returned Err for every node here.
+                        violation: GovernancePolicy::is_eligible(shard, node)
+                            .expect_err("node was not eligible"),
+                    })
+                    .collect();
+                return Err(PlacementRejection::NoEligibleNode {
+                    shard: shard.id.clone(),
+                    violations,
+                });
+            }
+            eligible.sort_by(|&a, &b| {
+                node_cost[a]
+                    .partial_cmp(&node_cost[b])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then(a.cmp(&b))
+            });
+            candidates.push(eligible);
+        }
+
+        // Optimistic per-shard minimum cost = cheapest eligible node's cost.
+        let min_cost: Vec<f64> = candidates.iter().map(|c| node_cost[c[0]]).collect();
+        // suffix_min[i] = sum of min_cost[i..], a lower bound on the remaining
+        // objective once shard `i` onward are placed.
+        let mut suffix_min = vec![0.0f64; shards.len() + 1];
+        for i in (0..shards.len()).rev() {
+            suffix_min[i] = suffix_min[i + 1] + min_cost[i];
+        }
+
+        let mut residual: Vec<u64> = nodes.iter().map(|n| n.available_memory_mb).collect();
+        let mut assign: Vec<usize> = vec![usize::MAX; shards.len()];
+        let mut best_cost = f64::INFINITY;
+        let mut best_assign: Option<Vec<usize>> = None;
+        let mut deepest = 0usize;
+
+        search(
+            0,
+            shards,
+            &candidates,
+            &node_cost,
+            &suffix_min,
+            &mut residual,
+            &mut assign,
+            0.0,
+            &mut best_cost,
+            &mut best_assign,
+            &mut deepest,
+        );
+
+        let best = match best_assign {
+            Some(b) => b,
+            None => {
+                // Every shard is individually placeable, but cumulative
+                // capacity cannot hold them all — reject, do not overcommit.
+                let fleet_available_mb: u64 =
+                    nodes.iter().map(|n| n.available_memory_mb).sum();
+                let stuck = &shards[deepest.min(shards.len() - 1)];
+                return Err(PlacementRejection::CapacityExhausted {
+                    shard: stuck.id.clone(),
+                    required_mb: stuck.required_memory_mb,
+                    fleet_available_mb,
+                });
+            }
+        };
+
+        let mut memory_used_mb: BTreeMap<NodeId, u64> = BTreeMap::new();
+        let mut assignments = Vec::with_capacity(shards.len());
+        let mut total_objective = 0.0;
+        for (i, shard) in shards.iter().enumerate() {
+            let ni = best[i];
+            let node = &nodes[ni];
+            assignments.push(ShardAssignment {
+                shard: shard.id.clone(),
+                stage_index: shard.stage_index,
+                node: node.id.clone(),
+            });
+            *memory_used_mb.entry(node.id.clone()).or_insert(0) += shard.required_memory_mb;
+            total_objective += node_cost[ni];
+        }
+
+        Ok(PlacementPlan {
+            assignments,
+            total_objective,
+            memory_used_mb,
+        })
+    }
+}
+
+/// Depth-first branch-and-bound over feasible complete assignments. Places
+/// shard `i`, respecting cumulative residual memory, and records the minimum-
+/// cost complete assignment in `best_assign`.
+#[allow(clippy::too_many_arguments)]
+fn search(
+    i: usize,
+    shards: &[ModelShard],
+    candidates: &[Vec<usize>],
+    node_cost: &[f64],
+    suffix_min: &[f64],
+    residual: &mut [u64],
+    assign: &mut [usize],
+    cur_cost: f64,
+    best_cost: &mut f64,
+    best_assign: &mut Option<Vec<usize>>,
+    deepest: &mut usize,
+) {
+    if i > *deepest {
+        *deepest = i;
+    }
+    if i == shards.len() {
+        if cur_cost < *best_cost {
+            *best_cost = cur_cost;
+            *best_assign = Some(assign.to_vec());
+        }
+        return;
+    }
+    // Prune: even the most optimistic completion cannot beat the incumbent.
+    if cur_cost + suffix_min[i] >= *best_cost {
+        return;
+    }
+
+    let need = shards[i].required_memory_mb;
+    for &ni in &candidates[i] {
+        if residual[ni] < need {
+            continue; // cumulative capacity: this node is already too full
+        }
+        residual[ni] -= need;
+        assign[i] = ni;
+        let next_cost = cur_cost + node_cost[ni];
+        if next_cost + suffix_min[i + 1] < *best_cost {
+            search(
+                i + 1,
+                shards,
+                candidates,
+                node_cost,
+                suffix_min,
+                residual,
+                assign,
+                next_cost,
+                best_cost,
+                best_assign,
+                deepest,
+            );
+        }
+        residual[ni] += need;
+        assign[i] = usize::MAX;
+    }
+}

--- a/crates/ruvllm/src/shard_placement/policy.rs
+++ b/crates/ruvllm/src/shard_placement/policy.rs
@@ -1,0 +1,163 @@
+//! Governance policy: the hard-constraint eligibility check for placing a
+//! single shard on a single node (PIR WP20, ruvector ADR-323).
+//!
+//! ADR-323 makes the split explicit: **residency, trust, and hardware
+//! capability are inviolable hard constraints**; latency/cost only optimize
+//! *within* the feasible set. This module owns the hard-constraint check for
+//! one `(shard, node)` pair. Cumulative memory capacity (a node hosting
+//! several shards) is a hard constraint too, but it is a property of a whole
+//! assignment, so the planner enforces it by passing the node's *residual*
+//! memory into [`GovernancePolicy::check`].
+
+use super::{FleetNode, ModelShard, NodeId, ResidencyZone, TrustTier};
+use std::collections::BTreeSet;
+
+/// A single hard-constraint violation explaining why a node is ineligible to
+/// host a shard. Ordered by the check sequence in [`GovernancePolicy::check`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConstraintViolation {
+    /// The shard is pinned to a residency zone the node is not in.
+    Residency {
+        /// Zone the shard's data is tagged for.
+        required: ResidencyZone,
+        /// Zone the node actually lives in.
+        node_zone: ResidencyZone,
+    },
+    /// The node's trust tier is below the shard's minimum.
+    Trust {
+        /// Minimum tier the shard requires.
+        required: TrustTier,
+        /// Tier the node satisfies.
+        node_tier: TrustTier,
+    },
+    /// The node is missing one or more hardware capabilities the shard needs.
+    Capability {
+        /// Capabilities the shard requires that the node does not provide.
+        missing: BTreeSet<String>,
+    },
+    /// The (residual) memory available on the node is below the shard's need.
+    Capacity {
+        /// Memory the shard requires, in MB.
+        required_mb: u64,
+        /// Memory available on the node at check time, in MB.
+        available_mb: u64,
+    },
+}
+
+impl std::fmt::Display for ConstraintViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConstraintViolation::Residency {
+                required,
+                node_zone,
+            } => write!(
+                f,
+                "residency: shard requires zone '{required}' but node is in '{node_zone}'"
+            ),
+            ConstraintViolation::Trust {
+                required,
+                node_tier,
+            } => write!(
+                f,
+                "trust: shard requires tier >= {required} but node is {node_tier}"
+            ),
+            ConstraintViolation::Capability { missing } => {
+                let list = missing
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "capability: node is missing [{list}]")
+            }
+            ConstraintViolation::Capacity {
+                required_mb,
+                available_mb,
+            } => write!(
+                f,
+                "capacity: shard needs {required_mb} MB but node has {available_mb} MB available"
+            ),
+        }
+    }
+}
+
+/// One node's ineligibility, pairing the node with its (first) violation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeViolation {
+    /// The ineligible node.
+    pub node: NodeId,
+    /// Why it is ineligible.
+    pub violation: ConstraintViolation,
+}
+
+impl std::fmt::Display for NodeViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "node '{}': {}", self.node, self.violation)
+    }
+}
+
+/// The stateless governance policy — a pure hard-constraint checker.
+pub struct GovernancePolicy;
+
+impl GovernancePolicy {
+    /// Check whether `shard` may be placed on `node` given `available_mb` of
+    /// residual memory on that node.
+    ///
+    /// Returns the **first** violated hard constraint, checked in the order
+    /// residency → trust → capability → capacity, or `Ok(())` if the node is
+    /// eligible. Residency/trust/capability are node-intrinsic and never
+    /// change with load; capacity is checked against the residual memory the
+    /// caller supplies so the same routine enforces cumulative capacity during
+    /// assignment.
+    pub fn check(
+        shard: &ModelShard,
+        node: &FleetNode,
+        available_mb: u64,
+    ) -> Result<(), ConstraintViolation> {
+        // 1. Residency — inviolable. A shard tagged for a zone must not cross
+        //    the boundary onto a node in a different zone.
+        if let Some(required) = &shard.residency {
+            if &node.residency_zone != required {
+                return Err(ConstraintViolation::Residency {
+                    required: required.clone(),
+                    node_zone: node.residency_zone.clone(),
+                });
+            }
+        }
+
+        // 2. Trust — inviolable. A shard above trust tier T only on nodes >= T.
+        if node.trust_tier < shard.min_trust_tier {
+            return Err(ConstraintViolation::Trust {
+                required: shard.min_trust_tier,
+                node_tier: node.trust_tier,
+            });
+        }
+
+        // 3. Hardware capability — inviolable. The node must provide every
+        //    capability the shard requires.
+        let missing: BTreeSet<String> = shard
+            .required_capabilities
+            .difference(&node.capabilities)
+            .cloned()
+            .collect();
+        if !missing.is_empty() {
+            return Err(ConstraintViolation::Capability { missing });
+        }
+
+        // 4. Capacity — inviolable. The shard must fit in the residual memory.
+        if available_mb < shard.required_memory_mb {
+            return Err(ConstraintViolation::Capacity {
+                required_mb: shard.required_memory_mb,
+                available_mb,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Convenience check against a node's *full* advertised capacity — the
+    /// eligibility test used before any load is assigned (i.e. "could this
+    /// shard ever live on this node in isolation?").
+    pub fn is_eligible(shard: &ModelShard, node: &FleetNode) -> Result<(), ConstraintViolation> {
+        Self::check(shard, node, node.available_memory_mb)
+    }
+}

--- a/crates/ruvllm/src/shard_placement/tests.rs
+++ b/crates/ruvllm/src/shard_placement/tests.rs
@@ -1,0 +1,409 @@
+//! Unit tests for the governed pipeline-shard placement planner
+//! (PIR WP20, ruvector ADR-323).
+//!
+//! The tests exercise the governance property that is the point of ADR-323:
+//! hard constraints (residency, trust, hardware capability, cumulative memory
+//! capacity) are inviolable and an infeasible request is rejected with a
+//! specific reason — never silently placed on a violating node — while the
+//! latency/cost objective only optimizes *among* feasible placements.
+
+use super::planner::{ObjectiveWeights, PlacementPlanner, PlacementRejection};
+use super::policy::{ConstraintViolation, GovernancePolicy};
+use super::{FleetNode, ModelShard, NodeId, ResidencyZone, ShardId, TrustTier};
+
+/// Assert a finished plan places every shard exactly once and that each
+/// placement satisfies all hard constraints against the node it landed on
+/// (including cumulative memory capacity per node).
+fn assert_plan_respects_constraints(
+    plan: &super::planner::PlacementPlan,
+    shards: &[ModelShard],
+    nodes: &[FleetNode],
+) {
+    // Exactly one assignment per shard, no shard missing or duplicated.
+    assert_eq!(plan.assignments.len(), shards.len());
+    let mut seen: Vec<&ShardId> = plan.assignments.iter().map(|a| &a.shard).collect();
+    seen.sort();
+    seen.dedup();
+    assert_eq!(seen.len(), shards.len(), "each shard placed exactly once");
+
+    let node_by_id = |id: &NodeId| nodes.iter().find(|n| &n.id == id).unwrap();
+    let shard_by_id = |id: &ShardId| shards.iter().find(|s| &s.id == id).unwrap();
+
+    // Per-node cumulative memory must never exceed the node's capacity.
+    for (node_id, used) in &plan.memory_used_mb {
+        let node = node_by_id(node_id);
+        assert!(
+            *used <= node.available_memory_mb,
+            "node {node_id} over capacity: used {used} > {}",
+            node.available_memory_mb
+        );
+    }
+
+    // Every individual placement satisfies residency/trust/capability/capacity.
+    for a in &plan.assignments {
+        let shard = shard_by_id(&a.shard);
+        let node = node_by_id(&a.node);
+        // Residency.
+        if let Some(zone) = &shard.residency {
+            assert_eq!(&node.residency_zone, zone, "residency respected for {}", a.shard);
+        }
+        // Trust.
+        assert!(
+            node.trust_tier >= shard.min_trust_tier,
+            "trust respected for {}",
+            a.shard
+        );
+        // Capability.
+        assert!(
+            shard.required_capabilities.is_subset(&node.capabilities),
+            "capability respected for {}",
+            a.shard
+        );
+        // Per-shard fit.
+        assert!(
+            shard.required_memory_mb <= node.available_memory_mb,
+            "capacity respected for {}",
+            a.shard
+        );
+    }
+}
+
+/// (1) A satisfiable placement produces a valid assignment respecting all hard
+/// constraints.
+#[test]
+fn satisfiable_placement_produces_valid_assignment() {
+    let shards = vec![
+        ModelShard::new("stage-0", 0, 4000)
+            .with_min_trust(TrustTier(2))
+            .with_residency(ResidencyZone::new("eu")),
+        ModelShard::new("stage-1", 1, 4000)
+            .with_min_trust(TrustTier(1))
+            .with_required_capabilities(["int4"]),
+    ];
+    let nodes = vec![
+        FleetNode::new("eu-a", ResidencyZone::new("eu"), TrustTier(3), 8000)
+            .with_profile(10.0, 1.0)
+            .with_capabilities(["int4", "avx512"]),
+        FleetNode::new("eu-b", ResidencyZone::new("eu"), TrustTier(2), 8000)
+            .with_profile(20.0, 1.0)
+            .with_capabilities(["int4"]),
+    ];
+
+    let plan = PlacementPlanner::default().plan(&shards, &nodes).unwrap();
+    assert_plan_respects_constraints(&plan, &shards, &nodes);
+}
+
+/// (2) A residency-violating candidate is rejected — not silently placed.
+#[test]
+fn residency_violation_is_rejected() {
+    // Shard's data is tagged for `eu`; the whole fleet is in `us`.
+    let shards = vec![ModelShard::new("stage-0", 0, 1000).with_residency(ResidencyZone::new("eu"))];
+    let nodes = vec![
+        FleetNode::new("us-a", ResidencyZone::new("us"), TrustTier(9), 64_000),
+        FleetNode::new("us-b", ResidencyZone::new("us"), TrustTier(9), 64_000),
+    ];
+
+    let err = PlacementPlanner::default()
+        .plan(&shards, &nodes)
+        .unwrap_err();
+    match err {
+        PlacementRejection::NoEligibleNode { shard, violations } => {
+            assert_eq!(shard, ShardId::new("stage-0"));
+            assert_eq!(violations.len(), 2);
+            for v in &violations {
+                assert!(
+                    matches!(v.violation, ConstraintViolation::Residency { .. }),
+                    "expected residency violation, got {:?}",
+                    v.violation
+                );
+            }
+        }
+        other => panic!("expected NoEligibleNode(residency), got {other:?}"),
+    }
+}
+
+/// (3) A trust-violating candidate is rejected.
+#[test]
+fn trust_violation_is_rejected() {
+    // Shard needs trust tier >= 5; every node is only tier 1.
+    let shards = vec![ModelShard::new("stage-0", 0, 1000).with_min_trust(TrustTier(5))];
+    let nodes = vec![
+        FleetNode::new("low-a", ResidencyZone::new("us"), TrustTier(1), 64_000),
+        FleetNode::new("low-b", ResidencyZone::new("us"), TrustTier(4), 64_000),
+    ];
+
+    let err = PlacementPlanner::default()
+        .plan(&shards, &nodes)
+        .unwrap_err();
+    match err {
+        PlacementRejection::NoEligibleNode { shard, violations } => {
+            assert_eq!(shard, ShardId::new("stage-0"));
+            assert_eq!(violations.len(), 2);
+            for v in &violations {
+                assert!(
+                    matches!(
+                        v.violation,
+                        ConstraintViolation::Trust {
+                            required: TrustTier(5),
+                            ..
+                        }
+                    ),
+                    "expected trust violation, got {:?}",
+                    v.violation
+                );
+            }
+        }
+        other => panic!("expected NoEligibleNode(trust), got {other:?}"),
+    }
+}
+
+/// (4) A capacity-overflowing shard (larger than any single node) is rejected.
+#[test]
+fn capacity_overflow_is_rejected() {
+    // Shard needs 100 GB; no single node has that much.
+    let shards = vec![ModelShard::new("stage-0", 0, 100_000)];
+    let nodes = vec![
+        FleetNode::new("small-a", ResidencyZone::new("us"), TrustTier(9), 16_000),
+        FleetNode::new("small-b", ResidencyZone::new("us"), TrustTier(9), 24_000),
+    ];
+
+    let err = PlacementPlanner::default()
+        .plan(&shards, &nodes)
+        .unwrap_err();
+    match err {
+        PlacementRejection::NoEligibleNode { shard, violations } => {
+            assert_eq!(shard, ShardId::new("stage-0"));
+            for v in &violations {
+                assert!(
+                    matches!(
+                        v.violation,
+                        ConstraintViolation::Capacity {
+                            required_mb: 100_000,
+                            ..
+                        }
+                    ),
+                    "expected capacity violation, got {:?}",
+                    v.violation
+                );
+            }
+        }
+        other => panic!("expected NoEligibleNode(capacity), got {other:?}"),
+    }
+}
+
+/// (5) A hardware-capability-violating candidate is rejected (ADR-323's
+/// hardware-capability hard constraint, mirroring the paper's INT4/Lunar-Lake
+/// hardware specificity).
+#[test]
+fn capability_violation_is_rejected() {
+    let shards =
+        vec![ModelShard::new("stage-0", 0, 1000).with_required_capabilities(["int4", "npu"])];
+    let nodes = vec![
+        FleetNode::new("cpu-a", ResidencyZone::new("us"), TrustTier(9), 64_000)
+            .with_capabilities(["int4"]), // missing "npu"
+        FleetNode::new("cpu-b", ResidencyZone::new("us"), TrustTier(9), 64_000)
+            .with_capabilities(["avx512"]), // missing both
+    ];
+
+    let err = PlacementPlanner::default()
+        .plan(&shards, &nodes)
+        .unwrap_err();
+    match err {
+        PlacementRejection::NoEligibleNode { violations, .. } => {
+            for v in &violations {
+                assert!(
+                    matches!(v.violation, ConstraintViolation::Capability { .. }),
+                    "expected capability violation, got {:?}",
+                    v.violation
+                );
+            }
+        }
+        other => panic!("expected NoEligibleNode(capability), got {other:?}"),
+    }
+}
+
+/// (6) Among multiple feasible placements, the planner picks the lower
+/// latency/cost one.
+#[test]
+fn picks_lowest_latency_cost_among_feasible() {
+    let shards = vec![ModelShard::new("stage-0", 0, 4000)];
+    // Both nodes are fully eligible; they differ only in latency.
+    let nodes = vec![
+        FleetNode::new("slow", ResidencyZone::new("us"), TrustTier(5), 8000).with_profile(30.0, 1.0),
+        FleetNode::new("fast", ResidencyZone::new("us"), TrustTier(5), 8000).with_profile(5.0, 1.0),
+    ];
+
+    let plan = PlacementPlanner::default().plan(&shards, &nodes).unwrap();
+    assert_eq!(plan.assignments.len(), 1);
+    assert_eq!(
+        plan.assignments[0].node,
+        NodeId::new("fast"),
+        "planner must choose the lower latency/cost node"
+    );
+    // objective = latency*1 + cost*1 = 5 + 1 = 6 for the "fast" node.
+    assert!((plan.total_objective - 6.0).abs() < 1e-9);
+}
+
+/// (6b) Objective weighting steers the choice: weighting cost heavily flips the
+/// pick to the cheaper-but-slower node, proving latency/cost optimization
+/// happens strictly within the feasible set.
+#[test]
+fn objective_weights_steer_choice_within_feasible_set() {
+    let shards = vec![ModelShard::new("stage-0", 0, 4000)];
+    let nodes = vec![
+        // Fast but expensive.
+        FleetNode::new("fast-pricey", ResidencyZone::new("us"), TrustTier(5), 8000)
+            .with_profile(5.0, 100.0),
+        // Slow but cheap.
+        FleetNode::new("slow-cheap", ResidencyZone::new("us"), TrustTier(5), 8000)
+            .with_profile(40.0, 1.0),
+    ];
+
+    // Latency-only weighting → fast node.
+    let latency_plan = PlacementPlanner::new(ObjectiveWeights {
+        latency: 1.0,
+        cost: 0.0,
+    })
+    .plan(&shards, &nodes)
+    .unwrap();
+    assert_eq!(latency_plan.assignments[0].node, NodeId::new("fast-pricey"));
+
+    // Cost-only weighting → cheap node.
+    let cost_plan = PlacementPlanner::new(ObjectiveWeights {
+        latency: 0.0,
+        cost: 1.0,
+    })
+    .plan(&shards, &nodes)
+    .unwrap();
+    assert_eq!(cost_plan.assignments[0].node, NodeId::new("slow-cheap"));
+}
+
+/// (7) The 4-node/70B feasibility case: a model whose shards fit collectively
+/// across the fleet but not on any single node. This is the *separate*
+/// 4-node/70B result of arXiv:2608.19147 (single-user interactive serving) —
+/// NOT the 2-node/8B 1.79× throughput result. Here we prove only the
+/// placement-feasibility shape: no node can hold the whole model, yet a valid
+/// governed placement exists that spreads the shards across the fleet.
+#[test]
+fn four_node_seventy_b_fits_collectively_not_singly() {
+    // A ~70B-class model split into 4 pipeline stages of 20 GB each (80 GB
+    // total). Each Lunar-Lake-class node advertises 24 GB — enough for one
+    // stage, never for two (2 * 20 GB = 40 GB > 24 GB), and never for the
+    // whole 80 GB model.
+    let stage_mb = 20_000u64;
+    let node_mb = 24_000u64;
+    let shards: Vec<ModelShard> = (0..4)
+        .map(|i| ModelShard::new(format!("stage-{i}"), i, stage_mb).with_min_trust(TrustTier(1)))
+        .collect();
+    let nodes: Vec<FleetNode> = (0..4)
+        .map(|i| {
+            FleetNode::new(
+                format!("lunar-{i}"),
+                ResidencyZone::new("eu"),
+                TrustTier(2),
+                node_mb,
+            )
+            .with_profile(10.0 + i as f64, 1.0)
+        })
+        .collect();
+
+    // Precondition: the whole model does NOT fit on any single node.
+    let total_model_mb: u64 = shards.iter().map(|s| s.required_memory_mb).sum();
+    assert!(
+        nodes.iter().all(|n| n.available_memory_mb < total_model_mb),
+        "test premise: no single node can hold the whole model"
+    );
+    // Precondition: it DOES fit collectively.
+    let fleet_mb: u64 = nodes.iter().map(|n| n.available_memory_mb).sum();
+    assert!(fleet_mb >= total_model_mb, "test premise: fleet holds it jointly");
+
+    let plan = PlacementPlanner::default().plan(&shards, &nodes).unwrap();
+    assert_plan_respects_constraints(&plan, &shards, &nodes);
+
+    // With one 20 GB stage per 24 GB node and no room for two, the four stages
+    // must land on four distinct nodes.
+    let mut used_nodes: Vec<&NodeId> = plan.assignments.iter().map(|a| &a.node).collect();
+    used_nodes.sort();
+    used_nodes.dedup();
+    assert_eq!(
+        used_nodes.len(),
+        4,
+        "each 20 GB stage must occupy its own 24 GB node"
+    );
+}
+
+/// (7b) Cumulative-capacity exhaustion: shards are each individually placeable
+/// but collectively exceed the fleet — rejected, never overcommitted.
+#[test]
+fn cumulative_capacity_exhaustion_is_rejected() {
+    // Three 20 GB stages (60 GB) but only two 24 GB nodes (48 GB total). Each
+    // stage fits a node individually; all three cannot fit together.
+    let shards: Vec<ModelShard> = (0..3)
+        .map(|i| ModelShard::new(format!("stage-{i}"), i, 20_000))
+        .collect();
+    let nodes = vec![
+        FleetNode::new("n0", ResidencyZone::new("eu"), TrustTier(2), 24_000),
+        FleetNode::new("n1", ResidencyZone::new("eu"), TrustTier(2), 24_000),
+    ];
+
+    // Sanity: each shard is individually eligible on each node.
+    for s in &shards {
+        for n in &nodes {
+            assert!(GovernancePolicy::is_eligible(s, n).is_ok());
+        }
+    }
+
+    let err = PlacementPlanner::default()
+        .plan(&shards, &nodes)
+        .unwrap_err();
+    match err {
+        PlacementRejection::CapacityExhausted {
+            required_mb,
+            fleet_available_mb,
+            ..
+        } => {
+            assert_eq!(required_mb, 20_000);
+            assert_eq!(fleet_available_mb, 48_000);
+        }
+        other => panic!("expected CapacityExhausted, got {other:?}"),
+    }
+}
+
+/// (8) The 2-node/8B configuration places validly. This is the configuration
+/// the paper's 1.79× concurrent-throughput figure applies to — and ONLY that
+/// configuration; this test asserts placement feasibility, not throughput.
+#[test]
+fn two_node_eight_b_places_validly() {
+    // An 8B-INT4-class model in two pipeline stages, ~2.4 GB each, on two
+    // same-family nodes advertising INT4 support.
+    let shards = vec![
+        ModelShard::new("stage-0", 0, 2400).with_required_capabilities(["int4"]),
+        ModelShard::new("stage-1", 1, 2400).with_required_capabilities(["int4"]),
+    ];
+    let nodes = vec![
+        FleetNode::new("aipc-0", ResidencyZone::new("eu"), TrustTier(2), 8000)
+            .with_profile(8.0, 1.0)
+            .with_capabilities(["int4"]),
+        FleetNode::new("aipc-1", ResidencyZone::new("eu"), TrustTier(2), 8000)
+            .with_profile(9.0, 1.0)
+            .with_capabilities(["int4"]),
+    ];
+
+    let plan = PlacementPlanner::default().plan(&shards, &nodes).unwrap();
+    assert_plan_respects_constraints(&plan, &shards, &nodes);
+    assert_eq!(plan.assignments.len(), 2);
+}
+
+/// Empty shard set is trivially satisfiable (nothing to place).
+#[test]
+fn empty_shard_set_is_trivially_satisfiable() {
+    let nodes = vec![FleetNode::new(
+        "n0",
+        ResidencyZone::new("eu"),
+        TrustTier(1),
+        8000,
+    )];
+    let plan = PlacementPlanner::default().plan(&[], &nodes).unwrap();
+    assert!(plan.assignments.is_empty());
+    assert_eq!(plan.total_objective, 0.0);
+}


### PR DESCRIPTION
## Summary

First shippable slice of **PIR WP20** (#867), implementing **ruvector ADR-323 — Governed Pipeline-Shard Placement** (which *extends* ruvector ADR-314 / WP13's KV-cache cross-model migration, both living in `crates/ruvllm`). Part of the RuV Perpetual Intelligence Runtime, Wave 2 (epic #837).

Per ADR-323, the RuV-native contribution is **not distributed inference itself** but **governed placement**: deciding which pipeline-stage shard runs on which fleet node, subject to inviolable governance constraints. This slice ships exactly that — the placement **planner + governance policy** — and nothing beyond it.

## Host decision

New module **`crates/ruvllm/src/shard_placement/`** (`mod.rs` types, `policy.rs` hard-constraint checker, `planner.rs` branch-and-bound solver, `tests.rs`), gated behind a default-OFF **`shard-placement`** Cargo feature. Justification:

- ADR-323 §Affected Repos scopes the work to `ruvnet/ruvector` only, `crates/ruvllm`, and ADR-323 *extends* ADR-314 whose code lives in `crates/ruvllm/src/kv_migration/`. Placement is a governance policy **over ruvllm's serving**, so it belongs beside its sibling capability, not in a standalone crate.
- The slice mirrors WP13's structure exactly: a self-contained module behind a default-OFF feature (`kv-migration` → `shard-placement`), so the default `ruvllm` build is provably unaffected.
- The module deliberately does **not** touch the three coordinated serving files (`kv_cache.rs`, `paged_attention.rs`, `serving/kv_cache_manager.rs`) that ADR-323 flags for WP13 merge-conflict coordination — it is net-new placement-policy surface, so there is **no conflict overlap** with the open WP13 PR.

## What the planner does

- Models `ModelShard`s (pipeline stages, each with a memory requirement, min trust tier, optional residency zone, required hardware capabilities) and `FleetNode`s (residency zone, trust tier, available memory, capability tags, latency/cost profile).
- `PlacementPlanner::plan` assigns shards → nodes subject to **hard constraints** (residency, trust, hardware capability, cumulative memory capacity), minimizing a latency/cost objective **only among feasible placements** (DFS branch-and-bound with a suffix-min lower bound → exact optimum for the small fleets targeted).
- **The governance is the point:** an infeasible placement is **rejected with a specific, structured `PlacementRejection`** (which shard, which constraint, per node) — never silently placed on a violating node.

## Citation discipline (ADR-323, binding)

arXiv:2608.19147, "Pre-Compiled Pipeline Shards for Distributed LLM Inference on Intel AI PC Fleets" reports **two separate results**, kept distinct here and **never conflated into one headline number**:

- **1.79× concurrent throughput** — applies **only** to the **two-node / Llama-3.1-8B-INT4** configuration ("serves two concurrent users at 1.79x the single-user throughput of the unsplit model on the same hardware").
- **Four-node Lunar Lake, 70B, interactive single-user serving** — a **separate** result (5.72 tok/s single-stream at 72.2% accept rate, 6.43 tok/s aggregate two-stream), with **no 1.79× figure attached**. Its relevance to this slice is purely the **feasibility shape**: a model whose shards fit collectively across the fleet but on no single node.

**Preprint-reproduction rule:** the paper's figures are the target shape to reproduce internally, never numbers this program cites as its own without independently measuring them (ADR-323; ADR-306 promotion gating). This slice measures no throughput — it is the placement planner only.

## Tests (11, all green)

| Test | Proves |
|------|--------|
| `satisfiable_placement_produces_valid_assignment` | valid assignment respects every hard constraint |
| `residency_violation_is_rejected` | residency-violating candidate rejected with reason |
| `trust_violation_is_rejected` | trust-violating candidate rejected with reason |
| `capacity_overflow_is_rejected` | shard larger than any node rejected with reason |
| `capability_violation_is_rejected` | missing-hardware-capability candidate rejected |
| `cumulative_capacity_exhaustion_is_rejected` | shards individually placeable but collectively over-capacity → rejected, never overcommitted |
| `picks_lowest_latency_cost_among_feasible` | among feasible placements, picks the lower latency/cost one |
| `objective_weights_steer_choice_within_feasible_set` | latency/cost optimization happens strictly within the feasible set |
| `four_node_seventy_b_fits_collectively_not_singly` | **4-node/70B** feasibility: no single node holds the model, yet a valid governed placement spreads shards across the fleet |
| `two_node_eight_b_places_validly` | **2-node/8B** configuration places validly |
| `empty_shard_set_is_trivially_satisfiable` | degenerate input handled |

```
cargo test -p ruvllm --features shard-placement --lib shard_placement
test result: ok. 11 passed; 0 failed; 0 ignored
cargo check -p ruvllm            # default features, feature OFF → clean, no default-build impact
cargo clippy -p ruvllm --features shard-placement --lib   # clean
```

## Planner-only vs deferred (honest scope)

**In this slice:** the placement planner + governance policy (hard-constraint feasibility, structured rejection, latency/cost optimization among feasible placements).

**Deferred follow-ups:** real OpenVINO per-stage shard compilation (incl. the `beam_idx`-Gather / `IndirectKVCache` fusion detail), actual distributed execution / inter-node transport, speculative decoding on stateful sharded models, live request-specific KV-state routing, and wiring node trust to this program's witness chain (ADR-134 / ADR-312) — node trust is an input attribute here.

Refs #867, #837.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)