### PR TITLE
feat: DeAR-pattern decentralized capability-grounded reasoning (PIR WP23, ADR-326)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4915,6 +4915,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "latentmesh-thoughtmap"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "lattice-embed"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,9 @@ members = [
     "crates/rvAgent/rvagent-mcp",
     "crates/rvAgent/rvagent-wasm",
     "crates/rvAgent/rvagent-a2a",
+    # PIR WP23 / ADR-326 — DeAR-pattern decentralized capability-grounded
+    # reasoning. First latentmesh-* crate; extended by ADR-309 WP5 transport.
+    "crates/rvAgent/latentmesh-thoughtmap",
     # ADR-159 a2a-swarm demo
     "examples/a2a-swarm",
     # ETL pipeline example

--- a/crates/rvAgent/latentmesh-thoughtmap/Cargo.toml
+++ b/crates/rvAgent/latentmesh-thoughtmap/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "latentmesh-thoughtmap"
+version = "0.1.0"
+edition = "2021"
+description = "DeAR-pattern decentralized capability-grounded reasoning over a shared thought map (PIR WP23, ADR-326). First latentmesh-* crate; extended by ADR-309 WP5 transport crates."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/ruvnet/RuVector"
+
+[dependencies]
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+# Research-tier greenfield crate (PIR WP23). Correctness + suspicious lints
+# stay denied; doc/style churn deferred, matching sibling rvAgent crates.
+[lints.rust]
+missing_docs = "allow"

--- a/crates/rvAgent/latentmesh-thoughtmap/src/capability.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/capability.rs
@@ -1,0 +1,272 @@
+//! Capability vectors replacing named agent roles (ADR-326 Decision §1–§2).
+//!
+//! DeAR's confirmed mechanism (arXiv:2608.17282, part 1) is *query-dependent
+//! agent specialization*. We operationalize it by replacing fixed labels like
+//! `"coder"` / `"reviewer"` with a capability vector recomputed **per query**:
+//!
+//! ```text
+//! C(i, j, q) = competence × trust × locality × freshness ÷ cost
+//! ```
+//!
+//! (ruv's formula in RuVector#882 / ADR-326.) `competence`, `locality`, and
+//! `freshness` are grounded against the specific query `q`, so an agent's
+//! effective specialization is a function of its measured profile against that
+//! query — not a static role.
+//!
+//! **Local peer selection is decentralized (ADR-326 §2).** [`LocalView::select_peer`]
+//! takes only the *selecting* agent's own view plus the candidate profiles it
+//! can observe. There is deliberately **no central planner / dispatcher / global
+//! registry** argument — the contrast point with `radio-moe`'s centralized
+//! reputation-weighted routing called out in ADR-326. Each agent chooses its
+//! next collaboration peer by locally comparing `C(i,j,q)`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::vecmath::cosine;
+
+/// Stable identifier for an agent / peer participating in the reasoning fabric.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct PeerId(pub u64);
+
+/// A query the reasoning fabric is collaborating on. Carries a small feature
+/// embedding so competence/locality/freshness can be grounded query-dependently
+/// (`C(i,j,q)` depends on `q`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Query {
+    pub id: u64,
+    /// Feature/embedding vector describing what the query needs.
+    pub features: Vec<f32>,
+}
+
+impl Query {
+    pub fn new(id: u64, features: Vec<f32>) -> Self {
+        Self { id, features }
+    }
+}
+
+/// An observable profile of a candidate peer. This is what an agent can *see*
+/// about another agent locally — its advertised skill embedding, its
+/// witness-logged trust score (ADR-312 tamper-evident inputs), its cost, and
+/// the last step at which it was observed active (drives freshness).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PeerProfile {
+    pub id: PeerId,
+    /// Capability embedding — dotted against the query to get query-dependent
+    /// competence.
+    pub skill: Vec<f32>,
+    /// Witnessed reliability in `[0, 1]`. MUST be a tamper-evident, witness-logged
+    /// input per ADR-326's capability-vector-integrity gate — a peer inflating
+    /// its own trust to attract traffic is a modeled attack, not assumed-honest.
+    pub trust: f32,
+    /// Relative resource cost of collaborating with this peer (`> 0`).
+    pub cost: f32,
+    /// Step index at which this peer was last observed contributing. Older ⇒
+    /// less fresh.
+    pub last_active_step: u64,
+}
+
+/// The resolved five-factor capability vector for one `(i, j, q)` triple.
+///
+/// This is exactly ADR-326's formula operands; [`CapabilityVector::score`] is
+/// the `C(i,j,q)` product.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct CapabilityVector {
+    /// Query-dependent skill match in `[0, 1]`.
+    pub competence: f32,
+    /// Witnessed trust in `[0, 1]`.
+    pub trust: f32,
+    /// Selecting agent's local affinity to the peer in `[0, 1]`.
+    pub locality: f32,
+    /// Recency of the peer's last contribution in `[0, 1]`.
+    pub freshness: f32,
+    /// Resource cost (`> 0`); the divisor.
+    pub cost: f32,
+}
+
+impl CapabilityVector {
+    /// `C(i,j,q) = competence × trust × locality × freshness ÷ cost`.
+    ///
+    /// Cost is clamped to a small positive floor so a zero/negative advertised
+    /// cost cannot manufacture an infinite score (a modeled gaming attack).
+    pub fn score(&self) -> f32 {
+        let cost = self.cost.max(1e-6);
+        (self.competence * self.trust * self.locality * self.freshness) / cost
+    }
+}
+
+/// The selecting agent's *local* view of the fabric — its identity, a locality
+/// kernel over peers, and the current step clock for freshness decay.
+///
+/// Everything peer-selection needs is carried here or passed as observable
+/// candidate profiles. There is no field pointing at a central router.
+#[derive(Debug, Clone)]
+pub struct LocalView {
+    pub me: PeerId,
+    /// Local affinity embedding — cosine against a peer's skill gives a
+    /// decentralized `locality` term (agents near in capability space are
+    /// "local" to each other). This is the *selecting* agent's own view.
+    pub locality_kernel: Vec<f32>,
+    /// Current logical step, used to decay `freshness`.
+    pub now_step: u64,
+    /// Freshness half-life in steps.
+    pub freshness_half_life: u64,
+}
+
+impl LocalView {
+    pub fn new(me: PeerId, locality_kernel: Vec<f32>, now_step: u64) -> Self {
+        Self {
+            me,
+            locality_kernel,
+            now_step,
+            freshness_half_life: 8,
+        }
+    }
+
+    /// Ground the five factors of `C(i,j,q)` for a single candidate peer against
+    /// a specific query. This is where query-dependence enters: `competence` and
+    /// `locality` are derived from the query and the selecting agent's own view.
+    pub fn ground(&self, peer: &PeerProfile, query: &Query) -> CapabilityVector {
+        // Query-dependent competence: how well the peer's skill matches what the
+        // query needs. cosine ∈ [-1,1] → clamp to [0,1] (negative match = none).
+        let competence = cosine(&peer.skill, &query.features).max(0.0);
+
+        // Decentralized locality: closeness of the peer to the selecting agent's
+        // own locality kernel. No global topology consulted.
+        let locality = cosine(&self.locality_kernel, &peer.skill).max(0.0);
+
+        // Freshness: exponential decay of staleness by half-life.
+        let age = self.now_step.saturating_sub(peer.last_active_step) as f32;
+        let hl = self.freshness_half_life.max(1) as f32;
+        let freshness = 0.5f32.powf(age / hl);
+
+        CapabilityVector {
+            competence,
+            trust: peer.trust.clamp(0.0, 1.0),
+            locality,
+            freshness,
+            cost: peer.cost,
+        }
+    }
+
+    /// **Local, decentralized peer selection.** Returns the candidate maximizing
+    /// `C(i,j,q)`, computed purely from this agent's own view and the observable
+    /// candidate profiles. No central planner participates.
+    ///
+    /// The selecting agent never picks itself. `excluded` lets callers skip peers
+    /// already visited on the current path or peers that are quarantined.
+    pub fn select_peer(
+        &self,
+        candidates: &[PeerProfile],
+        query: &Query,
+        excluded: &[PeerId],
+    ) -> Option<PeerSelection> {
+        candidates
+            .iter()
+            .filter(|p| p.id != self.me && !excluded.contains(&p.id))
+            .map(|p| {
+                let cap = self.ground(p, query);
+                PeerSelection {
+                    peer: p.id,
+                    capability: cap,
+                    score: cap.score(),
+                }
+            })
+            // Highest score wins; total_cmp gives a deterministic order for the
+            // NaN-free scores we produce.
+            .max_by(|a, b| a.score.total_cmp(&b.score))
+    }
+}
+
+/// Result of a local peer-selection round.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PeerSelection {
+    pub peer: PeerId,
+    pub capability: CapabilityVector,
+    pub score: f32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile(id: u64, skill: Vec<f32>, trust: f32, cost: f32, last: u64) -> PeerProfile {
+        PeerProfile {
+            id: PeerId(id),
+            skill,
+            trust,
+            cost,
+            last_active_step: last,
+        }
+    }
+
+    #[test]
+    fn score_is_the_adr_formula() {
+        let cap = CapabilityVector {
+            competence: 0.8,
+            trust: 0.5,
+            locality: 1.0,
+            freshness: 0.5,
+            cost: 2.0,
+        };
+        // 0.8 * 0.5 * 1.0 * 0.5 / 2.0 = 0.1
+        assert!((cap.score() - 0.1).abs() < 1e-6);
+    }
+
+    #[test]
+    fn competence_is_query_dependent() {
+        // Same peer, two different queries → different competence, therefore a
+        // different capability vector. This is the "no static role" property.
+        let view = LocalView::new(PeerId(0), vec![1.0, 1.0, 1.0], 10);
+        let peer = profile(1, vec![1.0, 0.0, 0.0], 1.0, 1.0, 10);
+
+        let q_match = Query::new(1, vec![1.0, 0.0, 0.0]);
+        let q_miss = Query::new(2, vec![0.0, 1.0, 0.0]);
+
+        let c_match = view.ground(&peer, &q_match).competence;
+        let c_miss = view.ground(&peer, &q_miss).competence;
+
+        assert!(c_match > 0.9, "aligned query → high competence");
+        assert!(c_miss < 0.1, "orthogonal query → ~zero competence");
+    }
+
+    #[test]
+    fn select_peer_is_local_and_picks_best() {
+        let view = LocalView::new(PeerId(0), vec![1.0, 0.0, 0.0], 10);
+        // Query wants the first skill dimension.
+        let query = Query::new(1, vec![1.0, 0.0, 0.0]);
+        let candidates = vec![
+            profile(1, vec![1.0, 0.0, 0.0], 0.9, 1.0, 10), // strong match
+            profile(2, vec![0.0, 1.0, 0.0], 0.9, 1.0, 10), // wrong skill
+            profile(3, vec![1.0, 0.0, 0.0], 0.9, 5.0, 10), // match but expensive
+        ];
+        let sel = view.select_peer(&candidates, &query, &[]).unwrap();
+        assert_eq!(sel.peer, PeerId(1), "best competence/cost wins locally");
+    }
+
+    #[test]
+    fn select_peer_never_returns_self_or_excluded() {
+        let view = LocalView::new(PeerId(1), vec![1.0, 0.0, 0.0], 10);
+        let query = Query::new(1, vec![1.0, 0.0, 0.0]);
+        let candidates = vec![
+            profile(1, vec![1.0, 0.0, 0.0], 1.0, 1.0, 10), // self
+            profile(2, vec![1.0, 0.0, 0.0], 1.0, 1.0, 10), // excluded below
+            profile(3, vec![0.9, 0.1, 0.0], 0.8, 1.0, 10),
+        ];
+        let sel = view
+            .select_peer(&candidates, &query, &[PeerId(2)])
+            .unwrap();
+        assert_eq!(sel.peer, PeerId(3));
+    }
+
+    #[test]
+    fn zero_cost_cannot_manufacture_infinite_score() {
+        let cap = CapabilityVector {
+            competence: 1.0,
+            trust: 1.0,
+            locality: 1.0,
+            freshness: 1.0,
+            cost: 0.0,
+        };
+        assert!(cap.score().is_finite());
+    }
+}

