### PR TITLE
feat(sota-harness): Zetta-pattern three-timescale evolution harness — synthetic slice (PIR WP24, ADR-327)

### DIFF
--- a/crates/ruvector-sota-bench/harness/src/timescaleEvolution.ts
+++ b/crates/ruvector-sota-bench/harness/src/timescaleEvolution.ts
@@ -1,0 +1,509 @@
+/**
+ * Zetta-pattern three-timescale evolution harness — synthetic slice
+ * (PIR WP24, ADR-327, issue #883; Zetta = arXiv:2608.16590).
+ *
+ * ────────────────────────────────────────────────────────────────────────
+ * HONEST SCOPE — read before extending. THIS IS A SYNTHETIC-ENVIRONMENT
+ * PATTERN SLICE, NOT PHYSICAL ROBOTICS.
+ *
+ *   - No repo in the ruvnet org operates a physical robot or a robot-rollout
+ *     harness today (verified: RVM is an agentic runtime, not robotics;
+ *     RuView is RF sensing, never actuation). This module therefore adopts
+ *     ONLY the timescale-separated evolution-harness PATTERN over a SYNTHETIC
+ *     environment. It drives no hardware, no simulator, no robot.
+ *   - The physical / RuView actuation target is EXPLICITLY DEFERRED to a
+ *     future ADR + hardware (ADR-327 Decision §5). Nothing here operates, or
+ *     is about to operate, a physical robot. Any future real-world path is
+ *     sensing-side coordination with RuView only — never actuation.
+ *   - This is the timescale-architecture pattern, NOT a reproduction of
+ *     Zetta's reported LIBERO-Pro / RoboCasa numbers. Those figures
+ *     (90.8% / 93.6% / 11.1x) are the source paper's own measurements on
+ *     robot benchmarks this program cannot run; the preprint-reproduction
+ *     rule forbids claiming them here (ADR-327 "Preprint-reproduction rule").
+ * ────────────────────────────────────────────────────────────────────────
+ *
+ * Zetta evolves runtime critics and recovery skills online while keeping the
+ * base policy FROZEN, across three timescale-separated loops (arXiv:2608.16590
+ * abstract, verbatim: "action-frequency governance, rollout-level
+ * critic-recovery proposal, and validation-gated skill updates"). This module
+ * is a timescale-structured VARIANT of WP9's SHAPER frozen-weight loop
+ * (shaperLoop.ts / genome.ts, ADR-313): same frozen `FrozenModelRef`, same
+ * structural frozen-weights enforcement (scripts/frozen-weights-check.mjs
+ * scans this directory), same ADR-306 evaluation → ADR-315 constitutional
+ * boundary → recommendation-only contract. It adds the three-tier separation.
+ *
+ * THREE TIERS, structurally distinct (ADR-327 Decision §3):
+ *
+ *   1. ms — LOCAL CRITIC (action-frequency governance). A fast, cheap,
+ *      model-free check gating one action: synthetic signal-quality /
+ *      staleness / confidence / anomaly critics. `runLocalCriticTier` is a
+ *      SYNCHRONOUS function taking only a `SyntheticObservation` — no
+ *      `FrozenModelRef` parameter exists in the critic path, and the ONLY
+ *      route to the frozen base policy (the async dream-machine evaluation
+ *      the minutes tier uses) cannot be reached from a synchronous function.
+ *      So the critic provably cannot invoke the frozen model. Test-asserted.
+ *
+ *   2. seconds — RECOVERY (rollout-level critic-recovery proposal). On a
+ *      critic-flagged failure, a local recovery behavior (retry / fallback /
+ *      degrade) runs. Also synchronous, also model-free: recovery selects a
+ *      behavior over the synthetic env and NEVER evolves or mutates the base.
+ *
+ *   3. minutes–hours — SKILL EVOLUTION (validation-gated skill updates). A
+ *      validated skill/critic mutation is promoted ONLY through WP9's
+ *      existing dream-machine → vetoes → flywheel path (`runShaperGeneration`,
+ *      reused unchanged), and ONLY after held-out-seed validation: the
+ *      candidate is scored on seeds it never trained against (maps to ruv's
+ *      Wave-3 acceptance-test held-out requirement and Zetta's own
+ *      "Held-out seeds → Reject/Promote" gate).
+ *
+ * FROZEN-BASE INVARIANT (ADR-327 Decision §2, reuses ADR-313's mechanism):
+ * NO tier may mutate the base policy — only critics, recovery, and skills
+ * evolve. Enforced STRUCTURALLY, not by policy:
+ *   - The ms and seconds tiers never receive a `FrozenModelRef` at all.
+ *   - The minutes tier receives the frozen model only as `genome.ts`'s
+ *     immutable `FrozenModelRef` (id + loop-start sha256) and routes through
+ *     `runShaperGeneration`, whose `MutationSurface` has no "weights" member —
+ *     a weight-mutating candidate is unrepresentable.
+ *   - This file lives in the frozen-weights-check mutation surface: importing
+ *     a training / weight-writing API here fails CI.
+ *
+ * CONSTITUTIONAL BOUNDARY (ADR-315, adopted verbatim from WP9): a promoted
+ * skill/critic that expands capability routes to the ADR-315 constitutional
+ * gate stub (blocked by default) via `runShaperGeneration`. This module
+ * exports NO promote/merge/approve function; every result is frozen data with
+ * no callable members. Promotion belongs to the vetoes/flywheel path plus a
+ * human. Test-asserted, identically to shaperLoop.test.ts.
+ */
+import {
+  runShaperGeneration,
+  type CandidateProposer,
+  type GenomeEvaluator,
+  type ShaperGenerationResult,
+} from "./shaperLoop.js";
+import {
+  assertFrozenModelRef,
+  type CandidateMutation,
+  type EvolvableGenome,
+  type FrozenModelRef,
+} from "./genome.js";
+
+// ───────────────────────────── ms tier: LOCAL CRITIC ─────────────────────
+//
+// action-frequency governance. Fast, cheap, model-free per-action gating.
+
+/**
+ * One synthetic-environment observation the ms-tier critic inspects. Purely
+ * synthetic scalars — this is NOT sensor data from any real device.
+ */
+export interface SyntheticObservation {
+  /** Rollout seed this observation belongs to (synthetic). */
+  readonly seed: number;
+  /** Step index within the rollout. */
+  readonly step: number;
+  /** Synthetic signal-quality score in [0, 1]. */
+  readonly signalQuality: number;
+  /** Synthetic state staleness, milliseconds since last refresh. */
+  readonly stateAgeMs: number;
+  /** Synthetic policy confidence in [0, 1]. */
+  readonly confidence: number;
+  /** Synthetic scalar whose magnitude, out of bounds, reads as an anomaly. */
+  readonly value: number;
+}
+
+/** The four fast critics Zetta names for the immediate-governance tier. */
+export type CriticFlag = "signal_quality" | "stale_state" | "low_confidence" | "anomaly";
+
+/** Thresholds parameterising the local critic. */
+export interface CriticThresholds {
+  readonly minSignalQuality: number;
+  readonly maxStateAgeMs: number;
+  readonly minConfidence: number;
+  /** |value| strictly greater than this reads as an anomaly. */
+  readonly anomalyAbs: number;
+}
+
+/**
+ * The ms-tier verdict. Frozen data. `tier` documents which timescale produced
+ * it — a fast local critic, never the frozen base policy.
+ */
+export interface CriticSignal {
+  readonly ok: boolean;
+  readonly flags: readonly CriticFlag[];
+  readonly tier: "ms-local-critic";
+}
+
+/**
+ * A local critic: synchronous, and — by TYPE — takes ONLY an observation.
+ * There is no `FrozenModelRef` parameter, so the critic cannot be handed the
+ * frozen base policy. This is the ms tier's structural frozen-base proof.
+ */
+export type LocalCritic = (observation: SyntheticObservation) => CriticSignal;
+
+/**
+ * Build the default model-free local critic from thresholds. Pure arithmetic —
+ * no I/O, no await, no model. Its evolvable form is a `skills`/`context`
+ * genome promoted through the minutes tier, never a weight change.
+ */
+export function defaultLocalCritic(thresholds: CriticThresholds): LocalCritic {
+  return (observation) => {
+    const flags: CriticFlag[] = [];
+    if (observation.signalQuality < thresholds.minSignalQuality) flags.push("signal_quality");
+    if (observation.stateAgeMs > thresholds.maxStateAgeMs) flags.push("stale_state");
+    if (observation.confidence < thresholds.minConfidence) flags.push("low_confidence");
+    if (Math.abs(observation.value) > thresholds.anomalyAbs) flags.push("anomaly");
+    return Object.freeze({
+      ok: flags.length === 0,
+      flags: Object.freeze(flags),
+      tier: "ms-local-critic" as const,
+    });
+  };
+}
+
+/**
+ * Runtime guard: a local critic must be model-free. A critic that declared a
+ * second parameter (e.g. to smuggle in a `FrozenModelRef`) is rejected. The
+ * type system already forbids it; this backstops untyped JS callers.
+ */
+export function assertModelFreeCritic(critic: LocalCritic): void {
+  if (typeof critic !== "function") throw new Error("local critic must be a function");
+  if (critic.length > 1) {
+    throw new Error(
+      `local critic must take ONLY an observation (arity ${critic.length}) — ` +
+      "the ms tier is model-free; the frozen base policy is unreachable here",
+    );
+  }
+}
+
+/** The ms tier's decision for one action. */
+export interface GatedAction {
+  readonly observation: SyntheticObservation;
+  readonly signal: CriticSignal;
+  /** "proceed" when the critic is clean, "gated" when any critic flagged. */
+  readonly action: "proceed" | "gated";
+}
+
+/**
+ * ms tier — gate ONE action with the local critic. DELIBERATELY SYNCHRONOUS:
+ * the only path to the frozen base policy is the async dream-machine
+ * evaluation the minutes tier uses (`runShaperGeneration` → `evaluateCandidate`
+ * → dream-machine `run`, all async). A synchronous function cannot await that
+ * path, so this tier provably cannot reach the frozen model — the structural
+ * frozen-base proof for the fast critic (test-asserted: the return value is a
+ * plain object, never a thenable).
+ */
+export function runLocalCriticTier(critic: LocalCritic, observation: SyntheticObservation): GatedAction {
+  assertModelFreeCritic(critic);
+  const signal = critic(observation);
+  return Object.freeze({
+    observation,
+    signal,
+    action: signal.ok ? "proceed" : "gated",
+  });
+}
+
+// ───────────────────────────── seconds tier: RECOVERY ────────────────────
+//
+// rollout-level critic-recovery. Local behavior selection; base never evolves.
+
+/** The recovery behaviors this synthetic tier can select (no base change). */
+export type RecoveryStrategy = "retry" | "fallback" | "degrade";
+
+/** The seconds-tier outcome. Frozen data; no model, no base mutation. */
+export interface RecoveryOutcome {
+  readonly strategy: RecoveryStrategy;
+  /** Which critic flags this recovery behavior addresses. */
+  readonly resolvedFlags: readonly CriticFlag[];
+  readonly recovered: boolean;
+  readonly tier: "seconds-recovery";
+}
+
+/**
+ * Map a critic flag to a recovery behavior. Pure. Staleness → retry (refresh
+ * state); signal/confidence → fallback (a safer known behavior); anomaly →
+ * degrade (reduce authority). None of these change the base policy.
+ */
+export function recoveryStrategyForFlags(flags: readonly CriticFlag[]): RecoveryStrategy {
+  if (flags.includes("anomaly")) return "degrade";
+  if (flags.includes("stale_state")) return "retry";
+  return "fallback";
+}
+
+/**
+ * seconds tier — run a recovery behavior for a critic-flagged action. Also
+ * SYNCHRONOUS and model-free: it selects and records a local behavior, and
+ * has no `FrozenModelRef` parameter and no genome-mutation path. It NEVER
+ * evolves the base — recovery is a runtime behavior, not a base change.
+ *
+ * A clean (un-flagged) action needs no recovery and throws if passed here:
+ * the seconds tier fires only on a critic-flagged failure.
+ */
+export function runRecoveryTier(gated: GatedAction): RecoveryOutcome {
+  if (gated.action !== "gated") {
+    throw new Error("runRecoveryTier is only invoked on a critic-flagged (gated) action");
+  }
+  const flags = gated.signal.flags;
+  const strategy = recoveryStrategyForFlags(flags);
+  return Object.freeze({
+    strategy,
+    resolvedFlags: Object.freeze([...flags]),
+    // Synthetic recovery model: a single local behavior clears the flagged
+    // failure. This is a pattern stub over a synthetic env, not a physical
+    // recovery guarantee.
+    recovered: true,
+    tier: "seconds-recovery",
+  });
+}
+
+// ──────────────────── minutes–hours tier: SKILL EVOLUTION ─────────────────
+//
+// validation-gated skill updates via WP9's flywheel path + held-out seeds.
+
+/**
+ * A train / held-out seed split. Promotion is validated on seeds the
+ * evolution loop NEVER trained against (ADR-327 §3 "Held-out seeds", ruv's
+ * Wave-3 held-out acceptance requirement).
+ */
+export interface HeldOutSplit {
+  /** Seeds the proposer learns the mutation from (the failure cluster). */
+  readonly trainSeeds: readonly number[];
+  /** Disjoint seeds the candidate is validated on but never trained against. */
+  readonly heldOutSeeds: readonly number[];
+}
+
+/**
+ * A seed split must be non-empty on both sides AND disjoint — a candidate
+ * validated on a seed it trained on is not held-out validation. Structural.
+ */
+export function assertDisjointSplit(split: HeldOutSplit): void {
+  if (split.trainSeeds.length === 0) throw new Error("held-out split requires at least one train seed");
+  if (split.heldOutSeeds.length === 0) throw new Error("held-out split requires at least one held-out seed");
+  const trainSet = new Set(split.trainSeeds);
+  const leaked = split.heldOutSeeds.filter((seed) => trainSet.has(seed));
+  if (leaked.length > 0) {
+    throw new Error(
+      `held-out seeds leaked into training: [${leaked.join(", ")}] — ` +
+      "the candidate must be validated only on seeds it never trained against",
+    );
+  }
+}
+
+/** Proposes a skill/critic mutation from the failure cluster's TRAIN seeds. */
+export type SkillProposer = (
+  parent: EvolvableGenome,
+  plannerModel: FrozenModelRef,
+  trainSeeds: readonly number[],
+) => CandidateMutation | Promise<CandidateMutation>;
+
+/** Scores a candidate over the HELD-OUT seeds — the seeds it never trained on. */
+export type HeldOutEvaluator = (
+  genome: EvolvableGenome,
+  optimizerModel: FrozenModelRef,
+  heldOutSeeds: readonly number[],
+) => readonly number[] | Promise<readonly number[]>;
+
+export interface SkillEvolutionOptions {
+  /** The frozen base policy — immutable, id + loop-start sha256 (genome.ts). */
+  frozenModel: FrozenModelRef;
+  /** Champion genome and its per-held-out-seed baseline samples. */
+  parent: { genome: EvolvableGenome; samples: readonly number[] };
+  /** Disjoint train / held-out seed split. */
+  split: HeldOutSplit;
+  /** Proposes the mutation; sees ONLY the train seeds. */
+  propose: SkillProposer;
+  /** Validates the mutation; scores ONLY on held-out seeds. */
+  evaluateHeldOut: HeldOutEvaluator;
+  /** Git commit sha the evaluation runs against (witness-stamped). */
+  commit: string;
+  /** Evaluation date, YYYY-MM-DD (defaults to today, UTC). */
+  date?: string;
+}
+
+/**
+ * The minutes-tier outcome. Frozen data — a RECOMMENDATION, never a
+ * promotion. Wraps WP9's `ShaperGenerationResult` unchanged and adds the
+ * held-out validation record.
+ */
+export interface SkillEvolutionResult {
+  readonly tier: "minutes-skill-evolution";
+  /** WP9's generation result: verdict, veto reasons, capability gate. */
+  readonly generation: ShaperGenerationResult;
+  readonly heldOut: {
+    readonly trainSeeds: readonly number[];
+    readonly heldOutSeeds: readonly number[];
+    /** The candidate cleared the flywheel gate on held-out seeds. */
+    readonly validatedOnHeldOut: boolean;
+  };
+  /** "recommend" only when the flywheel path recommends on held-out seeds. */
+  readonly recommendation: "recommend" | "blocked";
+}
+
+/**
+ * minutes–hours tier — validate a skill/critic mutation and produce a
+ * promotion RECOMMENDATION, reusing WP9's `runShaperGeneration` verbatim.
+ *
+ * The proposer sees ONLY the train seeds; the evaluator scores ONLY on the
+ * disjoint held-out seeds. `parent.samples` are the baseline over those same
+ * held-out seeds, so the paired-bootstrap compares candidate-on-held-out
+ * against baseline-on-held-out — a mutation validated on data it did not
+ * train on. A capability-expanding mutation is routed to the ADR-315
+ * constitutional gate by `runShaperGeneration` and blocked by default; the
+ * base policy is never mutated (genome.ts has no weights surface).
+ */
+export async function runSkillEvolutionTier(options: SkillEvolutionOptions): Promise<SkillEvolutionResult> {
+  assertFrozenModelRef(options.frozenModel);
+  assertDisjointSplit(options.split);
+  if (options.parent.samples.length !== options.split.heldOutSeeds.length) {
+    throw new Error(
+      `parent baseline samples (${options.parent.samples.length}) must be measured over the ` +
+      `held-out seeds (${options.split.heldOutSeeds.length}) — held-out validation compares like for like`,
+    );
+  }
+
+  const seenTrainSeeds: number[][] = [];
+  const seenEvalSeeds: number[][] = [];
+
+  // Bind WP9's proposer contract to the TRAIN seeds only.
+  const propose: CandidateProposer = async (parent, plannerModel) => {
+    seenTrainSeeds.push([...options.split.trainSeeds]);
+    return options.propose(parent, plannerModel, options.split.trainSeeds);
+  };
+
+  // Bind WP9's evaluator contract to the HELD-OUT seeds only.
+  const evaluate: GenomeEvaluator = async (genome, optimizerModel) => {
+    seenEvalSeeds.push([...options.split.heldOutSeeds]);
+    return options.evaluateHeldOut(genome, optimizerModel, options.split.heldOutSeeds);
+  };
+
+  const generation = await runShaperGeneration({
+    frozenModel: options.frozenModel,
+    parent: options.parent,
+    propose,
+    evaluate,
+    commit: options.commit,
+    ...(options.date ? { date: options.date } : {}),
+  });
+
+  // Belt-and-braces: the evaluator must never have seen a train seed.
+  for (const evalSeeds of seenEvalSeeds) {
+    const trainSet = new Set(options.split.trainSeeds);
+    if (evalSeeds.some((seed) => trainSet.has(seed))) {
+      throw new Error("held-out validation invariant broken: evaluator saw a train seed");
+    }
+  }
+
+  const validatedOnHeldOut = generation.recommendation === "recommend";
+  return Object.freeze({
+    tier: "minutes-skill-evolution",
+    generation,
+    heldOut: Object.freeze({
+      trainSeeds: Object.freeze([...options.split.trainSeeds]),
+      heldOutSeeds: Object.freeze([...options.split.heldOutSeeds]),
+      validatedOnHeldOut,
+    }),
+    recommendation: generation.recommendation,
+  });
+}
+
+// ─────────────────────────── three-tier orchestration ────────────────────
+
+/** One synthetic rollout: an ordered stream of observations for a seed. */
+export interface SyntheticRollout {
+  readonly seed: number;
+  readonly observations: readonly SyntheticObservation[];
+}
+
+export interface TimescaleGenerationOptions {
+  /** The frozen base policy (only the minutes tier ever receives it). */
+  frozenModel: FrozenModelRef;
+  /** The ms-tier local critic (model-free). */
+  critic: LocalCritic;
+  /** Synthetic rollouts to run the fast critic + recovery over. */
+  rollouts: readonly SyntheticRollout[];
+  /** Champion genome + baseline over held-out seeds (minutes tier). */
+  parent: { genome: EvolvableGenome; samples: readonly number[] };
+  /** Train / held-out seed split for held-out validation. */
+  split: HeldOutSplit;
+  propose: SkillProposer;
+  evaluateHeldOut: HeldOutEvaluator;
+  commit: string;
+  date?: string;
+}
+
+/** The tier order, recorded so the ordering is asserted, not assumed. */
+export const TIER_ORDER = ["ms-local-critic", "seconds-recovery", "minutes-skill-evolution"] as const;
+export type TierOrder = typeof TIER_ORDER;
+
+/**
+ * The whole generation's outcome. Frozen data, RECOMMENDATION only — there is
+ * no promote(), no merge(), no side-effect handle. Promotion belongs to the
+ * vetoes/flywheel path plus a human (WP2/WP9 contract, adopted unchanged).
+ */
+export interface TimescaleGenerationResult {
+  readonly ms: {
+    readonly gated: readonly GatedAction[];
+    readonly flaggedCount: number;
+  };
+  readonly seconds: {
+    readonly recoveries: readonly RecoveryOutcome[];
+  };
+  readonly minutes: SkillEvolutionResult;
+  /** Proof the three tiers ran, in Zetta's timescale order. */
+  readonly tiersRunInOrder: TierOrder;
+  /** The minutes-tier recommendation is the generation's recommendation. */
+  readonly recommendation: "recommend" | "blocked";
+}
+
+/**
+ * Run ONE three-timescale generation over a synthetic environment, in order:
+ *
+ *   ms local critic (gate every action) → seconds recovery (per flagged
+ *   failure) → minutes–hours skill evolution (validate on held-out seeds via
+ *   the flywheel gate).
+ *
+ * The three tiers are independently governed (ADR-327 "independent per-tier
+ * gating"): the ms critic gates actions, the seconds tier recovers flagged
+ * failures, and NEITHER promotes anything — only the minutes tier yields a
+ * promotion recommendation, and only through WP9's flywheel path with
+ * held-out validation. The frozen base policy is threaded to the minutes tier
+ * ALONE; the fast tiers never see it.
+ */
+export async function runTimescaleGeneration(
+  options: TimescaleGenerationOptions,
+): Promise<TimescaleGenerationResult> {
+  assertFrozenModelRef(options.frozenModel);
+  assertModelFreeCritic(options.critic);
+
+  // Tier 1 (ms): gate every action with the fast, model-free local critic.
+  const gated: GatedAction[] = [];
+  for (const rollout of options.rollouts) {
+    for (const observation of rollout.observations) {
+      gated.push(runLocalCriticTier(options.critic, observation));
+    }
+  }
+  const flagged = gated.filter((g) => g.action === "gated");
+
+  // Tier 2 (seconds): run recovery for each critic-flagged failure. Model-free;
+  // the base is never evolved here.
+  const recoveries = flagged.map((g) => runRecoveryTier(g));
+
+  // Tier 3 (minutes–hours): the failure cluster drives a validated skill
+  // mutation, promoted ONLY through the flywheel gate on held-out seeds. This
+  // is the ONLY tier that receives the frozen base policy.
+  const minutes = await runSkillEvolutionTier({
+    frozenModel: options.frozenModel,
+    parent: options.parent,
+    split: options.split,
+    propose: options.propose,
+    evaluateHeldOut: options.evaluateHeldOut,
+    commit: options.commit,
+    ...(options.date ? { date: options.date } : {}),
+  });
+
+  return Object.freeze({
+    ms: Object.freeze({ gated: Object.freeze(gated), flaggedCount: flagged.length }),
+    seconds: Object.freeze({ recoveries: Object.freeze(recoveries) }),
+    minutes,
+    tiersRunInOrder: TIER_ORDER,
+    recommendation: minutes.recommendation,
+  });
+}

