### PR TITLE
fix: close two LOW security residuals — caseId FS-collision + shard-placement input bound (PIR hardening)

### DIFF
--- a/crates/ruvector-sota-bench/harness/src/harnessRiskCases.ts
+++ b/crates/ruvector-sota-bench/harness/src/harnessRiskCases.ts
@@ -73,6 +73,38 @@ export function assertSafeCaseId(caseId: string): void {
   }
 }
 
+/**
+ * Reject a loaded case set in which two distinct case_ids collide once
+ * lowercased (PIR WP15 case-insensitive-FS follow-up, #862).
+ *
+ * Each case_id becomes a `${caseId}.state.json` filename in
+ * rvfWorkspaceBinder.bindWorkspace. assertSafeCaseId confines the charset (no
+ * traversal) but still admits case-only-distinct ids like "setup_1" and
+ * "Setup_1". On a case-INSENSITIVE filesystem (macOS/Windows dev machines; not
+ * Linux CI) those two ids resolve to the SAME state file, so one case's commit
+ * silently overwrites the other's — cross-contaminating workspace state and
+ * letting a case forge or mask the integrity signal the acceptance test reads.
+ *
+ * Detect the collision at load time (the boundary), so the readable, debuggable
+ * per-case filenames are kept intact. Ids that stay distinct when lowercased
+ * (e.g. "setup_1" / "setup_2") are fine.
+ */
+export function assertNoCaseIdCollisions(cases: readonly { caseId: string }[]): void {
+  const seenByStateFile = new Map<string, string>();
+  for (const { caseId } of cases) {
+    const stateFile = `${caseId.toLowerCase()}.state.json`;
+    const prior = seenByStateFile.get(stateFile);
+    if (prior !== undefined) {
+      throw new Error(
+        `case_id collision: ${JSON.stringify(prior)} and ${JSON.stringify(caseId)} both resolve ` +
+          `to the same state file ${JSON.stringify(stateFile)} on a case-insensitive filesystem ` +
+          "(macOS/Windows) — rename one so all case_ids are distinct ignoring case",
+      );
+    }
+    seenByStateFile.set(stateFile, caseId);
+  }
+}
+
 /** Resolve a phase from the row's phase column, falling back to the case-id prefix. */
 export function normalizePhase(raw: unknown, caseId: string): LifecyclePhase {
   if (typeof raw === "string" && PHASE_SET.has(raw)) return raw as LifecyclePhase;
@@ -177,6 +209,9 @@ export async function fetchHarnessRiskCases(
         "refusing a partial baseline (pass requireFullCaseSet:false to override)",
     );
   }
+  // Two case-only-distinct ids would share one .state.json on a case-insensitive
+  // FS and cross-contaminate workspace state — reject the whole set at load.
+  assertNoCaseIdCollisions(cases);
   return cases;
 }
 