--- a/crates/rvAgent/latentmesh-thoughtmap/src/causal.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/causal.rs
@@ -171,6 +171,24 @@ mod tests {
     }
 
     #[test]
+    fn nan_latent_never_accepted_at_the_gate() {
+        // Defense-in-depth: even if a non-finite latent reached the gate directly
+        // (bypassing the incorporate choke point), guarded cosine returns 0.0 (not
+        // NaN), so attribution < threshold and the message is Rejected — never the
+        // silent NaN→Accept fall-through.
+        let mut map = ThoughtMap::new();
+        let a = map.add_step(PeerId(1), vec![1.0, 0.0, 0.0], "A");
+        let _b = map.add_step(PeerId(2), vec![0.0, 1.0, 0.0], "B");
+        let v = ControlledReplacementVerifier::default();
+
+        let nan = msg(9, vec![f32::NAN, 0.0, 0.0], a);
+        assert!(!v.verify(&map, &nan).is_accepted(), "NaN must not be accepted");
+
+        let inf = msg(9, vec![f32::INFINITY, 0.0, 0.0], a);
+        assert!(!v.verify(&map, &inf).is_accepted(), "inf must not be accepted");
+    }
+
+    #[test]
     fn missing_antecedent_is_rejected() {
         let map = ThoughtMap::new();
         let m = msg(9, vec![1.0, 0.0, 0.0], StepId(42));

--- a/crates/rvAgent/latentmesh-thoughtmap/src/causal.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/causal.rs
@@ -1,0 +1,201 @@
+//! Causal-attribution gate for incoming latent messages (ADR-326 §4 security
+//! gate; ADR-310 controlled-replacement causal audit).
+//!
+//! **A received latent message must pass causal attribution before it is
+//! incorporated into the thought graph — it is not trusted merely because it
+//! arrived.** This is the security property WP23 must hold: attributability of
+//! every incorporated message (the WP6 concern flagged on RuVector#882).
+//!
+//! ## Controlled-replacement causal audit
+//!
+//! A message claims "I follow causally from antecedent step `A`." ADR-310's
+//! audit does not take that on faith. The gate applies two conditions:
+//!
+//! 1. **Attribution** — the message's latent contribution must actually be
+//!    explained by `A`'s latent signature (cosine ≥ `accept_threshold`). A
+//!    forged message whose latent is unrelated to its claimed cause fails here.
+//! 2. **Specificity (the controlled replacement)** — `A` must be *specifically*
+//!    load-bearing. We substitute a **control** antecedent (the mean signature of
+//!    the other steps) and re-measure attribution. If the control explains the
+//!    message just as well, `A` is not the genuine cause — the attribution is
+//!    spurious — and the message fails.
+//!
+//! Only a message that is both attributable to its claimed cause *and*
+//! specifically so is [`CausalVerdict::Accept`]ed. Everything else is rejected
+//! and never reaches the thought graph.
+
+use serde::{Deserialize, Serialize};
+
+use crate::thoughtmap::{ThoughtMap, StepId};
+use crate::transport::LatentMessage;
+use crate::vecmath::{cosine, mean};
+
+/// Outcome of the causal-attribution audit.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CausalVerdict {
+    /// Message is attributable to its claimed antecedent and that antecedent is
+    /// specifically load-bearing. Safe to incorporate.
+    Accept,
+    /// The claimed antecedent step does not exist in the thought map.
+    Reject(RejectReason),
+}
+
+/// Why a message failed the causal gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RejectReason {
+    /// The claimed antecedent step is not in the thought map.
+    MissingAntecedent,
+    /// The message's latent is not explained by its claimed cause.
+    Unattributable,
+    /// A control antecedent explains the message just as well — the attribution
+    /// to the claimed cause is spurious.
+    Spurious,
+}
+
+impl CausalVerdict {
+    pub fn is_accepted(&self) -> bool {
+        matches!(self, CausalVerdict::Accept)
+    }
+}
+
+/// The ADR-310 gate. A production audit (WP6) can implement this trait
+/// differently; the receiving agent only ever calls [`CausalVerifier::verify`].
+pub trait CausalVerifier {
+    fn verify(&self, map: &ThoughtMap, msg: &LatentMessage) -> CausalVerdict;
+}
+
+/// Default controlled-replacement verifier.
+#[derive(Debug, Clone, Copy)]
+pub struct ControlledReplacementVerifier {
+    /// Minimum attribution (cosine) of message → claimed antecedent.
+    pub accept_threshold: f32,
+    /// Minimum margin by which the claimed antecedent must beat the control.
+    pub specificity_margin: f32,
+}
+
+impl Default for ControlledReplacementVerifier {
+    fn default() -> Self {
+        Self {
+            accept_threshold: 0.6,
+            specificity_margin: 0.1,
+        }
+    }
+}
+
+impl ControlledReplacementVerifier {
+    pub fn new(accept_threshold: f32, specificity_margin: f32) -> Self {
+        Self {
+            accept_threshold,
+            specificity_margin,
+        }
+    }
+}
+
+impl CausalVerifier for ControlledReplacementVerifier {
+    fn verify(&self, map: &ThoughtMap, msg: &LatentMessage) -> CausalVerdict {
+        let antecedent: StepId = msg.causal.antecedent;
+
+        // Condition 0: the claimed cause must exist. A forged reference to a
+        // non-existent step is rejected outright.
+        let Some(node) = map.node(antecedent) else {
+            return CausalVerdict::Reject(RejectReason::MissingAntecedent);
+        };
+
+        // Condition 1: attribution — is the message explained by its claimed cause?
+        let attribution = cosine(&msg.latent, &node.latent);
+        if attribution < self.accept_threshold {
+            return CausalVerdict::Reject(RejectReason::Unattributable);
+        }
+
+        // Condition 2: controlled replacement — substitute a control antecedent
+        // (mean of the *other* steps) and re-measure. The claimed cause must be
+        // specifically responsible, not generically so.
+        let controls = map.control_signatures(antecedent);
+        if !controls.is_empty() {
+            let control = mean(&controls);
+            let control_attribution = cosine(&msg.latent, &control);
+            if attribution - control_attribution < self.specificity_margin {
+                return CausalVerdict::Reject(RejectReason::Spurious);
+            }
+        }
+
+        CausalVerdict::Accept
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capability::PeerId;
+    use crate::thoughtmap::ThoughtGraphBackend;
+    use crate::transport::{integrity_tag, CausalTag, LatentMessage};
+
+    fn msg(from: u64, latent: Vec<f32>, antecedent: StepId) -> LatentMessage {
+        LatentMessage {
+            from: PeerId(from),
+            to: PeerId(0),
+            integrity: integrity_tag(PeerId(from), PeerId(0), &latent, antecedent),
+            causal: CausalTag { antecedent },
+            latent,
+            summary: String::new(),
+        }
+    }
+
+    #[test]
+    fn genuine_message_is_accepted() {
+        let mut map = ThoughtMap::new();
+        // A "topic A" antecedent and an unrelated "topic B" node so the control
+        // population is meaningfully different.
+        let a = map.add_step(PeerId(1), vec![1.0, 0.0, 0.0], "A");
+        let _b = map.add_step(PeerId(2), vec![0.0, 1.0, 0.0], "B");
+
+        // A message genuinely derived from A (close to A, far from the control).
+        let m = msg(2, vec![0.98, 0.02, 0.0], a);
+        let v = ControlledReplacementVerifier::default();
+        assert_eq!(v.verify(&map, &m), CausalVerdict::Accept);
+    }
+
+    #[test]
+    fn forged_message_unrelated_to_cause_is_rejected() {
+        let mut map = ThoughtMap::new();
+        let a = map.add_step(PeerId(1), vec![1.0, 0.0, 0.0], "A");
+        let _b = map.add_step(PeerId(2), vec![0.0, 1.0, 0.0], "B");
+
+        // Latent orthogonal to the claimed antecedent A → not attributable.
+        let m = msg(9, vec![0.0, 0.0, 1.0], a);
+        let v = ControlledReplacementVerifier::default();
+        assert_eq!(
+            v.verify(&map, &m),
+            CausalVerdict::Reject(RejectReason::Unattributable)
+        );
+    }
+
+    #[test]
+    fn missing_antecedent_is_rejected() {
+        let map = ThoughtMap::new();
+        let m = msg(9, vec![1.0, 0.0, 0.0], StepId(42));
+        let v = ControlledReplacementVerifier::default();
+        assert_eq!(
+            v.verify(&map, &m),
+            CausalVerdict::Reject(RejectReason::MissingAntecedent)
+        );
+    }
+
+    #[test]
+    fn spurious_attribution_to_a_generic_cause_is_rejected() {
+        // When the message latent looks like the *average* of the map (explained
+        // equally by any node), attribution to the specific claimed cause is
+        // spurious and the controlled replacement catches it.
+        let mut map = ThoughtMap::new();
+        let a = map.add_step(PeerId(1), vec![1.0, 1.0, 1.0], "A");
+        let _b = map.add_step(PeerId(2), vec![1.0, 1.0, 1.0], "B");
+        let _c = map.add_step(PeerId(3), vec![1.0, 1.0, 1.0], "C");
+        // Message aligned with the shared direction — every node explains it.
+        let m = msg(2, vec![1.0, 1.0, 1.0], a);
+        let v = ControlledReplacementVerifier::default();
+        assert_eq!(
+            v.verify(&map, &m),
+            CausalVerdict::Reject(RejectReason::Spurious)
+        );
+    }
+}

--- a/crates/rvAgent/latentmesh-thoughtmap/src/engine.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/engine.rs
@@ -1,0 +1,179 @@
+//! The reasoning engine — wires capability grounding, the thought map, the
+//! causal gate, quarantine, and dead-end topology adaptation into one decision
+//! surface (ADR-326).
+//!
+//! Two responsibilities matter for the WP23 security properties:
+//!
+//! * [`ReasoningEngine::incorporate`] is the **single choke point** through which
+//!   any peer message reaches the thought graph. It enforces, in order:
+//!   integrity (ADR-311) → quarantine dampening (ADR-311) → causal attribution
+//!   (ADR-310). A message that fails any check is **never** written to the graph.
+//! * [`ReasoningEngine::handle_dead_end`] applies the swappable, explicitly
+//!   *unverified* dead-end [`DeadEndPolicy`] (ADR-326 §6), and **refuses any
+//!   topology change prompted by a quarantined peer** — a misbehaving peer
+//!   cannot churn the topology.
+
+use crate::capability::{LocalView, PeerId, PeerProfile, Query};
+use crate::causal::{CausalVerdict, CausalVerifier};
+use crate::quarantine::{Anomaly, Quarantine};
+use crate::thoughtmap::{StepId, ThoughtGraphBackend, ThoughtMap};
+use crate::topology::{DeadEndPolicy, TopologyCause, TopologyChange};
+use crate::transport::{integrity_tag, LatentMessage};
+
+/// Root step every reasoning process starts from; `Restart` resumes here.
+pub const ROOT_STEP: StepId = StepId(0);
+
+/// Weight a freshly incorporated peer-interaction edge starts at, before any
+/// success/failure feedback reinforces or weakens it.
+const INITIAL_EDGE_WEIGHT: f32 = 0.5;
+
+/// Result of attempting to incorporate a message.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Incorporation {
+    /// Accepted: a new reasoning step was written and connected to its cause.
+    Accepted { step: StepId },
+    /// Dropped because the sender is quarantined; the map is untouched.
+    Dampened,
+    /// Rejected by a gate; the map is untouched. Carries the reason.
+    Rejected(RejectionKind),
+}
+
+/// Why a message was rejected (distinct from being dampened for quarantine).
+#[derive(Debug, Clone, PartialEq)]
+pub enum RejectionKind {
+    /// Integrity tag did not match (tampering) — ADR-311.
+    Integrity,
+    /// Failed the causal-attribution gate — ADR-310.
+    Causal(crate::causal::RejectReason),
+}
+
+/// The engine. Generic over the [`CausalVerifier`] so WP6 can substitute a
+/// production audit without touching the choke-point logic.
+#[derive(Debug, Clone)]
+pub struct ReasoningEngine<V: CausalVerifier> {
+    pub map: ThoughtMap,
+    pub quarantine: Quarantine,
+    /// **Unverified design choice** (ADR-326 §6) — see [`crate::topology`].
+    pub policy: DeadEndPolicy,
+    verifier: V,
+}
+
+impl<V: CausalVerifier> ReasoningEngine<V> {
+    pub fn new(map: ThoughtMap, verifier: V, quarantine: Quarantine, policy: DeadEndPolicy) -> Self {
+        Self {
+            map,
+            quarantine,
+            policy,
+            verifier,
+        }
+    }
+
+    /// **The choke point.** Incorporate a received latent message into the
+    /// thought graph iff it passes every gate. Order is deliberate: cheap
+    /// tamper-evidence first, then quarantine, then the causal audit.
+    pub fn incorporate(&mut self, msg: &LatentMessage) -> Incorporation {
+        // 1. Integrity (ADR-311). A tampered channel is the strongest anomaly.
+        let expected = integrity_tag(msg.from, msg.to, &msg.latent, msg.causal.antecedent);
+        if msg.integrity != expected {
+            self.quarantine.record(msg.from, Anomaly::IntegrityFailure);
+            return Incorporation::Rejected(RejectionKind::Integrity);
+        }
+
+        // 2. Quarantine dampening (ADR-311). A quarantined peer's messages are
+        //    never incorporated — this is what stops a bad actor reshaping the map.
+        if self.quarantine.is_quarantined(msg.from) {
+            return Incorporation::Dampened;
+        }
+
+        // 3. Causal attribution (ADR-310). Must be attributable to its claimed
+        //    cause under controlled replacement before it may touch the graph.
+        match self.verifier.verify(&self.map, msg) {
+            CausalVerdict::Accept => {
+                let step = self
+                    .map
+                    .add_step(msg.from, msg.latent.clone(), msg.summary.clone());
+                self.map
+                    .connect(msg.causal.antecedent, step, msg.from, INITIAL_EDGE_WEIGHT);
+                Incorporation::Accepted { step }
+            }
+            CausalVerdict::Reject(reason) => {
+                // A message that fails causal attribution is an anomaly signal;
+                // sustained failures quarantine the sender.
+                self.quarantine.record(msg.from, Anomaly::CausalRejection);
+                Incorporation::Rejected(RejectionKind::Causal(reason))
+            }
+        }
+    }
+
+    /// Reinforce a confirmed-good reasoning path (ADR-326 §5).
+    pub fn reinforce(&mut self, path: &[StepId], delta: f32) {
+        self.map.reinforce_path(path, delta);
+    }
+
+    /// Weaken a confirmed-bad reasoning path (ADR-326 §5).
+    pub fn weaken(&mut self, path: &[StepId], delta: f32) {
+        self.map.weaken_path(path, delta);
+    }
+
+    /// Apply the dead-end policy at `node`.
+    ///
+    /// `triggered_by` is the peer/agent whose situation prompted the adaptation;
+    /// **if that peer is quarantined the change is refused (`None`)** so a
+    /// misbehaving peer cannot force topology churn. Every returned
+    /// [`TopologyChange`] is attributable (`cause` + `triggered_by`).
+    ///
+    /// For [`DeadEndPolicy::ContinueWithTopologyChange`] (the **unverified**
+    /// default, ADR-326 §6) reasoning resumes from `node` itself, re-routed to a
+    /// freshly selected non-quarantined peer — progress is preserved. For
+    /// [`DeadEndPolicy::Restart`] reasoning resumes from [`ROOT_STEP`].
+    pub fn handle_dead_end(
+        &mut self,
+        node: StepId,
+        view: &LocalView,
+        candidates: &[PeerProfile],
+        query: &Query,
+        visited: &[PeerId],
+        triggered_by: PeerId,
+    ) -> Option<TopologyChange> {
+        // Refuse churn prompted by a quarantined peer (ADR-311 / acceptance).
+        if self.quarantine.is_quarantined(triggered_by) {
+            return None;
+        }
+
+        match self.policy {
+            DeadEndPolicy::ContinueWithTopologyChange => {
+                // Re-route locally, excluding already-visited and quarantined peers.
+                let excluded = self.excluded_peers(visited, candidates);
+                let new_peer = view
+                    .select_peer(candidates, query, &excluded)
+                    .map(|s| s.peer);
+                Some(TopologyChange {
+                    resume_from: node, // continue from current state, NOT root
+                    new_peer,
+                    cause: TopologyCause::DeadEnd,
+                    triggered_by,
+                    continued: true,
+                })
+            }
+            DeadEndPolicy::Restart => Some(TopologyChange {
+                resume_from: ROOT_STEP, // discard progress
+                new_peer: None,
+                cause: TopologyCause::DeadEnd,
+                triggered_by,
+                continued: false,
+            }),
+        }
+    }
+
+    /// Visited peers plus every currently quarantined candidate — the exclusion
+    /// set for re-routing.
+    fn excluded_peers(&self, visited: &[PeerId], candidates: &[PeerProfile]) -> Vec<PeerId> {
+        let mut excluded = visited.to_vec();
+        for c in candidates {
+            if self.quarantine.is_quarantined(c.id) && !excluded.contains(&c.id) {
+                excluded.push(c.id);
+            }
+        }
+        excluded
+    }
+}