--- a/crates/ruvector-sota-bench/harness/test/timescaleEvolution.test.ts
+++ b/crates/ruvector-sota-bench/harness/test/timescaleEvolution.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Tests for the Zetta-pattern three-timescale evolution harness — synthetic
+ * slice (PIR WP24, ADR-327, issue #883; Zetta = arXiv:2608.16590).
+ *
+ * SCOPE: synthetic environment only. No physical robotics; the physical /
+ * RuView actuation target is deferred to a future ADR + hardware. These tests
+ * validate the timescale-architecture pattern, NOT any Zetta robot number.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import * as tse from "../src/timescaleEvolution.js";
+import {
+  defaultLocalCritic,
+  runLocalCriticTier,
+  runRecoveryTier,
+  recoveryStrategyForFlags,
+  assertModelFreeCritic,
+  assertDisjointSplit,
+  runSkillEvolutionTier,
+  runTimescaleGeneration,
+  TIER_ORDER,
+  type CriticThresholds,
+  type LocalCritic,
+  type SyntheticObservation,
+  type SyntheticRollout,
+} from "../src/timescaleEvolution.js";
+import type {
+  CandidateMutation,
+  EvolvableGenome,
+  FrozenModelRef,
+  SkillGenome,
+} from "../src/genome.js";
+
+const COMMIT = "0123456789abcdef0123456789abcdef01234567";
+
+const FROZEN_MODEL: FrozenModelRef = {
+  id: "ruvltra-frozen-q4",
+  sha256: "a".repeat(64),
+};
+
+const THRESHOLDS: CriticThresholds = {
+  minSignalQuality: 0.5,
+  maxStateAgeMs: 100,
+  minConfidence: 0.6,
+  anomalyAbs: 10,
+};
+
+const obs = (partial: Partial<SyntheticObservation> = {}): SyntheticObservation => ({
+  seed: 1,
+  step: 0,
+  signalQuality: 0.9,
+  stateAgeMs: 10,
+  confidence: 0.9,
+  value: 1,
+  ...partial,
+});
+
+const parentSkills: SkillGenome = {
+  surface: "skills",
+  version: 3,
+  skills: [{ name: "grasp", body: "reach, close gripper" }],
+};
+
+const skillMutation = (extra?: Partial<CandidateMutation>): CandidateMutation => ({
+  parent: parentSkills,
+  candidate: {
+    surface: "skills",
+    version: 4,
+    skills: [
+      { name: "grasp", body: "reach, close gripper" },
+      { name: "regrasp-on-slip", body: "detect slip, reopen, retry grasp" },
+    ],
+  },
+  describe: "add regrasp-on-slip recovery skill",
+  ...extra,
+});
+
+// Held-out baseline: five synthetic seeds the champion scores ~0.90 on.
+const HELD_OUT_SEEDS = [101, 103, 105, 107, 109];
+const TRAIN_SEEDS = [2, 4, 6, 8];
+const HELD_OUT_BASELINE = [0.90, 0.91, 0.89, 0.90, 0.92];
+
+// ───────────────────────────── ms tier: LOCAL CRITIC ─────────────────────
+
+test("ms local critic flags signal-quality / staleness / confidence / anomaly", () => {
+  const critic = defaultLocalCritic(THRESHOLDS);
+  assert.deepEqual(runLocalCriticTier(critic, obs()).signal.flags, []);
+  assert.equal(runLocalCriticTier(critic, obs()).action, "proceed");
+
+  assert.deepEqual(runLocalCriticTier(critic, obs({ signalQuality: 0.1 })).signal.flags, ["signal_quality"]);
+  assert.deepEqual(runLocalCriticTier(critic, obs({ stateAgeMs: 5000 })).signal.flags, ["stale_state"]);
+  assert.deepEqual(runLocalCriticTier(critic, obs({ confidence: 0.1 })).signal.flags, ["low_confidence"]);
+  assert.deepEqual(runLocalCriticTier(critic, obs({ value: 99 })).signal.flags, ["anomaly"]);
+
+  const gated = runLocalCriticTier(critic, obs({ confidence: 0.1, value: 99 }));
+  assert.equal(gated.action, "gated");
+  assert.deepEqual(gated.signal.flags, ["low_confidence", "anomaly"]);
+  assert.equal(gated.signal.tier, "ms-local-critic");
+  assert.ok(Object.isFrozen(gated));
+});
+
+test("ms critic is STRUCTURALLY FAST and CANNOT reach the frozen model", () => {
+  const critic = defaultLocalCritic(THRESHOLDS);
+
+  // 1. Structural: the tier is synchronous — its result is a plain object,
+  //    never a thenable. The only path to the frozen base policy is the async
+  //    dream-machine evaluation the minutes tier uses; a synchronous function
+  //    cannot await it, so the critic provably cannot invoke the frozen model.
+  const result = runLocalCriticTier(critic, obs());
+  assert.equal(typeof (result as { then?: unknown }).then, "undefined");
+  assert.notEqual(Object.prototype.toString.call(result), "[object Promise]");
+
+  // 2. The critic never RECEIVES a frozen model: it is called with exactly one
+  //    argument (the observation), which carries no model identity. A regular
+  //    function is used so `arguments` reflects the real call arity.
+  let receivedArgs = -1;
+  let sawModelShape = false;
+  const spyCritic = function (this: unknown, observation: SyntheticObservation) {
+    // eslint-disable-next-line prefer-rest-params
+    receivedArgs = arguments.length;
+    const o = observation as unknown as Record<string, unknown>;
+    if ("sha256" in o || "id" in o) sawModelShape = true;
+    return critic(observation);
+  } as LocalCritic;
+  runLocalCriticTier(spyCritic, obs());
+  assert.equal(receivedArgs, 1, "critic must be called with only the observation");
+  assert.equal(sawModelShape, false, "the observation must not carry a FrozenModelRef shape");
+
+  // 3. A critic that declares a second parameter (to smuggle a model in) is
+  //    rejected by the model-free guard.
+  const twoArg = ((_o: SyntheticObservation, _m: FrozenModelRef) => critic(_o)) as unknown as LocalCritic;
+  assert.throws(() => assertModelFreeCritic(twoArg), /model-free|arity/);
+
+  // 4. Cheap: 50k invocations complete well under a generous budget (pure
+  //    arithmetic, no I/O) — a loose ceiling, not a micro-benchmark.
+  const start = process.hrtime.bigint();
+  for (let i = 0; i < 50_000; i += 1) critic(obs({ step: i }));
+  const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
+  assert.ok(elapsedMs < 1000, `50k critic calls took ${elapsedMs.toFixed(1)}ms — expected < 1000ms`);
+});
+
+// ───────────────────────────── seconds tier: RECOVERY ────────────────────
+
+test("seconds recovery maps flags to retry/fallback/degrade without base mutation", () => {
+  assert.equal(recoveryStrategyForFlags(["stale_state"]), "retry");
+  assert.equal(recoveryStrategyForFlags(["signal_quality"]), "fallback");
+  assert.equal(recoveryStrategyForFlags(["low_confidence"]), "fallback");
+  assert.equal(recoveryStrategyForFlags(["anomaly"]), "degrade");
+  assert.equal(recoveryStrategyForFlags(["stale_state", "anomaly"]), "degrade");
+
+  const critic = defaultLocalCritic(THRESHOLDS);
+  const flagged = runLocalCriticTier(critic, obs({ stateAgeMs: 5000 }));
+  const recovery = runRecoveryTier(flagged);
+  assert.equal(recovery.strategy, "retry");
+  assert.deepEqual(recovery.resolvedFlags, ["stale_state"]);
+  assert.equal(recovery.recovered, true);
+  assert.equal(recovery.tier, "seconds-recovery");
+  assert.ok(Object.isFrozen(recovery));
+
+  // The seconds tier fires ONLY on a critic-flagged failure.
+  const clean = runLocalCriticTier(critic, obs());
+  assert.throws(() => runRecoveryTier(clean), /only invoked on a critic-flagged/);
+});
+
+// ──────────────────── minutes tier: SKILL EVOLUTION + held-out ────────────
+
+test("minutes skill evolution: a validated skill promotes through the flywheel gate on held-out seeds", async () => {
+  const trainSeen: number[][] = [];
+  const evalSeen: number[][] = [];
+
+  const result = await runSkillEvolutionTier({
+    frozenModel: FROZEN_MODEL,
+    parent: { genome: parentSkills, samples: HELD_OUT_BASELINE },
+    split: { trainSeeds: TRAIN_SEEDS, heldOutSeeds: HELD_OUT_SEEDS },
+    propose: (parent, _planner, trainSeeds) => {
+      trainSeen.push([...trainSeeds]);
+      assert.equal(parent, parentSkills);
+      return skillMutation();
+    },
+    evaluateHeldOut: (_genome, _optimizer, heldOutSeeds) => {
+      evalSeen.push([...heldOutSeeds]);
+      // Skill improvement, evaluated ON HELD-OUT seeds it never trained on.
+      return HELD_OUT_BASELINE.map((s) => s + 0.05);
+    },
+    commit: COMMIT,
+    date: "2026-08-21",
+  });
+
+  assert.equal(result.tier, "minutes-skill-evolution");
+  assert.equal(result.generation.verdict.verdict, "ACCEPT");
+  assert.equal(result.recommendation, "recommend");
+  assert.equal(result.heldOut.validatedOnHeldOut, true);
+
+  // The proposer saw ONLY train seeds; the evaluator saw ONLY held-out seeds.
+  assert.deepEqual(trainSeen, [TRAIN_SEEDS]);
+  assert.deepEqual(evalSeen, [HELD_OUT_SEEDS]);
+  // And the two splits are disjoint — the candidate validated on unseen seeds.
+  const trainSet = new Set(TRAIN_SEEDS);
+  assert.ok(HELD_OUT_SEEDS.every((s) => !trainSet.has(s)));
+  assert.ok(Object.isFrozen(result));
+});
+
+test("held-out split must be non-empty and disjoint (leaked seed is rejected)", () => {
+  assert.throws(() => assertDisjointSplit({ trainSeeds: [], heldOutSeeds: [1] }), /at least one train seed/);
+  assert.throws(() => assertDisjointSplit({ trainSeeds: [1], heldOutSeeds: [] }), /at least one held-out seed/);
+  assert.throws(
+    () => assertDisjointSplit({ trainSeeds: [1, 2, 3], heldOutSeeds: [3, 4] }),
+    /leaked into training/,
+  );
+  assert.doesNotThrow(() => assertDisjointSplit({ trainSeeds: TRAIN_SEEDS, heldOutSeeds: HELD_OUT_SEEDS }));
+});
+
+test("minutes tier rejects a baseline whose length does not match the held-out seeds", async () => {
+  await assert.rejects(
+    runSkillEvolutionTier({
+      frozenModel: FROZEN_MODEL,
+      parent: { genome: parentSkills, samples: [0.9, 0.9] }, // 2 != 5 held-out
+      split: { trainSeeds: TRAIN_SEEDS, heldOutSeeds: HELD_OUT_SEEDS },
+      propose: () => skillMutation(),
+      evaluateHeldOut: () => HELD_OUT_BASELINE,
+      commit: COMMIT,
+    }),
+    /baseline samples .* must be measured over the held-out seeds/,
+  );
+});
+
+test("a regressed skill is blocked through the existing veto path (no base mutation)", async () => {
+  const result = await runSkillEvolutionTier({
+    frozenModel: FROZEN_MODEL,
+    parent: { genome: parentSkills, samples: HELD_OUT_BASELINE },
+    split: { trainSeeds: TRAIN_SEEDS, heldOutSeeds: HELD_OUT_SEEDS },
+    propose: () => skillMutation({ describe: "bad mutation" }),
+    evaluateHeldOut: () => HELD_OUT_BASELINE.map((s) => s - 0.1),
+    commit: COMMIT,
+  });
+  assert.equal(result.generation.verdict.verdict, "REJECT");
+  assert.deepEqual(result.generation.vetoReasons, ["dream_machine_reject"]);
+  assert.equal(result.recommendation, "blocked");
+  assert.equal(result.heldOut.validatedOnHeldOut, false);
+});
+
+// ──────────────── constitutional boundary + frozen-base invariant ─────────
+
+test("capability-expanding skill routes to the ADR-315 constitutional stub and is BLOCKED", async () => {
+  let evaluated = false;
+  const result = await runSkillEvolutionTier({
+    frozenModel: FROZEN_MODEL,
+    parent: { genome: parentSkills, samples: HELD_OUT_BASELINE },
+    split: { trainSeeds: TRAIN_SEEDS, heldOutSeeds: HELD_OUT_SEEDS },
+    propose: () => skillMutation({
+      describe: "skill that would grant a new tool",
+      capabilityDelta: { addsTools: ["shell_exec"], addsActionClasses: [], addsCommunicationPeers: [] },
+    }),
+    evaluateHeldOut: () => {
+      evaluated = true;
+      return HELD_OUT_BASELINE.map((s) => s + 0.5);
+    },
+    commit: COMMIT,
+  });
+  // The evaluator never runs for an unauthorized capability expansion.
+  assert.equal(evaluated, false);
+  assert.ok(result.generation.capabilityGate);
+  assert.equal(result.generation.capabilityGate.allowed, false);
+  assert.ok(result.generation.capabilityGate.reasons.some((r) => r.includes("constitutional_gate_stub_unwired")));
+  assert.ok(result.generation.vetoReasons.includes("capability_expansion_unauthorized"));
+  assert.equal(result.recommendation, "blocked");
+});
+
+test("no tier can mutate the frozen base: weights are not a mutation surface", async () => {
+  const weightsGenome = { surface: "weights", version: 1 } as unknown as EvolvableGenome;
+  await assert.rejects(
+    runSkillEvolutionTier({
+      frozenModel: FROZEN_MODEL,
+      parent: { genome: weightsGenome, samples: HELD_OUT_BASELINE },
+      split: { trainSeeds: TRAIN_SEEDS, heldOutSeeds: HELD_OUT_SEEDS },
+      propose: () => skillMutation(),
+      evaluateHeldOut: () => HELD_OUT_BASELINE,
+      commit: COMMIT,
+    }),
+    /inadmissible mutation surface "weights"/,
+  );
+  // A malformed frozen-model hash never starts a generation at any tier.
+  await assert.rejects(
+    runSkillEvolutionTier({
+      frozenModel: { id: "m", sha256: "not-a-hash" },
+      parent: { genome: parentSkills, samples: HELD_OUT_BASELINE },
+      split: { trainSeeds: TRAIN_SEEDS, heldOutSeeds: HELD_OUT_SEEDS },
+      propose: () => skillMutation(),
+      evaluateHeldOut: () => HELD_OUT_BASELINE,
+      commit: COMMIT,
+    }),
+    /sha256 must be 64 lowercase hex/,
+  );
+});
+
+test("constitutional boundary: no promotion capability is exported or reachable", async () => {
+  // No export name looks like a promotion capability (WP9's identical contract).
+  const forbidden = /promote|merge|approve|apply|commit|push/i;
+  for (const [name] of Object.entries(tse)) {
+    assert.ok(!forbidden.test(name), `export "${name}" looks like a promotion capability`);
+  }
+
+  // Every result object is frozen data with no callable members.
+  const result = await runTimescaleGeneration(baselineGenerationOptions());
+  assert.ok(Object.isFrozen(result));
+  for (const [key, value] of Object.entries(result)) {
+    assert.notEqual(typeof value, "function", `result.${key} must be data, not a capability`);
+  }
+  // @ts-expect-error — TimescaleGenerationResult has no promote() by construction.
+  assert.equal(result.promote, undefined);
+});
+
+// ─────────────────────────── three-tier orchestration ────────────────────
+
+function syntheticRollouts(): SyntheticRollout[] {
+  return [
+    {
+      seed: 2,
+      observations: [
+        obs({ seed: 2, step: 0 }), // clean → proceed
+        obs({ seed: 2, step: 1, stateAgeMs: 5000 }), // stale → gated → retry
+        obs({ seed: 2, step: 2, value: 99 }), // anomaly → gated → degrade
+      ],
+    },
+    {
+      seed: 4,
+      observations: [
+        obs({ seed: 4, step: 0, confidence: 0.1 }), // low confidence → gated → fallback
+        obs({ seed: 4, step: 1 }), // clean → proceed
+      ],
+    },
+  ];
+}
+
+function baselineGenerationOptions(): tse.TimescaleGenerationOptions {
+  return {
+    frozenModel: FROZEN_MODEL,
+    critic: defaultLocalCritic(THRESHOLDS),
+    rollouts: syntheticRollouts(),
+    parent: { genome: parentSkills, samples: HELD_OUT_BASELINE },
+    split: { trainSeeds: TRAIN_SEEDS, heldOutSeeds: HELD_OUT_SEEDS },
+    propose: () => skillMutation(),
+    evaluateHeldOut: () => HELD_OUT_BASELINE.map((s) => s + 0.05),
+    commit: COMMIT,
+    date: "2026-08-21",
+  };
+}
+
+test("the three tiers run IN ORDER over a synthetic env; a flagged failure triggers recovery", async () => {
+  const result = await runTimescaleGeneration(baselineGenerationOptions());
+
+  // Tier order is Zetta's timescale ordering.
+  assert.deepEqual([...result.tiersRunInOrder], ["ms-local-critic", "seconds-recovery", "minutes-skill-evolution"]);
+  assert.deepEqual([...TIER_ORDER], [...result.tiersRunInOrder]);
+
+  // ms tier gated 3 of 5 actions (stale, anomaly, low-confidence).
+  assert.equal(result.ms.gated.length, 5);
+  assert.equal(result.ms.flaggedCount, 3);
+
+  // seconds tier ran a recovery for EACH flagged failure — and only those.
+  assert.equal(result.seconds.recoveries.length, 3);
+  assert.deepEqual(
+    result.seconds.recoveries.map((r) => r.strategy).sort(),
+    ["degrade", "fallback", "retry"],
+  );
+  assert.ok(result.seconds.recoveries.every((r) => r.recovered));
+
+  // minutes tier produced a held-out-validated recommendation.
+  assert.equal(result.minutes.tier, "minutes-skill-evolution");
+  assert.equal(result.minutes.recommendation, "recommend");
+  assert.equal(result.minutes.heldOut.validatedOnHeldOut, true);
+  assert.equal(result.recommendation, "recommend");
+});
+
+test("a clean synthetic env triggers NO recovery but still runs the minutes tier", async () => {
+  const cleanRollouts: SyntheticRollout[] = [
+    { seed: 2, observations: [obs({ seed: 2, step: 0 }), obs({ seed: 2, step: 1 })] },
+  ];
+  const result = await runTimescaleGeneration({ ...baselineGenerationOptions(), rollouts: cleanRollouts });
+  assert.equal(result.ms.flaggedCount, 0);
+  assert.equal(result.seconds.recoveries.length, 0);
+  assert.equal(result.minutes.recommendation, "recommend");
+});


### PR DESCRIPTION
## PIR WP24 — Zetta-pattern three-timescale evolution harness (synthetic slice)

Implements the **explicit stretch** of Wave 3 per merged **ADR-327**: the timescale-separated, frozen-base evolution-harness **pattern** from Zetta (**arXiv:2608.16590**, Grade A; reference impl `air-embodied-brain/Zetta-Embodiment`), landed beside WP9's SHAPER loop in `crates/ruvector-sota-bench/harness`. Refs #883, #837.

> ## ⚠️ HONEST SCOPE — read first
>
> - **Synthetic environment ONLY.** This drives no hardware, no simulator, no robot. It is the timescale-**architecture** pattern over synthetic scalars.
> - **NO physical robotics.** Verified: no `ruvnet` repo operates physical robots (RVM = agentic runtime, not robotics; RuView = RF sensing, never actuation). Zetta has no existing actuation home in the org.
> - **Physical / RuView actuation is EXPLICITLY DEFERRED** to a future ADR + hardware (ADR-327 Decision §5). Any future real-world path is sensing-side coordination with RuView only — never actuation.
> - **This is NOT a reproduction of Zetta's numbers.** The 90.8% / 93.6% / 11.1× LIBERO-Pro/RoboCasa figures are the source paper's own measurements on robot benchmarks this program cannot run. Per the preprint-reproduction rule, nothing here claims them.

This same scope statement is reproduced prominently in the module docstring and the test header.

### Three tiers (ADR-327 Decision §3), structurally distinct + independently gated

| Tier | Timescale | Role | Structure |
|------|-----------|------|-----------|
| **Local critic** | ms | action-frequency governance | **synchronous, model-free** signal-quality / staleness / confidence / anomaly critic gating one action |
| **Recovery** | seconds | rollout-level critic-recovery | retry / fallback / degrade on a flagged failure; synchronous, model-free; **never evolves the base** |
| **Skill evolution** | minutes–hours | validation-gated skill updates | validated mutation promoted **only** via WP9's dream-machine → vetoes → flywheel path (`runShaperGeneration`, reused unchanged), **only** after held-out-seed validation |

The orchestrator `runTimescaleGeneration` runs the three tiers **in order** over synthetic rollouts; the frozen base policy is threaded to the minutes tier **alone**.

### Frozen-base structural proofs (reuse ADR-313's mechanism, not a new one)

- **Fast critic cannot reach the frozen model.** `runLocalCriticTier` is **synchronous**; the only path to the frozen base policy is the **async** dream-machine evaluation the minutes tier uses — a synchronous function cannot await it. Test asserts the critic result is a plain object (never a thenable), the critic is called with exactly one argument carrying no model identity, and a two-arg critic (smuggling a `FrozenModelRef`) is rejected by `assertModelFreeCritic`.
- **No tier can mutate the base.** ms/seconds tiers never receive a `FrozenModelRef`; the minutes tier only ever sees `genome.ts`'s immutable `FrozenModelRef` and routes through `runShaperGeneration`, whose `MutationSurface` has no `weights` member — a weight-mutating candidate is unrepresentable (test: `surface: "weights"` throws *inadmissible mutation surface*).
- **`scripts/frozen-weights-check.mjs` passes** on this file (it lives in the scanned mutation surface): `OK — 33 files scanned, 0 training/weight-API references`; `--self-test` green.

### Held-out validation

The proposer sees **only** the train seeds (the failure cluster); the evaluator scores **only** on the **disjoint** held-out seeds (`assertDisjointSplit` rejects any leak). Baseline samples must be measured over those same held-out seeds. Maps to ruv's Wave-3 held-out acceptance requirement and Zetta's own *Held-out seeds → Reject/Promote* gate.

### Constitutional boundary

A capability-expanding skill routes to WP9's **ADR-315** constitutional gate stub (blocked by default) via `runShaperGeneration` — the evaluator never even runs. The module exports **no** promote/merge/approve function; every result is frozen, recommendation-only data (test-asserted, identical contract to `shaperLoop.test.ts`).

### Tests

`node --test`, 12 new tests, full harness suite green:

```
# tests 99
# pass 98
# fail 0
# skipped 1   (pre-existing RVF adapter integration, needs RVF_ADAPTER_IT=1)
```

New tests (67–78): ms critic flags + structural-fast/can't-reach-frozen-model proof; seconds recovery mapping + fires-only-on-failure; minutes held-out promotion; disjoint-split + baseline-length guards; regressed-skill veto; capability-expansion → constitutional stub; weights-not-a-surface; no-promotion-export; three-tiers-in-order; clean-env-no-recovery. Plus `frozen-weights-check` gate + `--self-test`.

### Files

- `crates/ruvector-sota-bench/harness/src/timescaleEvolution.ts`
- `crates/ruvector-sota-bench/harness/test/timescaleEvolution.test.ts`

Cite: Zetta ζ, **arXiv:2608.16590**. Extends ADR-313 (frozen-weight enforcement, reused unchanged); ADR-327 (this pattern).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)