--- a/crates/ruvector-sota-bench/harness/test/harnessRisk.test.ts
+++ b/crates/ruvector-sota-bench/harness/test/harnessRisk.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../src/harnessRisk.js";
 import { composeVetoProviders, type VetoContext } from "../src/vetoes.js";
 import {
+  assertNoCaseIdCollisions,
   EXPECTED_UPSTREAM_CASE_COUNT,
   FIRST_PARTY_EXAMPLE_CASES,
   fetchHarnessRiskCases,
@@ -259,6 +260,41 @@ test("parseHarnessRiskRow confines case_id to a safe filename charset (path-trav
   for (const good of ["setup_001", "action_016", "case.v2-final_A1", "memory_fp001"]) {
     assert.equal(parseHarnessRiskRow(row(good)).caseId, good);
   }
+});
+
+test("assertNoCaseIdCollisions rejects case-only-distinct ids and passes distinct-ignoring-case ids", () => {
+  // "setup_1" and "Setup_1" resolve to the same setup_1.state.json on a
+  // case-insensitive FS (macOS/Windows) — must be rejected at load time.
+  assert.throws(
+    () => assertNoCaseIdCollisions([{ caseId: "setup_1" }, { caseId: "Setup_1" }]),
+    /case_id collision.*case-insensitive/s,
+  );
+  // Ids that remain distinct once lowercased are fine.
+  assert.doesNotThrow(() =>
+    assertNoCaseIdCollisions([{ caseId: "setup_1" }, { caseId: "setup_2" }, { caseId: "Setup_3" }]),
+  );
+  // The shipped first-party example set is collision-free.
+  assert.doesNotThrow(() => assertNoCaseIdCollisions(FIRST_PARTY_EXAMPLE_CASES));
+});
+
+test("fetchHarnessRiskCases rejects a loaded set whose ids collide ignoring case", async () => {
+  const row = (case_id: string) => ({
+    case_id,
+    title: case_id,
+    phase: "setup_configuration",
+    user_messages: ["do the task"],
+  });
+  // A single page carrying two case-only-distinct ids — the loader must refuse
+  // the set rather than hand back two cases that share one state file.
+  const collidingFetch = ((url: string) => {
+    const offset = Number(new URL(url).searchParams.get("offset"));
+    const rows = offset === 0 ? [{ row: row("setup_1") }, { row: row("Setup_1") }] : [];
+    return Promise.resolve(new Response(JSON.stringify({ num_rows_total: 2, rows })));
+  }) as typeof fetch;
+  await assert.rejects(
+    fetchHarnessRiskCases({ fetchImpl: collidingFetch, requireFullCaseSet: false }),
+    /case_id collision/,
+  );
 });
 
 test("runtime loader pages through the dataset and refuses a partial baseline", async () => {

--- a/crates/ruvllm/src/shard_placement/planner.rs
+++ b/crates/ruvllm/src/shard_placement/planner.rs
@@ -28,6 +28,27 @@ use super::policy::{GovernancePolicy, NodeViolation};
 use super::{FleetNode, ModelShard, NodeId, ShardId};
 use std::collections::BTreeMap;
 
+/// Maximum shards a single placement request may contain (PIR WP20 defensive
+/// input bound, ruvector ADR-323, #867).
+///
+/// The branch-and-bound [`search`] recurses to depth = shard count, so an
+/// unbounded shard count is an unbounded native call stack. Every pipeline this
+/// planner governs is a handful of stages (the source paper's largest is a
+/// four-node/70B pipeline); 64 sits far above any real pipeline while capping
+/// the recursion depth. A request above this cap is rejected up front with
+/// [`PlacementRejection::InputTooLarge`] rather than risking stack exhaustion.
+pub const MAX_SHARDS: usize = 64;
+
+/// Maximum fleet nodes a single placement request may contain (PIR WP20
+/// defensive input bound, ruvector ADR-323, #867).
+///
+/// The search fans out over each shard's eligible nodes, so node count bounds
+/// the per-level search breadth (and, with [`MAX_SHARDS`], the combinatorial
+/// worst case). Governed fleets are handfuls of nodes; 256 is far above any
+/// real fleet while keeping the search breadth bounded. A request above this
+/// cap is rejected up front with [`PlacementRejection::InputTooLarge`].
+pub const MAX_NODES: usize = 256;
+
 /// Relative weighting of latency versus cost in the placement objective.
 /// Lower objective is better. Both default to `1.0`.
 #[derive(Debug, Clone, Copy)]
@@ -92,6 +113,21 @@ pub enum PlacementRejection {
         /// Per-node reasons (empty only when the fleet itself is empty).
         violations: Vec<NodeViolation>,
     },
+    /// The request exceeds a documented input-size cap ([`MAX_SHARDS`] /
+    /// [`MAX_NODES`]) and is rejected *before* the branch-and-bound search runs.
+    /// The search recurses to depth = shard count and fans out over eligible
+    /// nodes per shard, so a pathologically large request could exhaust the
+    /// native stack or blow up combinatorially; bounding the input closes both.
+    InputTooLarge {
+        /// Number of shards supplied in the request.
+        shards: usize,
+        /// Number of nodes supplied in the request.
+        nodes: usize,
+        /// The shard-count cap that was exceeded ([`MAX_SHARDS`]).
+        max_shards: usize,
+        /// The node-count cap that was exceeded ([`MAX_NODES`]).
+        max_nodes: usize,
+    },
     /// Every shard is individually placeable, but no *complete* assignment fits
     /// within the fleet's cumulative memory capacity (the shards collectively
     /// exceed what the eligible nodes can jointly hold).
@@ -121,6 +157,17 @@ impl std::fmt::Display for PlacementRejection {
                     .join("; ");
                 f.write_str(&joined)
             }
+            PlacementRejection::InputTooLarge {
+                shards,
+                nodes,
+                max_shards,
+                max_nodes,
+            } => write!(
+                f,
+                "placement request too large: {shards} shard(s) (max {max_shards}), \
+                 {nodes} node(s) (max {max_nodes}) — rejected before the bounded search to \
+                 avoid stack exhaustion / combinatorial blow-up"
+            ),
             PlacementRejection::CapacityExhausted {
                 shard,
                 required_mb,
@@ -167,12 +214,27 @@ impl PlacementPlanner {
         shards: &[ModelShard],
         nodes: &[FleetNode],
     ) -> Result<PlacementPlan, PlacementRejection> {
-        // Trivially satisfiable: nothing to place.
+        // Trivially satisfiable: nothing to place (bounded regardless of fleet
+        // size — depth-0 search, no fan-out).
         if shards.is_empty() {
             return Ok(PlacementPlan {
                 assignments: Vec::new(),
                 total_objective: 0.0,
                 memory_used_mb: BTreeMap::new(),
+            });
+        }
+
+        // Defensive input-size bound (PIR WP20, #867): the branch-and-bound
+        // search below recurses to depth = shards.len() and fans out over each
+        // shard's eligible nodes, so a pathologically large request could
+        // exhaust the native stack or blow up combinatorially. Reject over-cap
+        // inputs here, before any recursion, with a specific structured reason.
+        if shards.len() > MAX_SHARDS || nodes.len() > MAX_NODES {
+            return Err(PlacementRejection::InputTooLarge {
+                shards: shards.len(),
+                nodes: nodes.len(),
+                max_shards: MAX_SHARDS,
+                max_nodes: MAX_NODES,
             });
         }
 

--- a/crates/ruvllm/src/shard_placement/tests.rs
+++ b/crates/ruvllm/src/shard_placement/tests.rs
@@ -7,7 +7,9 @@
 //! specific reason — never silently placed on a violating node — while the
 //! latency/cost objective only optimizes *among* feasible placements.
 
-use super::planner::{ObjectiveWeights, PlacementPlanner, PlacementRejection};
+use super::planner::{
+    ObjectiveWeights, PlacementPlanner, PlacementRejection, MAX_NODES, MAX_SHARDS,
+};
 use super::policy::{ConstraintViolation, GovernancePolicy};
 use super::{FleetNode, ModelShard, NodeId, ResidencyZone, ShardId, TrustTier};
 
@@ -406,4 +408,82 @@ fn empty_shard_set_is_trivially_satisfiable() {
     let plan = PlacementPlanner::default().plan(&[], &nodes).unwrap();
     assert!(plan.assignments.is_empty());
     assert_eq!(plan.total_objective, 0.0);
+}
+
+/// Defensive input-size bound (PIR WP20, #867): a request whose shard or node
+/// count exceeds the documented cap is rejected up front — before the
+/// branch-and-bound search runs — so it can neither exhaust the native stack
+/// (recursion depth = shard count) nor blow up combinatorially.
+#[test]
+fn oversized_request_is_rejected_before_search() {
+    // One shard over the shard cap on a small fleet.
+    let too_many_shards: Vec<ModelShard> = (0..=MAX_SHARDS)
+        .map(|i| ModelShard::new(format!("stage-{i}"), i, 1))
+        .collect();
+    let small_fleet = vec![FleetNode::new(
+        "n0",
+        ResidencyZone::new("us"),
+        TrustTier(9),
+        1_000_000,
+    )];
+    match PlacementPlanner::default()
+        .plan(&too_many_shards, &small_fleet)
+        .unwrap_err()
+    {
+        PlacementRejection::InputTooLarge {
+            shards,
+            nodes,
+            max_shards,
+            max_nodes,
+        } => {
+            assert_eq!(shards, MAX_SHARDS + 1);
+            assert_eq!(nodes, 1);
+            assert_eq!(max_shards, MAX_SHARDS);
+            assert_eq!(max_nodes, MAX_NODES);
+        }
+        other => panic!("expected InputTooLarge (shards), got {other:?}"),
+    }
+
+    // One node over the node cap with a single shard.
+    let one_shard = vec![ModelShard::new("stage-0", 0, 1)];
+    let too_many_nodes: Vec<FleetNode> = (0..=MAX_NODES)
+        .map(|i| FleetNode::new(format!("n{i}"), ResidencyZone::new("us"), TrustTier(9), 1000))
+        .collect();
+    match PlacementPlanner::default()
+        .plan(&one_shard, &too_many_nodes)
+        .unwrap_err()
+    {
+        PlacementRejection::InputTooLarge {
+            nodes, max_nodes, ..
+        } => {
+            assert_eq!(nodes, MAX_NODES + 1);
+            assert_eq!(max_nodes, MAX_NODES);
+        }
+        other => panic!("expected InputTooLarge (nodes), got {other:?}"),
+    }
+}
+
+/// The bound admits at-cap requests: exactly [`MAX_SHARDS`] shards over
+/// [`MAX_NODES`] nodes is within limits and still produces a valid plan.
+#[test]
+fn at_cap_request_still_plans() {
+    let shards: Vec<ModelShard> = (0..MAX_SHARDS)
+        .map(|i| ModelShard::new(format!("stage-{i}"), i, 1))
+        .collect();
+    let nodes: Vec<FleetNode> = (0..MAX_NODES)
+        .map(|i| {
+            FleetNode::new(
+                format!("n{i}"),
+                ResidencyZone::new("us"),
+                TrustTier(9),
+                1_000_000,
+            )
+        })
+        .collect();
+    assert_eq!(shards.len(), MAX_SHARDS);
+    assert_eq!(nodes.len(), MAX_NODES);
+
+    let plan = PlacementPlanner::default().plan(&shards, &nodes).unwrap();
+    assert_plan_respects_constraints(&plan, &shards, &nodes);
+    assert_eq!(plan.assignments.len(), MAX_SHARDS);
 }


### PR DESCRIPTION
Final hardening pass for the PIR program: closes the two tracked LOW security residuals flagged as informational/non-blocking by security audit, for a clean board. Branched from `origin/main`.

## LOW #1 — WP15 caseId case-insensitive-FS collision (#862, re-verify of #873)

`case_id` (`^[A-Za-z0-9._-]+$`) prevents traversal but allows case-only-distinct ids (e.g. `setup_1` vs `Setup_1`) that collide to the same `${caseId}.state.json` filename on a case-insensitive FS (macOS/Windows dev machines; not Linux CI). Two distinct caseIds → one state file → cross-contamination of workspace state, which could forge or mask the acceptance-test integrity signal on those platforms.

**Fix (load-time collision rejection — the cleaner option):** new `assertNoCaseIdCollisions()` in `harnessRiskCases.ts`, wired into `fetchHarnessRiskCases()`, throws at load/parse time when two case_ids lowercase-collide. This catches the problem at the boundary and keeps the readable, debuggable per-case filenames intact. Distinct-ignoring-case ids are unaffected.

- `crates/ruvector-sota-bench/harness/src/harnessRiskCases.ts`
- Tests (`test/harnessRisk.test.ts`): two case-only-distinct ids → rejected (direct + via loader); distinct-ignoring-case ids → fine; first-party set is collision-free.

## LOW #2 — WP20 shard-placement unbounded search (#867 audit note)

`crates/ruvllm/src/shard_placement/planner.rs` — the branch-and-bound `search` recurses to depth = `shards.len()` and is worst-case exponential; pathologically large shard/node counts could stack-overflow or blow up combinatorially. Feature-gated off and fail-closed, but now defensively bounded.

**Fix:** documented input-size caps (`MAX_SHARDS = 64`, `MAX_NODES = 256` — pipeline stages and governed fleets are handfuls) reject over-cap requests with a structured `PlacementRejection::InputTooLarge { shards, nodes, max_shards, max_nodes }` **before** entering the recursive search, bounding both recursion depth and combinatorial breadth.

- `crates/ruvllm/src/shard_placement/planner.rs`
- Tests (`tests.rs`): over-cap request (shards and nodes dimensions) rejected with `InputTooLarge`; at-cap request (64 shards × 256 nodes) still produces a valid plan.

## Verification

- `npm test` (harness): 86 pass / 0 fail / 1 pre-existing skip — includes the 2 new tests.
- `cargo test -p ruvllm --features shard-placement` (shard_placement module): 13 pass — includes the 2 new tests.
- `cargo check -p ruvllm` **without** the feature: clean — no default-build impact.
- `scripts/frozen-weights-check.mjs`: OK (0 references).

Note: `test_time_based_flush_simulation` (witness_log, a wall-clock sleep/elapsed assertion) flakes under CPU contention from parallel worktree agents; it is untouched by this PR (empty diff vs `origin/main`) and unrelated to these changes.

Will be security-re-verified before merge.

Refs #862 #867 #837

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)