--- a/crates/rvAgent/latentmesh-thoughtmap/src/engine.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/engine.rs
@@ -41,6 +41,12 @@ pub enum Incorporation {
 /// Why a message was rejected (distinct from being dampened for quarantine).
 #[derive(Debug, Clone, PartialEq)]
 pub enum RejectionKind {
+    /// The latent payload contained a non-finite (NaN/±inf) element. Such a
+    /// message is malformed/hostile and is rejected at the choke point *before*
+    /// the causal gate — a NaN would otherwise make every `<`-comparison in the
+    /// gate false and silently fall through to Accept, then poison the map-wide
+    /// control population. This is the real fix for that class of attack.
+    NonFinite,
     /// Integrity tag did not match (tampering) — ADR-311.
     Integrity,
     /// Failed the causal-attribution gate — ADR-310.
@@ -72,6 +78,17 @@ impl<V: CausalVerifier> ReasoningEngine<V> {
     /// thought graph iff it passes every gate. Order is deliberate: cheap
     /// tamper-evidence first, then quarantine, then the causal audit.
     pub fn incorporate(&mut self, msg: &LatentMessage) -> Incorporation {
+        // 0. Finiteness (the real NaN-bypass fix). A non-finite latent would make
+        //    the causal gate's `<`-comparisons false and fall through to Accept,
+        //    then poison the map-wide control. Reject BEFORE any gate, never write
+        //    it, and strike the sender — a non-finite injection IS map degradation
+        //    (this is where the previously-unrecorded MapDegradation anomaly is
+        //    wired), so a repeat offender quarantines instead of retrying forever.
+        if !crate::vecmath::is_finite(&msg.latent) {
+            self.quarantine.record(msg.from, Anomaly::MapDegradation);
+            return Incorporation::Rejected(RejectionKind::NonFinite);
+        }
+
         // 1. Integrity (ADR-311). A tampered channel is the strongest anomaly.
         let expected = integrity_tag(msg.from, msg.to, &msg.latent, msg.causal.antecedent);
         if msg.integrity != expected {

--- a/crates/rvAgent/latentmesh-thoughtmap/src/lib.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/lib.rs
@@ -1,0 +1,74 @@
+//! # latentmesh-thoughtmap — DeAR-pattern decentralized capability-grounded reasoning
+//!
+//! PIR **WP23** (RuVector#882), implementing **ADR-326** over the LatentMesh
+//! fabric (ADR-309 transport, ADR-310 causal gate, ADR-311 quarantine).
+//!
+//! Informed by **DeAR** — *Decentralized Agentic Reasoning via Capability
+//! Grounding and Collaborative Thought Navigation* (arXiv:2608.17282), graded
+//! **B+, not A**, with **no released code** (the paper's repo is a placeholder
+//! `https://open_upon_acceptance` URL). This crate is therefore a **first-party
+//! build from the paper's description**, not a port. Under the program's
+//! preprint-reproduction rule, DeAR's reported numbers are hypotheses, not the
+//! acceptance bar.
+//!
+//! ## What this first shippable slice provides
+//!
+//! 1. **Capability vectors replace named roles** ([`capability`]): for a triple
+//!    `(agent i, peer j, query q)`, `C(i,j,q) = competence × trust × locality ×
+//!    freshness ÷ cost`, recomputed *per query*. Each agent selects its next peer
+//!    **locally** — no central planner ([`capability::LocalView::select_peer`]).
+//! 2. **A shared, navigable thought map** ([`thoughtmap`]): nodes are reasoning
+//!    steps, edges are peer interactions; success **reinforces** edges, failure
+//!    **weakens** them. First-party in-memory graph today, with a documented
+//!    RuVector-integration seam ([`thoughtmap::ThoughtGraphBackend`]).
+//! 3. **LatentMesh transport carrying compressed latent state** ([`transport`]),
+//!    with **causal verification before acceptance** ([`causal`]) — a received
+//!    latent message must pass ADR-310's controlled-replacement causal audit or
+//!    it is never incorporated.
+//! 4. **Dead-end handling** ([`topology`]): change topology and *continue from
+//!    the current state* rather than restart — **explicitly marked an unverified
+//!    design choice (ADR-326 §6), not a reproduced DeAR claim**, and kept
+//!    swappable via [`topology::DeadEndPolicy`].
+//! 5. **Security** ([`quarantine`], [`engine`]): every incorporated message is
+//!    causally attributable, and a peer that degrades the map is dampened /
+//!    quarantined so it cannot churn the topology.
+//!
+//! ## Deferred (honest scope)
+//!
+//! Real multi-agent execution, the 9-benchmark DeAR evaluation, and full
+//! LatentMesh **wire** transport (compression codec + `ruvnet/LatentMesh`
+//! wire-format coordination) are out of scope for this slice. The transport is a
+//! defined seam with an in-process stub; a WP5 crate implements
+//! [`transport::LatentTransport`] later without changing callers.
+//!
+//! ## ⚠️ Unverified-behavior marker (binding, ADR-326)
+//!
+//! The dead-end **"continue, not restart"** behavior is this program's own
+//! working interpretation of the abstract's four-word *"topology update for
+//! adaptive error correction"* — **not** a verified paper claim. It must be
+//! re-verified against the full paper or released code before being treated as a
+//! fixed contract. See [`topology`] for the full marker.
+
+pub mod capability;
+pub mod causal;
+pub mod engine;
+pub mod quarantine;
+pub mod thoughtmap;
+pub mod topology;
+pub mod transport;
+mod vecmath;
+
+pub use capability::{CapabilityVector, LocalView, PeerId, PeerProfile, PeerSelection, Query};
+pub use causal::{
+    CausalVerdict, CausalVerifier, ControlledReplacementVerifier, RejectReason,
+};
+pub use engine::{Incorporation, ReasoningEngine, RejectionKind, ROOT_STEP};
+pub use quarantine::{Anomaly, PeerReputation, Quarantine};
+pub use thoughtmap::{
+    StepId, ThoughtEdge, ThoughtGraphBackend, ThoughtMap, ThoughtNode,
+};
+pub use topology::{DeadEndPolicy, TopologyCause, TopologyChange};
+pub use transport::{
+    integrity_tag, CausalTag, InProcessTransport, LatentMessage, LatentState, LatentTransport,
+    TransportError,
+};

--- a/crates/rvAgent/latentmesh-thoughtmap/src/quarantine.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/quarantine.rs
@@ -1,0 +1,156 @@
+//! Anomaly quarantine for misbehaving peers (ADR-326 §security; ADR-311).
+//!
+//! The WP7 concern flagged on RuVector#882: **a misbehaving peer must not be
+//! able to trigger spurious topology churn.** A peer that degrades the shared
+//! thought map — repeatedly sending messages that fail the causal gate, failing
+//! integrity checks, or weakening good edges / injecting bad steps — accrues
+//! anomaly strikes. Once over threshold the peer is **quarantined**: its
+//! messages are dampened (not incorporated) and, crucially, its proposed
+//! topology mutations are ignored, so it cannot arbitrarily reshape the graph.
+//!
+//! This is deliberately *not* a hair-trigger: a single failure dampens influence
+//! but does not quarantine. Only sustained anomalous behavior quarantines,
+//! bounding the damage one bad actor can do without penalizing transient noise.
+
+use std::collections::HashMap;
+
+use crate::capability::PeerId;
+
+/// The kind of anomalous behavior observed from a peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Anomaly {
+    /// A message failed the ADR-310 causal-attribution gate.
+    CausalRejection,
+    /// A message failed the ADR-311 integrity (HMAC) check.
+    IntegrityFailure,
+    /// The peer's incorporated contribution was later confirmed to have
+    /// weakened a known-good path or injected a bad step.
+    MapDegradation,
+}
+
+impl Anomaly {
+    /// How many strikes this class of anomaly contributes. Integrity failures
+    /// are treated as the strongest signal of a malicious/tampered channel.
+    fn weight(self) -> u32 {
+        match self {
+            Anomaly::CausalRejection => 1,
+            Anomaly::MapDegradation => 2,
+            Anomaly::IntegrityFailure => 3,
+        }
+    }
+}
+
+/// Per-peer reputation and quarantine state.
+#[derive(Debug, Clone)]
+pub struct PeerReputation {
+    pub peer: PeerId,
+    pub strikes: u32,
+    pub quarantined: bool,
+}
+
+/// Tracks anomalies per peer and decides quarantine.
+#[derive(Debug, Clone)]
+pub struct Quarantine {
+    reputations: HashMap<PeerId, PeerReputation>,
+    /// Strike total at or above which a peer is quarantined.
+    pub strike_threshold: u32,
+}
+
+impl Default for Quarantine {
+    fn default() -> Self {
+        Self {
+            reputations: HashMap::new(),
+            strike_threshold: 3,
+        }
+    }
+}
+
+impl Quarantine {
+    pub fn new(strike_threshold: u32) -> Self {
+        Self {
+            reputations: HashMap::new(),
+            strike_threshold,
+        }
+    }
+
+    fn entry(&mut self, peer: PeerId) -> &mut PeerReputation {
+        self.reputations.entry(peer).or_insert(PeerReputation {
+            peer,
+            strikes: 0,
+            quarantined: false,
+        })
+    }
+
+    /// Record an anomaly for a peer, returning whether it is now quarantined.
+    pub fn record(&mut self, peer: PeerId, anomaly: Anomaly) -> bool {
+        let threshold = self.strike_threshold;
+        let rep = self.entry(peer);
+        rep.strikes = rep.strikes.saturating_add(anomaly.weight());
+        if rep.strikes >= threshold {
+            rep.quarantined = true;
+        }
+        rep.quarantined
+    }
+
+    /// Whether a peer is currently quarantined. Quarantined peers' messages are
+    /// dampened and their topology mutations ignored.
+    pub fn is_quarantined(&self, peer: PeerId) -> bool {
+        self.reputations
+            .get(&peer)
+            .map(|r| r.quarantined)
+            .unwrap_or(false)
+    }
+
+    pub fn strikes(&self, peer: PeerId) -> u32 {
+        self.reputations.get(&peer).map(|r| r.strikes).unwrap_or(0)
+    }
+
+    /// Reinstate a peer whose good behavior has been re-established (e.g. after a
+    /// witness-verified appeal). Kept explicit so reinstatement is always an
+    /// auditable action, never automatic decay.
+    pub fn reinstate(&mut self, peer: PeerId) {
+        if let Some(rep) = self.reputations.get_mut(&peer) {
+            rep.strikes = 0;
+            rep.quarantined = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_failure_does_not_quarantine() {
+        let mut q = Quarantine::default();
+        assert!(!q.record(PeerId(7), Anomaly::CausalRejection));
+        assert!(!q.is_quarantined(PeerId(7)));
+    }
+
+    #[test]
+    fn sustained_anomalies_quarantine() {
+        let mut q = Quarantine::default();
+        q.record(PeerId(7), Anomaly::CausalRejection);
+        q.record(PeerId(7), Anomaly::CausalRejection);
+        let now = q.record(PeerId(7), Anomaly::CausalRejection);
+        assert!(now);
+        assert!(q.is_quarantined(PeerId(7)));
+    }
+
+    #[test]
+    fn integrity_failure_quarantines_fast() {
+        let mut q = Quarantine::default();
+        // Weight 3 ≥ threshold 3 in one shot — a tampered channel is high signal.
+        assert!(q.record(PeerId(9), Anomaly::IntegrityFailure));
+    }
+
+    #[test]
+    fn reinstate_clears_state() {
+        let mut q = Quarantine::default();
+        q.record(PeerId(7), Anomaly::IntegrityFailure);
+        assert!(q.is_quarantined(PeerId(7)));
+        q.reinstate(PeerId(7));
+        assert!(!q.is_quarantined(PeerId(7)));
+        assert_eq!(q.strikes(PeerId(7)), 0);
+    }
+}

--- a/crates/rvAgent/latentmesh-thoughtmap/src/thoughtmap.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/thoughtmap.rs
@@ -141,6 +141,15 @@ impl ThoughtGraphBackend for ThoughtMap {
     fn add_step(&mut self, author: PeerId, latent: Vec<f32>, summary: impl Into<String>) -> StepId {
         let id = StepId(self.next_step);
         self.next_step += 1;
+        // Defense-in-depth: never store a non-finite latent, even if a caller
+        // bypassed the `incorporate` choke point. A non-finite element is
+        // sanitized to 0.0 so the map's signatures — and the control population
+        // derived from them — stay finite and the causal gate cannot silently
+        // degrade. The real fix rejects such messages before they reach here.
+        let latent: Vec<f32> = latent
+            .into_iter()
+            .map(|x| if x.is_finite() { x } else { 0.0 })
+            .collect();
         self.nodes.push(ThoughtNode {
             id,
             author,

--- a/crates/rvAgent/latentmesh-thoughtmap/src/thoughtmap.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/thoughtmap.rs
@@ -1,0 +1,234 @@
+//! The shared thought map (ADR-326 Decision §3, §5).
+//!
+//! DeAR's confirmed mechanism (arXiv:2608.17282, part 2) is *thought-map
+//! navigation for targeted peer interactions*. We persist the evolving
+//! collaborative reasoning process as a graph: each **node** is a reasoning
+//! step, each **edge** is a targeted peer interaction. Successful reasoning
+//! paths **reinforce** their edges; failed paths **weaken** them — an evolving,
+//! experience-weighted topology rather than a static one.
+//!
+//! ## RuVector-integration seam
+//!
+//! ADR-326 §3 states the thought graph should be persisted in RuVector's durable
+//! graph substrate (as ADR-307 memory tiers / ADR-320 causal episodic graph do).
+//! This first shippable slice ships a **first-party in-memory graph** so WP23 is
+//! testable without blocking on the WP5 transport crates, and exposes a
+//! documented seam — the [`ThoughtGraphBackend`] trait — that a RuVector-backed
+//! store (`ruvector-graph`) implements later without changing callers. The
+//! in-memory [`ThoughtMap`] is one implementation of that seam.
+
+use serde::{Deserialize, Serialize};
+
+use crate::capability::PeerId;
+
+/// Identifier for a reasoning step (a node in the thought map).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct StepId(pub u64);
+
+/// A reasoning step. Carries a `latent` signature — the compressed latent state
+/// (KV-cache-style, ADR-326 §4) that summarizes the step — used both for
+/// navigation and as the anchor for causal attribution of incoming messages.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ThoughtNode {
+    pub id: StepId,
+    /// The agent whose contribution produced this step.
+    pub author: PeerId,
+    /// Compressed latent signature of the step.
+    pub latent: Vec<f32>,
+    /// Optional human-readable summary (debugging / witness records).
+    #[serde(default)]
+    pub summary: String,
+}
+
+/// A directed edge: a targeted peer interaction connecting two reasoning steps.
+/// `weight` is the experience-weighted strength; reinforcement raises it, failure
+/// lowers it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ThoughtEdge {
+    pub from: StepId,
+    pub to: StepId,
+    /// The peer interaction this edge represents.
+    pub peer: PeerId,
+    /// Experience-weighted strength in `[0, 1]`.
+    pub weight: f32,
+}
+
+/// The RuVector-integration seam. A RuVector-backed thought graph (e.g. over
+/// `ruvector-graph`) implements this without changing any caller; [`ThoughtMap`]
+/// is the first-party in-memory implementation used by this slice.
+pub trait ThoughtGraphBackend {
+    fn add_step(&mut self, author: PeerId, latent: Vec<f32>, summary: impl Into<String>) -> StepId;
+    fn connect(&mut self, from: StepId, to: StepId, peer: PeerId, weight: f32);
+    fn node(&self, id: StepId) -> Option<&ThoughtNode>;
+    fn reinforce_path(&mut self, path: &[StepId], delta: f32);
+    fn weaken_path(&mut self, path: &[StepId], delta: f32);
+}
+
+/// First-party in-memory thought map (the default [`ThoughtGraphBackend`]).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ThoughtMap {
+    nodes: Vec<ThoughtNode>,
+    edges: Vec<ThoughtEdge>,
+    next_step: u64,
+    /// Edges below this weight are treated as pruned for navigation: a node whose
+    /// every outgoing edge is below it is a dead end.
+    pub dead_edge_threshold: f32,
+}
+
+impl ThoughtMap {
+    pub fn new() -> Self {
+        Self {
+            dead_edge_threshold: 0.15,
+            ..Default::default()
+        }
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Look up a reasoning step by id. Inherent method so concrete callers don't
+    /// need [`ThoughtGraphBackend`] in scope; the trait impl delegates here.
+    pub fn node(&self, id: StepId) -> Option<&ThoughtNode> {
+        self.nodes.iter().find(|n| n.id == id)
+    }
+
+    pub fn edge_count(&self) -> usize {
+        self.edges.len()
+    }
+
+    pub fn edges(&self) -> &[ThoughtEdge] {
+        &self.edges
+    }
+
+    /// The signatures of every node except `exclude` — the control population for
+    /// controlled-replacement causal attribution (ADR-310). See [`crate::causal`].
+    pub fn control_signatures(&self, exclude: StepId) -> Vec<Vec<f32>> {
+        self.nodes
+            .iter()
+            .filter(|n| n.id != exclude)
+            .map(|n| n.latent.clone())
+            .collect()
+    }
+
+    /// Look up the strength of a specific edge (for assertions/tests).
+    pub fn edge_weight(&self, from: StepId, to: StepId) -> Option<f32> {
+        self.edges
+            .iter()
+            .find(|e| e.from == from && e.to == to)
+            .map(|e| e.weight)
+    }
+
+    /// Outgoing edges of a node, strongest first.
+    pub fn neighbors(&self, node: StepId) -> Vec<&ThoughtEdge> {
+        let mut out: Vec<&ThoughtEdge> = self.edges.iter().filter(|e| e.from == node).collect();
+        out.sort_by(|a, b| b.weight.total_cmp(&a.weight));
+        out
+    }
+
+    /// A node is a dead end when it has no outgoing edge strong enough to follow.
+    /// (Dead-end *handling* — the continue-vs-restart design choice — lives in
+    /// [`crate::topology`], deliberately separated from detection.)
+    pub fn is_dead_end(&self, node: StepId) -> bool {
+        !self
+            .edges
+            .iter()
+            .any(|e| e.from == node && e.weight >= self.dead_edge_threshold)
+    }
+}
+
+impl ThoughtGraphBackend for ThoughtMap {
+    fn add_step(&mut self, author: PeerId, latent: Vec<f32>, summary: impl Into<String>) -> StepId {
+        let id = StepId(self.next_step);
+        self.next_step += 1;
+        self.nodes.push(ThoughtNode {
+            id,
+            author,
+            latent,
+            summary: summary.into(),
+        });
+        id
+    }
+
+    fn connect(&mut self, from: StepId, to: StepId, peer: PeerId, weight: f32) {
+        self.edges.push(ThoughtEdge {
+            from,
+            to,
+            peer,
+            weight: weight.clamp(0.0, 1.0),
+        });
+    }
+
+    fn node(&self, id: StepId) -> Option<&ThoughtNode> {
+        ThoughtMap::node(self, id)
+    }
+
+    /// Reinforce every edge along a successful path.
+    fn reinforce_path(&mut self, path: &[StepId], delta: f32) {
+        for pair in path.windows(2) {
+            if let Some(edge) = self
+                .edges
+                .iter_mut()
+                .find(|e| e.from == pair[0] && e.to == pair[1])
+            {
+                edge.weight = (edge.weight + delta).clamp(0.0, 1.0);
+            }
+        }
+    }
+
+    /// Weaken every edge along a failed path.
+    fn weaken_path(&mut self, path: &[StepId], delta: f32) {
+        for pair in path.windows(2) {
+            if let Some(edge) = self
+                .edges
+                .iter_mut()
+                .find(|e| e.from == pair[0] && e.to == pair[1])
+            {
+                edge.weight = (edge.weight - delta).clamp(0.0, 1.0);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reinforce_and_weaken_move_edge_weights() {
+        let mut map = ThoughtMap::new();
+        let a = map.add_step(PeerId(1), vec![1.0, 0.0], "start");
+        let b = map.add_step(PeerId(2), vec![0.9, 0.1], "next");
+        map.connect(a, b, PeerId(2), 0.5);
+
+        map.reinforce_path(&[a, b], 0.3);
+        assert!((map.edge_weight(a, b).unwrap() - 0.8).abs() < 1e-6);
+
+        map.weaken_path(&[a, b], 0.6);
+        assert!((map.edge_weight(a, b).unwrap() - 0.2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn weights_stay_clamped() {
+        let mut map = ThoughtMap::new();
+        let a = map.add_step(PeerId(1), vec![1.0], "a");
+        let b = map.add_step(PeerId(2), vec![1.0], "b");
+        map.connect(a, b, PeerId(2), 0.9);
+        map.reinforce_path(&[a, b], 5.0);
+        assert_eq!(map.edge_weight(a, b).unwrap(), 1.0);
+        map.weaken_path(&[a, b], 5.0);
+        assert_eq!(map.edge_weight(a, b).unwrap(), 0.0);
+    }
+
+    #[test]
+    fn dead_end_detection() {
+        let mut map = ThoughtMap::new();
+        let a = map.add_step(PeerId(1), vec![1.0], "a");
+        let b = map.add_step(PeerId(2), vec![1.0], "b");
+        assert!(map.is_dead_end(a), "no outgoing edges → dead end");
+        map.connect(a, b, PeerId(2), 0.05); // below threshold
+        assert!(map.is_dead_end(a), "only a weak edge → still a dead end");
+        map.connect(a, b, PeerId(2), 0.5); // strong
+        assert!(!map.is_dead_end(a));
+    }
+}

--- a/crates/rvAgent/latentmesh-thoughtmap/src/topology.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/topology.rs
@@ -1,0 +1,100 @@
+//! Dead-end-triggered topology adaptation (ADR-326 Decision §6).
+//!
+//! # ⚠️ UNVERIFIED DESIGN CHOICE — NOT A REPRODUCED DeAR CLAIM
+//!
+//! DeAR (arXiv:2608.17282) grades **B+, not A**, precisely because of the
+//! behavior in this module. The abstract's confirmed text on dead-end handling
+//! is **four words** — *"topology update for adaptive error correction"*. It
+//! does **not** state a continue-vs-restart mechanism.
+//!
+//! The behavior implemented here — on a dead end, **mutate topology and CONTINUE
+//! from the current reasoning state rather than restarting** — is
+//! **this program's own design decision** (ADR-326 §6), *informed by but not
+//! confirmed against* the paper. It MUST NOT be presented as reproduced from
+//! DeAR, and this WP MUST NOT harden acceptance criteria around it as a fixed
+//! behavioral contract.
+//!
+//! **Re-verify against the full paper (unavailable today) or the eventual code
+//! release before locking this in.** If the full text contradicts the
+//! continue-not-restart reading, [`DeadEndPolicy::default`] and ADR-326 §6 must
+//! be revised. The behavior is kept **swappable** via [`DeadEndPolicy`] for
+//! exactly this reason: flipping to [`DeadEndPolicy::Restart`] is a one-line
+//! change with no other code depending on the choice.
+//!
+//! (Per ADR-326's binding "design-choice labeling discipline" gate: a missing
+//! label on this behavior is a review-blocking defect. Hence the loud markers.)
+
+use serde::{Deserialize, Serialize};
+
+use crate::capability::PeerId;
+use crate::thoughtmap::StepId;
+
+/// How the reasoning fabric reacts when a reasoning path hits a dead end.
+///
+/// **The variants encode the unverified continue-vs-restart choice explicitly so
+/// it stays a *choice*, not a buried assumption.**
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeadEndPolicy {
+    /// **This program's design choice (UNVERIFIED, ADR-326 §6):** change topology
+    /// and continue from the *current* state — re-route to a different peer via
+    /// updated capability vectors rather than discarding progress. Not attributed
+    /// to DeAR.
+    ContinueWithTopologyChange,
+    /// Swappable alternative: abandon the current reasoning state and restart
+    /// from the root. Provided so the continue-vs-restart decision can be flipped
+    /// if the full paper / released code contradicts the working interpretation.
+    Restart,
+}
+
+impl Default for DeadEndPolicy {
+    /// Defaults to the program's working interpretation. **This default is the
+    /// unverified design choice, not a paper claim** — see module docs.
+    fn default() -> Self {
+        DeadEndPolicy::ContinueWithTopologyChange
+    }
+}
+
+/// A single topology mutation. **Every mutation is attributable** (ADR-326 §
+/// acceptance: topology changes trace to a cause) — `cause` names why it
+/// happened, and `triggered_by` names the peer/agent whose action prompted it,
+/// so the quarantine layer can refuse churn proposed by a quarantined peer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TopologyChange {
+    /// Where reasoning resumes from after the change.
+    pub resume_from: StepId,
+    /// The newly selected collaboration peer (if the change re-routed).
+    pub new_peer: Option<PeerId>,
+    /// Machine-readable cause — makes the change auditable end-to-end.
+    pub cause: TopologyCause,
+    /// The peer/agent whose action prompted the change (attribution).
+    pub triggered_by: PeerId,
+    /// Whether progress was preserved (continue) or discarded (restart).
+    pub continued: bool,
+}
+
+/// Why a topology change happened. Auditable, witness-loggable cause.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TopologyCause {
+    /// A reasoning path hit a dead end and the [`DeadEndPolicy`] fired.
+    DeadEnd,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_policy_is_the_unverified_continue_choice() {
+        assert_eq!(
+            DeadEndPolicy::default(),
+            DeadEndPolicy::ContinueWithTopologyChange
+        );
+    }
+
+    #[test]
+    fn policy_is_swappable() {
+        // The whole point of the enum: flipping the design choice is trivial.
+        let p = DeadEndPolicy::Restart;
+        assert_ne!(p, DeadEndPolicy::default());
+    }
+}

--- a/crates/rvAgent/latentmesh-thoughtmap/src/transport.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/transport.rs
@@ -1,0 +1,159 @@
+//! LatentMesh transport seam (ADR-326 Decision §4, over ADR-309's greenfield
+//! crates).
+//!
+//! Peer-to-peer messages in this topology are carried as **compressed latent
+//! state** (KV-cache-style), *not* natural-language token streams — the
+//! first-mover angle ADR-326 captures: testing DeAR's topology under a
+//! communication substrate the paper itself does not use.
+//!
+//! ## Seam status (honest scope)
+//!
+//! ADR-309's greenfield `latentmesh-*` transport crates do not yet expose a wire
+//! API on `origin/main`. So this module **defines the seam** — the
+//! [`LatentTransport`] trait and the [`LatentMessage`] envelope — and ships a
+//! working **in-process stub** ([`InProcessTransport`]) so WP23 is end-to-end
+//! testable now. Full LatentMesh wire carriage (compression codec, framing,
+//! `ruvnet/LatentMesh` wire-format coordination) is deferred to WP5; a WP5
+//! transport crate implements [`LatentTransport`] without changing any caller.
+
+use serde::{Deserialize, Serialize};
+
+use crate::capability::PeerId;
+use crate::thoughtmap::StepId;
+
+/// Compressed latent state carried between agents (KV-cache-style). This slice
+/// models it as an `f32` vector; the WP5 codec replaces the representation
+/// behind the same envelope.
+pub type LatentState = Vec<f32>;
+
+/// Causal attribution evidence attached to every message (consumed by the
+/// ADR-310 gate in [`crate::causal`]). The message claims it follows causally
+/// from `antecedent`; the gate verifies that claim under controlled replacement
+/// before the receiving agent may incorporate it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CausalTag {
+    /// The thought-map step this message claims to causally follow from.
+    pub antecedent: StepId,
+}
+
+/// A peer-to-peer message: compressed latent payload + causal attribution +
+/// integrity tag. Nothing here is trusted until the causal gate and the
+/// quarantine integrity check pass.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LatentMessage {
+    pub from: PeerId,
+    pub to: PeerId,
+    /// Compressed latent contribution this message proposes to add.
+    pub latent: LatentState,
+    /// Causal attribution evidence (ADR-310).
+    pub causal: CausalTag,
+    /// HMAC-style integrity tag (ADR-311). A mismatch means tampering and the
+    /// message is quarantined regardless of the sender's capability score.
+    pub integrity: u64,
+    #[serde(default)]
+    pub summary: String,
+}
+
+/// The transport seam. A WP5 LatentMesh crate implements this; callers only ever
+/// see this trait.
+pub trait LatentTransport {
+    /// Enqueue a message for carriage to `msg.to`.
+    fn send(&mut self, msg: LatentMessage) -> Result<(), TransportError>;
+    /// Dequeue the next message addressed to `me`, if any.
+    fn recv(&mut self, me: PeerId) -> Option<LatentMessage>;
+}
+
+/// Transport-level failure. Wire-format/codec errors join here under WP5.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum TransportError {
+    #[error("transport channel closed")]
+    Closed,
+}
+
+/// In-process FIFO stub of [`LatentTransport`] for tests and single-node runs.
+/// **Not** the wire transport — that is WP5.
+#[derive(Debug, Default)]
+pub struct InProcessTransport {
+    queue: Vec<LatentMessage>,
+}
+
+impl InProcessTransport {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn pending(&self) -> usize {
+        self.queue.len()
+    }
+}
+
+impl LatentTransport for InProcessTransport {
+    fn send(&mut self, msg: LatentMessage) -> Result<(), TransportError> {
+        self.queue.push(msg);
+        Ok(())
+    }
+
+    fn recv(&mut self, me: PeerId) -> Option<LatentMessage> {
+        if let Some(pos) = self.queue.iter().position(|m| m.to == me) {
+            Some(self.queue.remove(pos))
+        } else {
+            None
+        }
+    }
+}
+
+/// Deterministic integrity tag over a message's load-bearing fields. Stands in
+/// for the ADR-311 HMAC; WP5 swaps in a keyed MAC. Exposed so senders can stamp
+/// a message and the quarantine layer can recompute and compare.
+pub fn integrity_tag(from: PeerId, to: PeerId, latent: &[f32], antecedent: StepId) -> u64 {
+    // FNV-1a over the byte representation of the fields. Deterministic and
+    // dependency-free; the point under test is "recomputed tag must match", which
+    // any MAC satisfies.
+    fn mix(hash: &mut u64, bytes: &[u8]) {
+        for &b in bytes {
+            *hash ^= b as u64;
+            *hash = hash.wrapping_mul(0x100000001b3);
+        }
+    }
+    let mut hash: u64 = 0xcbf29ce484222325;
+    mix(&mut hash, &from.0.to_le_bytes());
+    mix(&mut hash, &to.0.to_le_bytes());
+    mix(&mut hash, &antecedent.0.to_le_bytes());
+    for v in latent {
+        mix(&mut hash, &v.to_bits().to_le_bytes());
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn in_process_transport_routes_by_recipient() {
+        let mut t = InProcessTransport::new();
+        let msg = LatentMessage {
+            from: PeerId(1),
+            to: PeerId(2),
+            latent: vec![1.0, 2.0],
+            causal: CausalTag {
+                antecedent: StepId(0),
+            },
+            integrity: 0,
+            summary: String::new(),
+        };
+        t.send(msg.clone()).unwrap();
+        assert!(t.recv(PeerId(3)).is_none(), "not addressed to 3");
+        assert_eq!(t.recv(PeerId(2)).unwrap().from, PeerId(1));
+        assert_eq!(t.pending(), 0);
+    }
+
+    #[test]
+    fn integrity_tag_is_deterministic_and_sensitive() {
+        let a = integrity_tag(PeerId(1), PeerId(2), &[1.0, 2.0], StepId(0));
+        let same = integrity_tag(PeerId(1), PeerId(2), &[1.0, 2.0], StepId(0));
+        let tampered = integrity_tag(PeerId(1), PeerId(2), &[1.0, 2.5], StepId(0));
+        assert_eq!(a, same);
+        assert_ne!(a, tampered);
+    }
+}

--- a/crates/rvAgent/latentmesh-thoughtmap/src/vecmath.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/vecmath.rs
@@ -1,0 +1,45 @@
+//! Tiny, dependency-free vector helpers shared by capability grounding and
+//! causal attribution. Kept private to the crate.
+
+/// Dot product of two equal-length slices. Extra elements on the longer slice
+/// are ignored (both are truncated to the shorter length).
+pub(crate) fn dot(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
+}
+
+/// L2 norm.
+pub(crate) fn norm(a: &[f32]) -> f32 {
+    dot(a, a).sqrt()
+}
+
+/// Cosine similarity in `[-1, 1]`. Returns `0.0` when either vector is empty or
+/// has zero magnitude (an undefined direction contributes no evidence).
+pub(crate) fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    let na = norm(a);
+    let nb = norm(b);
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    (dot(a, b) / (na * nb)).clamp(-1.0, 1.0)
+}
+
+/// Element-wise mean of a set of equal-length vectors. Returns an empty vector
+/// when the input is empty.
+pub(crate) fn mean(vectors: &[Vec<f32>]) -> Vec<f32> {
+    let mut iter = vectors.iter();
+    let Some(first) = iter.next() else {
+        return Vec::new();
+    };
+    let mut acc = first.clone();
+    let mut count = 1.0f32;
+    for v in iter {
+        for (a, x) in acc.iter_mut().zip(v.iter()) {
+            *a += x;
+        }
+        count += 1.0;
+    }
+    for a in acc.iter_mut() {
+        *a /= count;
+    }
+    acc
+}

--- a/crates/rvAgent/latentmesh-thoughtmap/src/vecmath.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/vecmath.rs
@@ -12,21 +12,39 @@ pub(crate) fn norm(a: &[f32]) -> f32 {
     dot(a, a).sqrt()
 }
 
-/// Cosine similarity in `[-1, 1]`. Returns `0.0` when either vector is empty or
-/// has zero magnitude (an undefined direction contributes no evidence).
+/// Whether every element of a latent vector is finite (no NaN/±inf).
+pub(crate) fn is_finite(v: &[f32]) -> bool {
+    v.iter().all(|x| x.is_finite())
+}
+
+/// Cosine similarity in `[-1, 1]`. Returns `0.0` when either vector is empty,
+/// has zero magnitude, or is **non-finite** (an undefined direction contributes
+/// no evidence).
+///
+/// NaN-safety is load-bearing for the causal gate: a NaN slipping through here
+/// would make every `<`-comparison in [`crate::causal`] false and silently fall
+/// through to Accept. A non-finite operand ⇒ `0.0` (no match), never NaN.
 pub(crate) fn cosine(a: &[f32], b: &[f32]) -> f32 {
     let na = norm(a);
     let nb = norm(b);
-    if na == 0.0 || nb == 0.0 {
+    if na == 0.0 || nb == 0.0 || !na.is_finite() || !nb.is_finite() {
         return 0.0;
     }
-    (dot(a, b) / (na * nb)).clamp(-1.0, 1.0)
+    let sim = dot(a, b) / (na * nb);
+    if !sim.is_finite() {
+        return 0.0;
+    }
+    sim.clamp(-1.0, 1.0)
 }
 
 /// Element-wise mean of a set of equal-length vectors. Returns an empty vector
 /// when the input is empty.
+///
+/// **Non-finite vectors are skipped** so a single NaN/±inf signature cannot
+/// poison the map-wide control population the causal specificity check depends
+/// on (defense-in-depth behind the `incorporate` choke point).
 pub(crate) fn mean(vectors: &[Vec<f32>]) -> Vec<f32> {
-    let mut iter = vectors.iter();
+    let mut iter = vectors.iter().filter(|v| is_finite(v));
     let Some(first) = iter.next() else {
         return Vec::new();
     };

--- a/crates/rvAgent/latentmesh-thoughtmap/tests/acceptance.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/tests/acceptance.rs
@@ -136,6 +136,102 @@ fn latent_message_failing_causal_verification_is_rejected_not_incorporated() {
     assert_eq!(engine.map.node_count(), nodes_before + 1);
 }
 
+// 3n — SECURITY PROOF (NaN bypass): a NON-FINITE latent must NOT slip through
+//      the causal gate. A NaN would make the gate's `<`-comparisons false and
+//      fall through to Accept; it is instead rejected at the choke point, never
+//      written, and the sender is struck (not left at strikes=0 to retry).
+#[test]
+fn nan_latent_is_rejected_not_accepted_and_strikes_sender() {
+    let mut engine = engine_with_root();
+    let before = engine.map.node_count();
+    let attacker = PeerId(77);
+
+    // NaN latent that claims a REAL antecedent (root). Correctly integrity-stamped
+    // so only the finiteness guard can catch it.
+    let nan = signed_msg(attacker.0, 0, vec![f32::NAN, 0.1, 0.0], ROOT_STEP);
+    assert_eq!(
+        engine.incorporate(&nan),
+        Incorporation::Rejected(RejectionKind::NonFinite),
+        "a NaN latent must be REJECTED, never fall through to Accept"
+    );
+    assert_eq!(
+        engine.map.node_count(),
+        before,
+        "rejected NaN message must NOT be written to the thought graph"
+    );
+    assert!(
+        engine.quarantine.strikes(attacker) > 0,
+        "malformed NaN message must strike the sender, not leave it at strikes=0"
+    );
+
+    // A repeat offender quarantines instead of retrying forever.
+    let nan2 = signed_msg(attacker.0, 0, vec![f32::NAN, 0.0, 0.0], ROOT_STEP);
+    let _ = engine.incorporate(&nan2);
+    assert!(
+        engine.quarantine.is_quarantined(attacker),
+        "a repeat non-finite offender must eventually quarantine"
+    );
+}
+
+// 3i — Same for +inf / -inf latents.
+#[test]
+fn infinite_latent_is_rejected() {
+    let mut engine = engine_with_root();
+    let before = engine.map.node_count();
+    for bad in [f32::INFINITY, f32::NEG_INFINITY] {
+        let msg = signed_msg(78, 0, vec![bad, 0.0, 0.0], ROOT_STEP);
+        assert_eq!(
+            engine.incorporate(&msg),
+            Incorporation::Rejected(RejectionKind::NonFinite)
+        );
+    }
+    assert_eq!(engine.map.node_count(), before, "no inf latent may be stored");
+}
+
+// 3c — CASCADE PROOF: a rejected non-finite injection must NOT poison the
+//      map-wide control. A genuinely-spurious message stays Rejected(Spurious)
+//      afterwards (the specificity check still fires — control is not NaN).
+#[test]
+fn nonfinite_injection_does_not_poison_mapwide_specificity_control() {
+    // A map whose nodes share one direction, so a message aligned with it is
+    // genuinely spurious (explained equally by any node).
+    let mut map = ThoughtMap::new();
+    let a = map.add_step(PeerId(0), vec![1.0, 1.0, 1.0], "a");
+    map.add_step(PeerId(0), vec![1.0, 1.0, 1.0], "b");
+    map.add_step(PeerId(0), vec![1.0, 1.0, 1.0], "c");
+    let mut engine = ReasoningEngine::new(
+        map,
+        ControlledReplacementVerifier::default(),
+        Quarantine::default(),
+        DeadEndPolicy::default(),
+    );
+
+    // Baseline: a spurious message is correctly Rejected(Spurious).
+    let spurious_before = signed_msg(6, 0, vec![1.0, 1.0, 1.0], a);
+    assert_eq!(
+        engine.incorporate(&spurious_before),
+        Incorporation::Rejected(RejectionKind::Causal(RejectReason::Spurious))
+    );
+
+    // Attempt a NaN injection — rejected, nothing written.
+    let nan = signed_msg(50, 0, vec![f32::NAN, 0.0, 0.0], a);
+    assert_eq!(
+        engine.incorporate(&nan),
+        Incorporation::Rejected(RejectionKind::NonFinite)
+    );
+    assert_eq!(engine.map.node_count(), 3, "NaN injection wrote nothing");
+
+    // CASCADE CHECK: the spurious message is STILL Rejected(Spurious). If the NaN
+    // had poisoned the control (mean → NaN → control_attribution NaN), the
+    // specificity check would silently pass and this would wrongly Accept.
+    let spurious_after = signed_msg(7, 0, vec![1.0, 1.0, 1.0], a);
+    assert_eq!(
+        engine.incorporate(&spurious_after),
+        Incorporation::Rejected(RejectionKind::Causal(RejectReason::Spurious)),
+        "map-wide specificity control must survive a rejected non-finite injection"
+    );
+}
+
 // 3b — A tampered (bad-integrity) message is rejected before the causal gate.
 #[test]
 fn tampered_message_is_rejected_on_integrity() {

--- a/crates/rvAgent/latentmesh-thoughtmap/tests/acceptance.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/tests/acceptance.rs
@@ -1,0 +1,265 @@
+//! WP23 acceptance tests (ADR-326 / RuVector#882).
+//!
+//! One test per acceptance criterion, exercising the crate end-to-end through
+//! the public API — the same surface a real fabric would use.
+
+use latentmesh_thoughtmap::{
+    integrity_tag, CausalTag, ControlledReplacementVerifier, DeadEndPolicy, Incorporation,
+    LatentMessage, LocalView, PeerId, PeerProfile, Query, Quarantine, ReasoningEngine,
+    RejectReason, RejectionKind, ThoughtGraphBackend, ThoughtMap, ROOT_STEP,
+};
+
+/// Build a well-formed (correctly stamped) message.
+fn signed_msg(
+    from: u64,
+    to: u64,
+    latent: Vec<f32>,
+    antecedent: latentmesh_thoughtmap::StepId,
+) -> LatentMessage {
+    LatentMessage {
+        from: PeerId(from),
+        to: PeerId(to),
+        integrity: integrity_tag(PeerId(from), PeerId(to), &latent, antecedent),
+        causal: CausalTag { antecedent },
+        latent,
+        summary: String::new(),
+    }
+}
+
+fn engine_with_root() -> ReasoningEngine<ControlledReplacementVerifier> {
+    let mut map = ThoughtMap::new();
+    // Seed a root reasoning step (topic-A direction) plus an unrelated step so the
+    // causal control population is meaningful.
+    map.add_step(PeerId(0), vec![1.0, 0.0, 0.0], "root/topic-A");
+    map.add_step(PeerId(0), vec![0.0, 1.0, 0.0], "topic-B");
+    ReasoningEngine::new(
+        map,
+        ControlledReplacementVerifier::default(),
+        Quarantine::default(),
+        DeadEndPolicy::default(),
+    )
+}
+
+// 1 — Query-dependent peer specialization with NO central role-assigner.
+#[test]
+fn local_peer_selection_is_decentralized_and_query_dependent() {
+    // Two agents, each with only their OWN local view, select peers for the same
+    // candidate set but different queries — and reach different, query-appropriate
+    // choices with no shared/central router involved.
+    let candidates = vec![
+        PeerProfile {
+            id: PeerId(10),
+            skill: vec![1.0, 0.0, 0.0], // specialist A
+            trust: 0.9,
+            cost: 1.0,
+            last_active_step: 5,
+        },
+        PeerProfile {
+            id: PeerId(11),
+            skill: vec![0.0, 1.0, 0.0], // specialist B
+            trust: 0.9,
+            cost: 1.0,
+            last_active_step: 5,
+        },
+    ];
+
+    let view = LocalView::new(PeerId(1), vec![1.0, 1.0, 1.0], 5);
+
+    let q_a = Query::new(1, vec![1.0, 0.0, 0.0]);
+    let q_b = Query::new(2, vec![0.0, 1.0, 0.0]);
+
+    let pick_a = view.select_peer(&candidates, &q_a, &[]).unwrap();
+    let pick_b = view.select_peer(&candidates, &q_b, &[]).unwrap();
+
+    assert_eq!(pick_a.peer, PeerId(10), "query A → specialist A, chosen locally");
+    assert_eq!(pick_b.peer, PeerId(11), "query B → specialist B, chosen locally");
+    assert_ne!(
+        pick_a.peer, pick_b.peer,
+        "same peers, different query → different specialization (no static role)"
+    );
+}
+
+// 2 — Shared thought map is directly navigable; success reinforces / failure weakens.
+#[test]
+fn thought_map_edges_reinforce_on_success_and_weaken_on_failure() {
+    let mut map = ThoughtMap::new();
+    let a = map.add_step(PeerId(1), vec![1.0, 0.0], "a");
+    let b = map.add_step(PeerId(2), vec![0.9, 0.1], "b");
+    let c = map.add_step(PeerId(3), vec![0.8, 0.2], "c");
+    map.connect(a, b, PeerId(2), 0.5);
+    map.connect(b, c, PeerId(3), 0.5);
+
+    // A confirmed-good path a→b→c reinforces both edges.
+    map.reinforce_path(&[a, b, c], 0.3);
+    assert!((map.edge_weight(a, b).unwrap() - 0.8).abs() < 1e-6);
+    assert!((map.edge_weight(b, c).unwrap() - 0.8).abs() < 1e-6);
+
+    // A confirmed-bad path weakens.
+    map.weaken_path(&[a, b], 0.7);
+    assert!((map.edge_weight(a, b).unwrap() - 0.1).abs() < 1e-6);
+
+    // Navigation: strongest neighbor of a is now b→c's chain start via weight.
+    assert_eq!(map.neighbors(a).len(), 1);
+}
+
+// 3 — SECURITY PROOF: a latent message failing causal verification is REJECTED,
+//     never incorporated.
+#[test]
+fn latent_message_failing_causal_verification_is_rejected_not_incorporated() {
+    let mut engine = engine_with_root();
+    let nodes_before = engine.map.node_count();
+    let root = ROOT_STEP; // topic-A direction [1,0,0]
+
+    // A forged message: latent orthogonal to its claimed antecedent (root/topic-A).
+    // Correctly integrity-stamped, so ONLY the causal gate can catch it.
+    let forged = signed_msg(99, 0, vec![0.0, 0.0, 1.0], root);
+
+    let outcome = engine.incorporate(&forged);
+
+    assert_eq!(
+        outcome,
+        Incorporation::Rejected(RejectionKind::Causal(RejectReason::Unattributable)),
+        "message not attributable to its claimed cause must be rejected"
+    );
+    assert_eq!(
+        engine.map.node_count(),
+        nodes_before,
+        "REJECTED message must NOT be written to the thought graph"
+    );
+
+    // Contrast: a genuine message derived from the same antecedent IS incorporated.
+    let genuine = signed_msg(5, 0, vec![0.97, 0.03, 0.0], root);
+    match engine.incorporate(&genuine) {
+        Incorporation::Accepted { .. } => {}
+        other => panic!("genuine causally-attributable message should be accepted, got {other:?}"),
+    }
+    assert_eq!(engine.map.node_count(), nodes_before + 1);
+}
+
+// 3b — A tampered (bad-integrity) message is rejected before the causal gate.
+#[test]
+fn tampered_message_is_rejected_on_integrity() {
+    let mut engine = engine_with_root();
+    let before = engine.map.node_count();
+    let mut msg = signed_msg(99, 0, vec![0.97, 0.03, 0.0], ROOT_STEP);
+    msg.latent[0] = 0.5; // mutate payload after stamping → integrity mismatch
+    assert_eq!(
+        engine.incorporate(&msg),
+        Incorporation::Rejected(RejectionKind::Integrity)
+    );
+    assert_eq!(engine.map.node_count(), before);
+}
+
+// 4 — Dead-end → topology change CONTINUES from current state (NOT restart),
+//     and the choice is swappable. (UNVERIFIED design choice, ADR-326 §6.)
+#[test]
+fn dead_end_continues_from_state_and_is_swappable() {
+    let mut engine = engine_with_root();
+    // Add a step d that has no productive outgoing edge → dead end.
+    let d = engine.map.add_step(PeerId(3), vec![0.5, 0.5, 0.0], "stuck");
+    assert!(engine.map.is_dead_end(d));
+
+    let view = LocalView::new(PeerId(1), vec![1.0, 1.0, 1.0], 10);
+    let query = Query::new(1, vec![1.0, 0.0, 0.0]);
+    let candidates = vec![PeerProfile {
+        id: PeerId(20),
+        skill: vec![1.0, 0.0, 0.0],
+        trust: 0.9,
+        cost: 1.0,
+        last_active_step: 10,
+    }];
+
+    // Default policy = ContinueWithTopologyChange (the unverified design choice).
+    let change = engine
+        .handle_dead_end(d, &view, &candidates, &query, &[], PeerId(1))
+        .expect("non-quarantined trigger yields a change");
+    assert!(change.continued, "continue, NOT restart");
+    assert_eq!(change.resume_from, d, "resume from current state, not the root");
+    assert_eq!(change.new_peer, Some(PeerId(20)), "re-routed to a new peer");
+
+    // Swap the policy → Restart resumes from ROOT and discards progress.
+    engine.policy = DeadEndPolicy::Restart;
+    let restart = engine
+        .handle_dead_end(d, &view, &candidates, &query, &[], PeerId(1))
+        .unwrap();
+    assert!(!restart.continued);
+    assert_eq!(restart.resume_from, ROOT_STEP);
+}
+
+// 5 — A misbehaving peer is dampened/quarantined and CANNOT churn the thought map.
+#[test]
+fn misbehaving_peer_is_quarantined_and_cannot_churn_topology() {
+    let mut engine = engine_with_root();
+    let bad = PeerId(66);
+
+    // The bad peer sends three forged (unattributable) messages. Each is rejected
+    // and accrues a strike; after threshold it is quarantined.
+    for _ in 0..3 {
+        let forged = signed_msg(bad.0, 0, vec![0.0, 0.0, 1.0], ROOT_STEP);
+        assert!(matches!(
+            engine.incorporate(&forged),
+            Incorporation::Rejected(RejectionKind::Causal(_))
+        ));
+    }
+    assert!(engine.quarantine.is_quarantined(bad), "sustained anomalies quarantine the peer");
+
+    let nodes_after_rejects = engine.map.node_count();
+
+    // Now the quarantined peer sends a *well-formed, causally valid* message.
+    // It must be DAMPENED (not incorporated) purely because it is quarantined —
+    // a bad actor cannot buy its way back into the map with one good message.
+    let good_but_quarantined = signed_msg(bad.0, 0, vec![0.97, 0.03, 0.0], ROOT_STEP);
+    assert_eq!(engine.incorporate(&good_but_quarantined), Incorporation::Dampened);
+    assert_eq!(
+        engine.map.node_count(),
+        nodes_after_rejects,
+        "quarantined peer cannot add nodes"
+    );
+
+    // And it cannot trigger a topology change (no spurious churn).
+    let view = LocalView::new(PeerId(1), vec![1.0, 1.0, 1.0], 10);
+    let query = Query::new(1, vec![1.0, 0.0, 0.0]);
+    let churn = engine.handle_dead_end(ROOT_STEP, &view, &[], &query, &[], bad);
+    assert!(churn.is_none(), "quarantined peer cannot trigger topology churn");
+}
+
+// 6 — Topology changes remain attributable (every change names its cause + trigger).
+#[test]
+fn topology_changes_are_attributable() {
+    let mut engine = engine_with_root();
+    let d = engine.map.add_step(PeerId(3), vec![0.5, 0.5, 0.0], "stuck");
+    let view = LocalView::new(PeerId(1), vec![1.0, 1.0, 1.0], 10);
+    let query = Query::new(1, vec![1.0, 0.0, 0.0]);
+
+    let change = engine
+        .handle_dead_end(d, &view, &[], &query, &[], PeerId(1))
+        .unwrap();
+    // Attribution: cause is machine-readable and the trigger is named.
+    assert_eq!(change.cause, latentmesh_thoughtmap::TopologyCause::DeadEnd);
+    assert_eq!(change.triggered_by, PeerId(1));
+}
+
+// Extra — the peer-selection choke ties into quarantine: re-routing skips
+// quarantined peers, so churn can't be redirected onto a bad actor either.
+#[test]
+fn rerouting_skips_quarantined_candidates() {
+    let mut engine = engine_with_root();
+    let bad = PeerId(66);
+    // Quarantine `bad` via an integrity failure (weight 3).
+    let mut tampered = signed_msg(bad.0, 0, vec![0.97, 0.03, 0.0], ROOT_STEP);
+    tampered.latent[0] = 0.1;
+    let _ = engine.incorporate(&tampered);
+    assert!(engine.quarantine.is_quarantined(bad));
+
+    let d = engine.map.add_step(PeerId(3), vec![0.5, 0.5, 0.0], "stuck");
+    let view = LocalView::new(PeerId(1), vec![1.0, 1.0, 1.0], 10);
+    let query = Query::new(1, vec![1.0, 0.0, 0.0]);
+    let candidates = vec![
+        PeerProfile { id: bad, skill: vec![1.0, 0.0, 0.0], trust: 0.9, cost: 1.0, last_active_step: 10 },
+        PeerProfile { id: PeerId(21), skill: vec![1.0, 0.0, 0.0], trust: 0.9, cost: 1.0, last_active_step: 10 },
+    ];
+    let change = engine
+        .handle_dead_end(d, &view, &candidates, &query, &[], PeerId(1))
+        .unwrap();
+    assert_eq!(change.new_peer, Some(PeerId(21)), "re-route skips the quarantined peer");
+}


### PR DESCRIPTION
## PIR WP23 — RuVector#882 · ADR-326 · Epic #837

First shippable slice of DeAR-pattern decentralized capability-grounded reasoning, implementing merged **ADR-326** over the LatentMesh fabric (**ADR-309** transport / **ADR-310** causal gate / **ADR-311** quarantine).

**Evidence posture (preprint-reproduction rule).** Informed by **DeAR** — *Decentralized Agentic Reasoning via Capability Grounding and Collaborative Thought Navigation* ([arXiv:2608.17282](https://arxiv.org/abs/2608.17282)), graded **B+ (not A)**, with **no released code** (the paper's repo is a placeholder `https://open_upon_acceptance` URL). This is a **first-party build from the paper's description**, not a port. DeAR's reported numbers are hypotheses, not the acceptance bar; promotion requires an independently recomputed `research-gate` delta over the pre-WP baseline.

### Host decision
No `latentmesh-*` crates exist on `origin/main` yet (only ADR-305/ADR-309 docs), so the WP5 greenfield crates are not substantial. WP23 is hosted as a **new crate `crates/rvAgent/latentmesh-thoughtmap`** — exactly the crate name ADR-326's *Affected Repos* names as the likely landing spot, sitting alongside the other rvAgent crates. It establishes the first `latentmesh-*` crate that WP5's transport work extends via the seams below.

### What's implemented
1. **Capability vectors replace named roles** (`capability.rs`) — `C(i,j,q) = competence × trust × locality × freshness ÷ cost`, recomputed per-query. `competence`/`locality`/`freshness` are grounded against the specific query, so specialization is dynamic, not a fixed label. `LocalView::select_peer` chooses the next peer **locally** — no central planner/dispatcher argument exists in the signature (the contrast point with `radio-moe`'s centralized routing).
2. **Shared thought map** (`thoughtmap.rs`) — reasoning-step nodes, peer-interaction edges; success **reinforces** edges, failure **weakens** them. First-party in-memory graph with a documented **RuVector-integration seam** (`ThoughtGraphBackend` trait) a `ruvector-graph`-backed store implements later without changing callers.
3. **LatentMesh transport + causal verification** (`transport.rs`, `causal.rs`) — messages carry **compressed latent state** (KV-cache-style, not token streams — ADR-326's first-mover angle). A received message must pass ADR-310's **controlled-replacement causal audit** (`ControlledReplacementVerifier`) before it is incorporated: it must be *attributable* to its claimed antecedent **and** that antecedent must be *specifically* load-bearing (a control substitution catches spurious attribution). Full wire transport (codec + `ruvnet/LatentMesh` coordination) is a defined seam with an in-process stub — **deferred to WP5**.
4. **Dead-end handling** (`topology.rs`) — on a dead end, change topology and **continue from current state, not restart**.
5. **Security** (`quarantine.rs`, `engine.rs`) — `ReasoningEngine::incorporate` is the single choke point: integrity (ADR-311) → quarantine dampening → causal attribution (ADR-310). A misbehaving peer accrues strikes and is quarantined; quarantined peers are dampened and **cannot trigger topology churn**. Every topology change is attributable (carries `cause` + `triggered_by`).

### ⚠️ Continue-vs-restart is marked UNVERIFIED (ADR-326 §6 binding gate)
The "continue, not restart" dead-end behavior is **this program's own working interpretation** of the abstract's four-word *"topology update for adaptive error correction"* — **NOT a reproduced DeAR claim**. Per ADR-326's binding design-choice-labeling discipline it is loudly labeled as such in `topology.rs` module docs, on `DeadEndPolicy` and its `Default`, in `engine.rs`, and in `lib.rs`, and kept **swappable** (`DeadEndPolicy::Restart` is a one-line flip with nothing else depending on the choice). Must be re-verified against the full paper or released code before being treated as a fixed contract.

### Tests (28 green: 20 unit + 8 acceptance)
- Capability-vector scoring is the ADR formula; competence is query-dependent; local peer selection picks best with no central planner.
- Edge reinforce on success / weaken on failure.
- **A latent message failing causal verification is REJECTED, not incorporated** (`node_count` unchanged); genuine message accepted; tampered message rejected on integrity.
- Dead-end → topology change **continues from current state** (resume_from = current node, not root), and policy is swappable to Restart.
- A misbehaving peer is quarantined, dampened (a later good message still not incorporated), and cannot churn topology; re-routing skips quarantined peers.
- Topology changes are attributable.

`cargo test -p latentmesh-thoughtmap` green, `cargo check` + `clippy` clean, workspace membership added and verified via `scripts/workspace-check.mjs` (0 orphans). `npx @claude-flow/cli security scan` run (touches a topology-mutation surface) — no findings in this crate.

### Deferred (honest scope)
Real multi-agent execution, the 9-benchmark DeAR evaluation, and full LatentMesh **wire** transport (compression codec + wire-format coordination) — the transport is a defined seam (`LatentTransport`) with an in-process stub for WP5 to implement.

Refs #882, #837. Depends on ADR-309/310/311.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)