### PR TITLE
feat(sota-bench): AI4AI-Bench recursive-improvement adapter with frozen task identity and mutation lineage (PIR WP25, ADR-328)

### DIFF
--- a/crates/ruvector-sota-bench/harness/src/ai4aiBench.ts
+++ b/crates/ruvector-sota-bench/harness/src/ai4aiBench.ts
@@ -137,11 +137,20 @@ export function assertAi4aiTaskManifest(value: unknown): asserts value is Ai4aiT
   }
 }
 
+/**
+ * Canonical encoding for hashing. Keys sort by CODE UNIT, never by
+ * `localeCompare`: locale collation is locale- and ICU-build-dependent, so
+ * `{ z, ä, a }` orders as a,z,ä under sv_SE but a,ä,z under en_US — the same
+ * payload would digest differently on two machines with different LANG. Code
+ * -unit order is what RFC 8785 (JSON Canonicalization Scheme) specifies, and
+ * it makes cross-process digests reproducible by construction rather than by
+ * accident of which key sets happen to be fixed and ASCII.
+ */
 function canonical(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
   if (value && typeof value === "object") {
     return `{${Object.entries(value as Record<string, unknown>)
-      .sort(([a], [b]) => a.localeCompare(b))
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
       .map(([key, child]) => `${JSON.stringify(key)}:${canonical(child)}`).join(",")}}`;
   }
   return JSON.stringify(value);
@@ -373,19 +382,55 @@ const ATTESTATIONS = new WeakMap<object, Ai4aiAttestation>();
 const MODULE_INSTANCE_MARKER = Symbol.for("ruvector.ai4ai.module-instance");
 const MODULE_INSTANCE_ID = randomBytes(8).toString("hex");
 
-/** Stable digest over evaluator output, using the module's canonical encoder. */
-function contentDigestOf(raw: unknown): string {
+/**
+ * Stable digest over evaluator output, using the module's canonical encoder.
+ * Exported so the content guarantee is DIRECTLY testable: on every
+ * constructible path the deep-freeze below stops a payload edit first, so the
+ * comparison in `assertAi4aiContentUnchanged` would otherwise never execute in
+ * any test — leaving a guard that could be inverted (`!==` to `===`) with the
+ * whole suite still green. A pure hash with no state and no authority is a
+ * cheap public surface to pay for keeping that guard exercised.
+ */
+export function ai4aiContentDigest(raw: unknown): string {
   return createHash("sha256")
     .update("ruvector.ai4ai.evaluator-output.v1\0")
     .update(canonical(raw))
     .digest("hex");
 }
 
-/** Recursively freeze the evaluator output (defense-in-depth, not the fix). */
-function deepFreeze<T>(value: T): T {
-  if (value && typeof value === "object" && !Object.isFrozen(value)) {
-    Object.freeze(value);
-    for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+/**
+ * Refuse evaluator output that no longer matches what was attested at
+ * execution time. Pure and exported for the same dormant-guard reason as
+ * `ai4aiContentDigest`: this is where a content mismatch is DETECTED, and a
+ * detection path that no test can reach is a detection path that can rot.
+ */
+export function assertAi4aiContentUnchanged(
+  raw: unknown,
+  attestedDigest: string,
+  mutationId: string,
+): void {
+  if (ai4aiContentDigest(raw) !== attestedDigest) {
+    throw new Error(
+      `ai4ai evaluator output was modified after execution for mutation ` +
+      `${mutationId} (content digest mismatch); a mutated result is not a score`,
+    );
+  }
+}
+
+/**
+ * Recursively freeze the evaluator output (defense-in-depth, not the fix).
+ * Recursion is NOT gated on the parent's frozen state — an already-frozen
+ * parent can still hold unfrozen children, which the guard would have skipped.
+ * Unreachable for JSON.parse output, wrong if this helper is ever reused. A
+ * `seen` set keeps cycles from recursing forever now that frozen nodes no
+ * longer terminate the walk.
+ */
+function deepFreeze<T>(value: T, seen: WeakSet<object> = new WeakSet()): T {
+  if (value && typeof value === "object") {
+    if (seen.has(value)) return value;
+    seen.add(value);
+    if (!Object.isFrozen(value)) Object.freeze(value);
+    for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child, seen);
   }
   return value;
 }
@@ -524,11 +569,13 @@ export function commandAi4aiExecutor(options: Ai4aiCommandExecutorOptions): Ai4a
       } finally {
         await handle.close();
       }
-      // Attest the CONTENT as well as the object. The content digest is taken
-      // here, over the output exactly as the evaluator produced it, and is
-      // recomputed at read: that is what makes a post-execution edit of the
-      // scored payload detectable. Deep-freezing `raw` is defense-in-depth on
-      // top (plain Object.freeze is shallow and would leave `raw` writable).
+      // Attest the CONTENT as well as the object, and freeze the payload.
+      // On every reachable path the deep-freeze is what BLOCKS a
+      // post-execution edit of the scored payload (plain Object.freeze is
+      // shallow and would leave `raw` writable); the content digest, taken
+      // here over the output exactly as the evaluator produced it and
+      // recomputed at read, is what CATCHES such an edit if a refactor ever
+      // rebuilds the result or drops the freeze.
       deepFreeze(raw);
       const outcome = {
         raw,
@@ -538,7 +585,7 @@ export function commandAi4aiExecutor(options: Ai4aiCommandExecutorOptions): Ai4a
       };
       ATTESTATIONS.set(outcome, {
         identity: executorIdentity,
-        contentDigest: contentDigestOf(raw),
+        contentDigest: ai4aiContentDigest(raw),
       });
       return Object.freeze(outcome);
     } finally {
@@ -598,25 +645,30 @@ export async function runAi4aiMutation(
     : undefined;
   if (attestation === undefined && typeof outcome === "object" && outcome !== null &&
       (outcome as Record<symbol, unknown>)[MODULE_INSTANCE_MARKER] !== undefined) {
-    // Carries our marker but is not in OUR registry: a second loaded copy of
-    // this module produced it. The record still degrades to `injected` (never
-    // upgrades), but say so, or the downgrade looks arbitrary.
+    // Marked but not registry-identical. The record degrades to `injected`
+    // either way (never upgrades); this line only explains WHY, so it must not
+    // send someone hunting the wrong problem — and must not let the very
+    // component being downgraded write arbitrary `ai4ai:`-prefixed log lines.
+    // The marker value is attacker-controlled, so it is JSON-encoded (newlines
+    // escaped) and length-capped before it reaches the log.
+    const theirs = JSON.stringify(
+      String((outcome as Record<symbol, unknown>)[MODULE_INSTANCE_MARKER]).slice(0, 64),
+    );
     process.stderr.write(
-      `ai4ai: result produced by a different loaded instance of ai4aiBench ` +
-      `(theirs=${String((outcome as Record<symbol, unknown>)[MODULE_INSTANCE_MARKER])}, ` +
-      `ours=${MODULE_INSTANCE_ID}); classing as injected — load one instance to ` +
-      `keep byte-derived evidence\n`,
+      theirs === JSON.stringify(MODULE_INSTANCE_ID)
+        ? `ai4ai: result carries this instance's marker (${theirs}) but is not the ` +
+          `object this module registered — wrapped or copied, not a different ` +
+          `instance; classing as injected\n`
+        : `ai4ai: result produced by a different loaded instance of ai4aiBench ` +
+          `(theirs=${theirs}, ours=${JSON.stringify(MODULE_INSTANCE_ID)}); classing ` +
+          `as injected — load one instance to keep byte-derived evidence\n`,
     );
   }
   // Content attestation: the scored payload must be what the evaluator
-  // produced. Object.freeze is shallow, so this — not the freeze — is what
-  // makes a post-execution edit of `raw` detectable, and it keeps working if a
-  // future refactor rebuilds the result object.
-  if (attestation !== undefined && contentDigestOf(outcome.raw) !== attestation.contentDigest) {
-    throw new Error(
-      `ai4ai evaluator output was modified after execution for mutation ` +
-      `${mutation.id} (content digest mismatch); a mutated result is not a score`,
-    );
+  // produced. The deep-freeze blocks an edit on every reachable path; this
+  // catches one if a refactor ever rebuilds the result or drops the freeze.
+  if (attestation !== undefined) {
+    assertAi4aiContentUnchanged(outcome.raw, attestation.contentDigest, mutation.id);
   }
   const attestedIdentity = attestation?.identity;
   let executorClass: Ai4aiExecutorClass;

--- a/crates/ruvector-sota-bench/harness/src/ai4aiBench.ts
+++ b/crates/ruvector-sota-bench/harness/src/ai4aiBench.ts
@@ -57,6 +57,13 @@
  * by an external evaluator on external hardware — it is not a weight update
  * performed by this harness, and no path in this module persists weights.
  *
+ * TRUST SCOPE (binding, stated once here and again on `Ai4aiEvidencePolicy`):
+ * this module provides WITHIN-PROCESS INTEGRITY — a record cannot misreport
+ * what the adapter's own executor produced. It is NOT cross-party
+ * authentication: the lineage digest is unkeyed and nothing is signed, so an
+ * adversary controlling the process can fabricate a chain that verifies.
+ * Signing plus an issued-nonce ledger would close that; both are follow-up.
+ *
  * KNOWN LIMITATION (accepted, exact parity with benchmark.ts): the command
  * executor SIGKILLs only the spawned child, not its process group — an
  * evaluator that forks can leave orphans past the timeout. Inherited from
@@ -321,13 +328,67 @@ function lineageDigest(record: Omit<Ai4aiLineageRecord, "digest">): string {
 export type Ai4aiExecutorClass = "byte-derived-command" | "wrapper-waived" | "injected";
 
 /**
- * Module-private attestation registry: maps the exact result object this
- * module constructed to the identity IT derived from real file bytes. Not
- * exported and not reachable from outside — an arbitrary executor cannot add
- * an entry, and mutating a returned object cannot change the attested value
- * because the adapter reads the identity from here, never off the object.
+ * What this module attests about a result it built itself: the identity it
+ * derived from the entrypoint's real bytes, AND a digest over the evaluator
+ * output as it stood when execution finished.
+ *
+ * The CONTENT digest is the load-bearing half. Attesting only the object
+ * answers "did this come from the command executor?" but not "is this score
+ * what the evaluator produced" — and `Object.freeze` is SHALLOW, so the
+ * parsed `raw` payload the score is read from stays mutable even when the
+ * wrapper object does not. Recomputing this digest at read time closes that
+ * gap by construction, and keeps closing it across refactors that rebuild the
+ * result object, which an enumeration of specific mutation paths would not.
  */
-const BYTE_DERIVED_IDENTITY = new WeakMap<object, string>();
+interface Ai4aiAttestation {
+  readonly identity: string;
+  readonly contentDigest: string;
+}
+
+/**
+ * Module-private attestation registry: maps the exact result object this
+ * module constructed to what it attests about that result. Not exported and
+ * not reachable from outside — an arbitrary executor cannot add an entry, and
+ * mutating a returned object cannot change the attested values because the
+ * adapter reads them from here, never off the object.
+ *
+ * MODULE-INSTANCE SCOPE (see `MODULE_INSTANCE_MARKER`): the registry belongs
+ * to ONE loaded copy of this module. A second instance — a bundler duplicate,
+ * a symlinked path, dist-vs-src — has its own registry, so a result produced
+ * by instance A is unknown to instance B. This is not a laundering path:
+ * cross-instance records degrade to `injected`, never upgrade. It does mean an
+ * honest byte-derived run can silently become `injected` and a strict gate
+ * then rejects GOOD evidence, so the downgrade is made legible rather than
+ * mysterious.
+ */
+const ATTESTATIONS = new WeakMap<object, Ai4aiAttestation>();
+
+/**
+ * Cross-realm-visible marker stamped on every result this module builds.
+ * Its only purpose is diagnostic: if a result carries the marker but is
+ * absent from OUR registry, the result came from a different loaded instance
+ * of this module, and the resulting downgrade to `injected` is explained
+ * instead of appearing arbitrary.
+ */
+const MODULE_INSTANCE_MARKER = Symbol.for("ruvector.ai4ai.module-instance");
+const MODULE_INSTANCE_ID = randomBytes(8).toString("hex");
+
+/** Stable digest over evaluator output, using the module's canonical encoder. */
+function contentDigestOf(raw: unknown): string {
+  return createHash("sha256")
+    .update("ruvector.ai4ai.evaluator-output.v1\0")
+    .update(canonical(raw))
+    .digest("hex");
+}
+
+/** Recursively freeze the evaluator output (defense-in-depth, not the fix). */
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+  }
+  return value;
+}
 
 /**
  * The injected executor: given a pinned task and one mutation, run the real
@@ -463,15 +524,22 @@ export function commandAi4aiExecutor(options: Ai4aiCommandExecutorOptions): Ai4a
       } finally {
         await handle.close();
       }
-      // Attest byte-derived identity on the exact object we return. Only this
-      // module can make this entry; the adapter reads the identity from the
-      // registry, never off the (potentially mutated) object.
+      // Attest the CONTENT as well as the object. The content digest is taken
+      // here, over the output exactly as the evaluator produced it, and is
+      // recomputed at read: that is what makes a post-execution edit of the
+      // scored payload detectable. Deep-freezing `raw` is defense-in-depth on
+      // top (plain Object.freeze is shallow and would leave `raw` writable).
+      deepFreeze(raw);
       const outcome = {
         raw,
         executorIdentity,
         wrapperIndirection: options.wrapperIndirection ?? false,
+        [MODULE_INSTANCE_MARKER]: MODULE_INSTANCE_ID,
       };
-      BYTE_DERIVED_IDENTITY.set(outcome, executorIdentity);
+      ATTESTATIONS.set(outcome, {
+        identity: executorIdentity,
+        contentDigest: contentDigestOf(raw),
+      });
       return Object.freeze(outcome);
     } finally {
       await rm(directory, { recursive: true, force: true });
@@ -525,9 +593,32 @@ export async function runAi4aiMutation(
   const wrapperIndirection = outcome.wrapperIndirection ?? false;
   // The ONLY source of a byte-derived identity is this module's own registry.
   // A self-reported string can never reach this variable.
-  const attestedIdentity = typeof outcome === "object" && outcome !== null
-    ? BYTE_DERIVED_IDENTITY.get(outcome)
+  const attestation = typeof outcome === "object" && outcome !== null
+    ? ATTESTATIONS.get(outcome)
     : undefined;
+  if (attestation === undefined && typeof outcome === "object" && outcome !== null &&
+      (outcome as Record<symbol, unknown>)[MODULE_INSTANCE_MARKER] !== undefined) {
+    // Carries our marker but is not in OUR registry: a second loaded copy of
+    // this module produced it. The record still degrades to `injected` (never
+    // upgrades), but say so, or the downgrade looks arbitrary.
+    process.stderr.write(
+      `ai4ai: result produced by a different loaded instance of ai4aiBench ` +
+      `(theirs=${String((outcome as Record<symbol, unknown>)[MODULE_INSTANCE_MARKER])}, ` +
+      `ours=${MODULE_INSTANCE_ID}); classing as injected — load one instance to ` +
+      `keep byte-derived evidence\n`,
+    );
+  }
+  // Content attestation: the scored payload must be what the evaluator
+  // produced. Object.freeze is shallow, so this — not the freeze — is what
+  // makes a post-execution edit of `raw` detectable, and it keeps working if a
+  // future refactor rebuilds the result object.
+  if (attestation !== undefined && contentDigestOf(outcome.raw) !== attestation.contentDigest) {
+    throw new Error(
+      `ai4ai evaluator output was modified after execution for mutation ` +
+      `${mutation.id} (content digest mismatch); a mutated result is not a score`,
+    );
+  }
+  const attestedIdentity = attestation?.identity;
   let executorClass: Ai4aiExecutorClass;
   let executorIdentity: string;
   if (attestedIdentity !== undefined && !wrapperIndirection) {
@@ -590,6 +681,21 @@ export async function runAi4aiLineage(
  * What a caller demands of a lineage's evidence class. Structural integrity
  * (digest, chain, task, nonce) is ALWAYS checked; this governs only the
  * evidence-strength question.
+ *
+ * SCOPE BOUNDARY — read this before building a gate on `requireEvaluatorBound`.
+ * What this slice provides is WITHIN-PROCESS INTEGRITY: a record cannot
+ * misreport what the adapter's own executor produced. It is NOT cross-party
+ * authentication — an adversary who controls the process can still fabricate a
+ * chain, because nothing here is signed. `lineageDigest` is an UNKEYED hash, so
+ * a wholly hand-constructed chain can claim `byte-derived-command` and verify
+ * clean; the attestation registry constrains what THIS module's executor path
+ * will report, not what a hostile process can hand you.
+ *
+ * So `requireEvaluatorBound` defends against honest-but-weak evidence — an
+ * injected stub, a wrapper entrypoint, a stale run — and NOT against an
+ * adversary. Closing that gap requires signing the chain and an issued-nonce
+ * ledger, both scoped as follow-up work, neither present here. A gate that
+ * treats strict mode as proof against a malicious producer is over-trusting it.
  */
 export interface Ai4aiEvidencePolicy {
   /**
@@ -604,8 +710,14 @@ export interface Ai4aiEvidencePolicy {
   readonly requireEvaluatorBound?: boolean;
 }
 
-/** The weakest executor class present — the class of the lineage as a whole. */
+/**
+ * The weakest executor class present — the class of the lineage as a whole.
+ * An EMPTY lineage is `injected`, not the strongest class: zero records is
+ * zero evidence, and falling through to `byte-derived-command` would invert
+ * this function's whole contract on a public surface cli.ts prints.
+ */
 export function ai4aiEvidenceClass(lineage: Ai4aiLineage): Ai4aiExecutorClass {
+  if (lineage.records.length === 0) return "injected";
   if (lineage.records.some((record) => record.executorClass === "injected")) return "injected";
   if (lineage.records.some((record) => record.executorClass === "wrapper-waived")) {
     return "wrapper-waived";

--- a/crates/ruvector-sota-bench/harness/src/ai4aiBench.ts
+++ b/crates/ruvector-sota-bench/harness/src/ai4aiBench.ts
@@ -1,0 +1,466 @@
+/**
+ * AI4AI-Bench recursive-improvement adapter — first shippable slice
+ * (PIR WP25, ADR-328).
+ *
+ * Source benchmark, cited in full on every reference (same naming discipline
+ * as ADR-324 §5): AI4AI-Bench (arXiv:2608.20318, "AI4AI-Bench: Benchmarking
+ * LLM Agents in Algorithmic Design for Recursive Self-Improvement";
+ * github.com/Einsia/AI4AI-Bench, Apache-2.0). The benchmark freezes ten
+ * research repositories spanning ten learning-algorithm families and asks an
+ * agent to rewrite the learning algorithm itself; hyperparameter tuning and
+ * data collection do not count as genuine improvement.
+ *
+ * WHAT THIS SLICE IS: the manifest/identity discipline, executor seam, score
+ * ingest, and mutation-lineage chain that let MetaHarness treat AI4AI-Bench
+ * (arXiv:2608.20318) tasks as an EXTERNAL published benchmark — exactly the
+ * "published-benchmark" evidence kind ADR-324's external-grounding invariant
+ * admits. Every candidate mutation this adapter observes carries reproducible
+ * provenance (task identity → parent digest → diff digest → seed → executor
+ * identity), so a run's full lineage can be replayed and audited.
+ *
+ * WHAT THIS SLICE IS NOT (honest scope): a real AI4AI-Bench run executes a
+ * frozen repository's training pipeline inside the benchmark's own Docker
+ * evaluator on datacenter-GPU hardware (the paper's official runs assume one
+ * B300-class GPU). None of that happens here. The adapter takes a
+ * CONSTRUCTOR-INJECTED executor (the same seam as
+ * `RuvectorFlywheelOptions.benchmark` / `BenchmarkRunOptions.commandPrefixArgs`)
+ * and this repo's CI exercises it only against a first-party fixture. The
+ * command executor below spawns whatever evaluator entrypoint the caller
+ * pins — locally that is a fixture; on real hardware it is the AI4AI-Bench
+ * (arXiv:2608.20318) evaluator.
+ *
+ * PREPRINT-REPRODUCTION RULE (binding, unchanged from Waves 1–3): the paper's
+ * published numbers — best 0.250, mean 0.166 across evaluated systems — are
+ * HYPOTHESES and targets, never this program's acceptance bar. Promotion of
+ * any mutation this adapter observes still routes exclusively through
+ * statistics.ts `pairedBootstrapDecision` and the vetoes.ts conjunctive veto
+ * algebra; an AI4AI score above 0.250 proves nothing by itself. The score
+ * scale matters when reading results: 0.1 is the frozen repository's shipped
+ * algorithm, so 0.250 closes less than a fifth of the ship-to-optimum
+ * distance.
+ *
+ * FAIL-LOUD METRIC INTEGRITY (Wave-3 lesson, #888): an executor crash or a
+ * non-finite / out-of-range score THROWS — it is never coerced into an
+ * observation. NaN defeats every `<` comparison silently, so finiteness is
+ * rejected at the choke point before any gate can see the value. Genuine-vs-
+ * tuning classification is ingested only when the evaluator output carries
+ * it; this adapter never fabricates the distinction.
+ *
+ * NO CACHING: a real AI4AI-Bench (arXiv:2608.20318) evaluation retrains a
+ * stochastic pipeline; replaying a cached score as if it were a fresh run
+ * would be evidence laundering. Every call to the executor is a real call.
+ *
+ * FROZEN WEIGHTS ARE STRUCTURAL: this file lives inside the mutation-surface
+ * directory scripts/frozen-weights-check.mjs scans. It imports no weight-
+ * updating API and names no model weight file. Rewriting a frozen BENCHMARK
+ * repository's learning algorithm is the benchmark's task definition executed
+ * by an external evaluator on external hardware — it is not a weight update
+ * performed by this harness, and no path in this module persists weights.
+ */
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pairedBootstrapDecision, type PairedDecision } from "./statistics.js";
+import type { PromotionVetoProvider } from "./vetoes.js";
+
+/** Exact citation for every reference (no bare "AI4AI" — naming discipline). */
+export const AI4AI_BENCH_CITATION =
+  "AI4AI-Bench (arXiv:2608.20318, github.com/Einsia/AI4AI-Bench)" as const;
+
+/** The benchmark's score for the shipped algorithm — the floor, not zero. */
+export const AI4AI_SHIPPED_ALGORITHM_SCORE = 0.1;
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const SLUG = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+
+// ---------------------------------------------------------------------------
+// FROZEN TASK IDENTITY — mirrors benchmark.ts's dataset-identity discipline.
+// ---------------------------------------------------------------------------
+
+/**
+ * A pinned AI4AI-Bench (arXiv:2608.20318) task. `repoSnapshotSha256` is the
+ * mandatory lowercase SHA-256 over the frozen repository snapshot the task
+ * ships; `evaluatorSha256` pins the evaluator that scores submissions. A
+ * manifest missing either hash is refused outright — the same posture
+ * normalizeSuiteItem takes toward dataset identity: no hash, no run.
+ */
+export interface Ai4aiTaskManifest {
+  /** Benchmark repo slug, e.g. "einsia-ai4ai-bench". */
+  readonly benchmark: string;
+  /** Task id inside the benchmark, e.g. "task-03-policy-gradient". */
+  readonly taskId: string;
+  /** The learning-algorithm family the frozen repo implements. */
+  readonly algorithmFamily: string;
+  /** Lowercase SHA-256 over the frozen repository snapshot. */
+  readonly repoSnapshotSha256: string;
+  /** Lowercase SHA-256 over the evaluator that scores submissions. */
+  readonly evaluatorSha256: string;
+  readonly citation: typeof AI4AI_BENCH_CITATION;
+}
+
+/** Refuse anything that is not a fully hash-pinned task manifest. */
+export function assertAi4aiTaskManifest(value: unknown): asserts value is Ai4aiTaskManifest {
+  if (!value || typeof value !== "object") throw new Error("ai4ai task manifest must be an object");
+  const manifest = value as Partial<Ai4aiTaskManifest>;
+  if (!manifest.benchmark || !SLUG.test(manifest.benchmark)) {
+    throw new Error("ai4ai task manifest requires a benchmark slug");
+  }
+  if (!manifest.taskId || !SLUG.test(manifest.taskId)) {
+    throw new Error("ai4ai task manifest requires a task id slug");
+  }
+  if (!manifest.algorithmFamily || typeof manifest.algorithmFamily !== "string") {
+    throw new Error("ai4ai task manifest requires an algorithm family");
+  }
+  if (!manifest.repoSnapshotSha256 || !HEX64.test(manifest.repoSnapshotSha256)) {
+    throw new Error("ai4ai task manifest requires a lowercase SHA-256 repo snapshot identity");
+  }
+  if (!manifest.evaluatorSha256 || !HEX64.test(manifest.evaluatorSha256)) {
+    throw new Error("ai4ai task manifest requires a lowercase SHA-256 evaluator identity");
+  }
+  if (manifest.citation !== AI4AI_BENCH_CITATION) {
+    throw new Error(`ai4ai task manifest must carry the exact citation "${AI4AI_BENCH_CITATION}"`);
+  }
+}
+
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => `${JSON.stringify(key)}:${canonical(child)}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/** The frozen task identity: SHA-256 over the canonical manifest encoding. */
+export function ai4aiTaskIdentity(manifest: Ai4aiTaskManifest): string {
+  assertAi4aiTaskManifest(manifest);
+  return createHash("sha256")
+    .update("ruvector.ai4ai.task-identity.v1\0")
+    .update(canonical(manifest))
+    .digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// MUTATIONS + LINEAGE — reproducible provenance for every candidate.
+// ---------------------------------------------------------------------------
+
+/**
+ * One candidate learning-algorithm mutation submitted against a task. The
+ * mutation itself (the diff) lives with the executor; the adapter records its
+ * digest so lineage is reproducible without the harness ever holding the
+ * candidate code.
+ */
+export interface Ai4aiMutation {
+  /** Stable id, e.g. "mut-007". */
+  readonly id: string;
+  /** Lowercase SHA-256 over the candidate diff against the parent state. */
+  readonly diffSha256: string;
+  /** The run seed the evaluator is asked to use. */
+  readonly seed: number;
+  /** One-line description of the algorithmic change (self-reported). */
+  readonly description: string;
+}
+
+export function assertAi4aiMutation(value: unknown): asserts value is Ai4aiMutation {
+  if (!value || typeof value !== "object") throw new Error("ai4ai mutation must be an object");
+  const mutation = value as Partial<Ai4aiMutation>;
+  if (!mutation.id || !SLUG.test(mutation.id)) throw new Error("ai4ai mutation requires an id slug");
+  if (!mutation.diffSha256 || !HEX64.test(mutation.diffSha256)) {
+    throw new Error("ai4ai mutation requires a lowercase SHA-256 diff digest");
+  }
+  if (!Number.isSafeInteger(mutation.seed) || (mutation.seed ?? -1) < 0) {
+    throw new Error("ai4ai mutation seed must be a non-negative integer");
+  }
+  if (!mutation.description) throw new Error("ai4ai mutation requires a description");
+}
+
+/**
+ * How the evaluator classified a submission. "unreported" means the evaluator
+ * output carried no classification — the adapter NEVER fabricates one, per
+ * the paper's own headline finding that only genuine algorithm changes count.
+ */
+export type Ai4aiSubmissionKind = "algorithm-change" | "tuning-only" | "unreported";
+
+/** Parsed, validated evaluator output for one mutation. */
+export interface Ai4aiEvaluation {
+  /** Finite score in [0, 1]; 0.1 is the shipped algorithm. */
+  readonly score: number;
+  readonly submissionKind: Ai4aiSubmissionKind;
+}
+
+/**
+ * Parse raw evaluator output. FAIL-LOUD: a missing, non-numeric, non-finite,
+ * or out-of-range score THROWS — it never becomes an observation (Wave-3
+ * lesson: NaN silently defeats every comparison-based gate downstream).
+ */
+export function parseAi4aiEvaluatorOutput(value: unknown): Ai4aiEvaluation {
+  if (!value || typeof value !== "object") throw new Error("ai4ai evaluator output must be an object");
+  const output = value as { score?: unknown; algorithm_changed?: unknown };
+  if (typeof output.score !== "number" || !Number.isFinite(output.score)) {
+    throw new Error("ai4ai evaluator score must be a finite number (fail-loud: refusing non-finite)");
+  }
+  if (output.score < 0 || output.score > 1) {
+    throw new Error(`ai4ai evaluator score out of range [0, 1]: ${output.score}`);
+  }
+  let submissionKind: Ai4aiSubmissionKind = "unreported";
+  if (output.algorithm_changed === true) submissionKind = "algorithm-change";
+  else if (output.algorithm_changed === false) submissionKind = "tuning-only";
+  else if (output.algorithm_changed !== undefined) {
+    throw new Error("ai4ai evaluator algorithm_changed must be boolean when present");
+  }
+  return Object.freeze({ score: output.score, submissionKind });
+}
+
+/**
+ * One link in the lineage chain. `parentDigest` is the previous record's
+ * digest (the task identity for the root); `digest` commits to everything —
+ * task, parent, diff, seed, executor identity, and the evaluation — so the
+ * chain is tamper-evident and any run can be re-derived and audited.
+ */
+export interface Ai4aiLineageRecord {
+  readonly taskIdentity: string;
+  readonly parentDigest: string;
+  readonly mutation: Ai4aiMutation;
+  readonly executorIdentity: string;
+  readonly evaluation: Ai4aiEvaluation;
+  readonly digest: string;
+}
+
+function lineageDigest(record: Omit<Ai4aiLineageRecord, "digest">): string {
+  return createHash("sha256")
+    .update("ruvector.ai4ai.lineage.v1\0")
+    .update(canonical(record))
+    .digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// EXECUTOR SEAM — injected, never run in-repo (no GPU, no Docker here).
+// ---------------------------------------------------------------------------
+
+/**
+ * The injected executor: given a pinned task and one mutation, run the real
+ * AI4AI-Bench (arXiv:2608.20318) evaluator somewhere it can actually run and
+ * return its RAW output plus a stable identity for the executor itself (so
+ * lineage records name what produced each score). A crash must propagate —
+ * the adapter re-throws with context and never scores a crash as a result.
+ */
+export type Ai4aiExecutor = (
+  manifest: Ai4aiTaskManifest,
+  mutation: Ai4aiMutation,
+) => Promise<{ readonly raw: unknown; readonly executorIdentity: string }>;
+
+export interface Ai4aiCommandExecutorOptions {
+  /** Absolute path to the evaluator entrypoint to spawn. */
+  readonly executorPath: string;
+  /** Trusted argv inserted before the entrypoint (primarily test wrappers). */
+  readonly commandPrefixArgs?: readonly string[];
+  readonly timeoutMs?: number;
+  readonly maxOutputBytes?: number;
+}
+
+/**
+ * A command-spawning executor with benchmark.ts's isolation discipline: a
+ * scrubbed environment (PATH only), a wall timeout, an output ceiling, and a
+ * temp workspace removed afterward. The entrypoint receives
+ * `--task <manifest.json> --mutation <mutation.json> --output <result.json>`
+ * and must write its evaluation JSON to the output path. Executor identity is
+ * the SHA-256 of the entrypoint file's bytes, so lineage pins WHAT ran.
+ */
+export function commandAi4aiExecutor(options: Ai4aiCommandExecutorOptions): Ai4aiExecutor {
+  return async (manifest, mutation) => {
+    const executorPath = resolve(options.executorPath);
+    const executorIdentity = createHash("sha256").update(await readFile(executorPath)).digest("hex");
+    const directory = await mkdtemp(join(tmpdir(), "ruvector-ai4ai-"));
+    try {
+      const taskFile = join(directory, "task.json");
+      const mutationFile = join(directory, "mutation.json");
+      const outputFile = join(directory, "result.json");
+      await writeFile(taskFile, `${JSON.stringify(manifest)}\n`, { mode: 0o600 });
+      await writeFile(mutationFile, `${JSON.stringify(mutation)}\n`, { mode: 0o600 });
+      const prefix = options.commandPrefixArgs ?? [];
+      const [command, ...leading] = prefix.length > 0 ? prefix : [executorPath];
+      const args = [
+        ...leading,
+        ...(prefix.length > 0 ? [executorPath] : []),
+        "--task", taskFile,
+        "--mutation", mutationFile,
+        "--output", outputFile,
+      ];
+      await new Promise<void>((resolveRun, reject) => {
+        const child = spawn(command!, args, {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: { PATH: process.env.PATH ?? "" },
+        });
+        let stderr = "";
+        let outputBytes = 0;
+        let limitFailure = "";
+        const consume = (chunk: Buffer, capture: boolean) => {
+          outputBytes += chunk.length;
+          if (capture) stderr = `${stderr}${chunk.toString("utf8")}`.slice(-2_000);
+          if (outputBytes > (options.maxOutputBytes ?? 10 * 1024 * 1024)) {
+            limitFailure = "ai4ai executor output limit exceeded";
+            child.kill("SIGKILL");
+          }
+        };
+        child.stdout.on("data", (chunk: Buffer) => consume(chunk, false));
+        child.stderr.on("data", (chunk: Buffer) => consume(chunk, true));
+        const timer = setTimeout(() => {
+          child.kill("SIGKILL");
+          reject(new Error(`ai4ai executor exceeded ${options.timeoutMs ?? 300_000}ms`));
+        }, options.timeoutMs ?? 300_000);
+        child.once("error", (error) => {
+          clearTimeout(timer);
+          reject(error);
+        });
+        child.once("exit", (code) => {
+          clearTimeout(timer);
+          code === 0 && !limitFailure
+            ? resolveRun()
+            : reject(new Error(limitFailure || `ai4ai executor exited ${code}: ${stderr}`));
+        });
+      });
+      return { raw: JSON.parse(await readFile(outputFile, "utf8")) as unknown, executorIdentity };
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RUNNING — one mutation, or a lineage chain of them.
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate one mutation against a pinned task. Validates the manifest and
+ * mutation, invokes the injected executor, and parses its output fail-loud.
+ * An executor crash propagates as an error naming the mutation — it is NEVER
+ * folded into a score (adapter-crash ≠ result, same discipline as the WP16
+ * subprocess binder).
+ */
+export async function runAi4aiMutation(
+  manifest: Ai4aiTaskManifest,
+  mutation: Ai4aiMutation,
+  executor: Ai4aiExecutor,
+  parentDigest: string,
+): Promise<Ai4aiLineageRecord> {
+  assertAi4aiTaskManifest(manifest);
+  assertAi4aiMutation(mutation);
+  if (!HEX64.test(parentDigest)) {
+    throw new Error("ai4ai parent digest must be 64 lowercase hex chars");
+  }
+  let outcome: Awaited<ReturnType<Ai4aiExecutor>>;
+  try {
+    outcome = await executor(manifest, mutation);
+  } catch (error) {
+    throw new Error(
+      `ai4ai executor failed for mutation ${mutation.id} (crash is not a score): ${
+        error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!outcome.executorIdentity) throw new Error("ai4ai executor must report a non-empty identity");
+  const evaluation = parseAi4aiEvaluatorOutput(outcome.raw);
+  const body = {
+    taskIdentity: ai4aiTaskIdentity(manifest),
+    parentDigest,
+    mutation,
+    executorIdentity: outcome.executorIdentity,
+    evaluation,
+  };
+  return Object.freeze({ ...body, digest: lineageDigest(body) });
+}
+
+/**
+ * Evaluate a sequence of mutations as one lineage chain: the first mutation's
+ * parent is the frozen task identity, each subsequent mutation's parent is
+ * the previous record's digest. The whole chain is tamper-evident; a single
+ * failing evaluation aborts the chain loudly rather than recording a hole.
+ */
+export async function runAi4aiLineage(
+  manifest: Ai4aiTaskManifest,
+  mutations: readonly Ai4aiMutation[],
+  executor: Ai4aiExecutor,
+): Promise<readonly Ai4aiLineageRecord[]> {
+  assertAi4aiTaskManifest(manifest);
+  if (mutations.length === 0) throw new Error("ai4ai lineage requires at least one mutation");
+  const records: Ai4aiLineageRecord[] = [];
+  let parentDigest = ai4aiTaskIdentity(manifest);
+  for (const mutation of mutations) {
+    const record = await runAi4aiMutation(manifest, mutation, executor, parentDigest);
+    records.push(record);
+    parentDigest = record.digest;
+  }
+  return Object.freeze(records);
+}
+
+/**
+ * Re-verify a lineage chain: every record must re-derive its own digest, name
+ * the same frozen task, and chain to its predecessor. Returns veto-style
+ * reasons (empty ⇒ intact). This is what the veto provider below consumes.
+ */
+export function verifyAi4aiLineage(
+  manifest: Ai4aiTaskManifest,
+  records: readonly Ai4aiLineageRecord[],
+): string[] {
+  const reasons: string[] = [];
+  if (records.length === 0) {
+    reasons.push("ai4ai_lineage_empty");
+    return reasons;
+  }
+  const taskIdentity = ai4aiTaskIdentity(manifest);
+  let expectedParent = taskIdentity;
+  for (const record of records) {
+    if (record.taskIdentity !== taskIdentity) reasons.push("ai4ai_lineage_task_mismatch");
+    if (record.parentDigest !== expectedParent) reasons.push("ai4ai_lineage_broken_chain");
+    const { digest, ...body } = record;
+    if (lineageDigest(body) !== digest) reasons.push("ai4ai_lineage_digest_mismatch");
+    expectedParent = record.digest;
+  }
+  return [...new Set(reasons)].sort();
+}
+
+// ---------------------------------------------------------------------------
+// PROMOTION — our own paired statistics, never the paper's number.
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare baseline vs candidate score samples with the EXISTING paired-
+ * bootstrap authority. Finiteness is re-checked at this choke point even
+ * though ingest already enforced it (defense-in-depth: a hypothetical bypass
+ * still cannot reach the gate with a NaN). The paper's 0.250 best-system
+ * score is a TARGET for reporting, never an acceptance bar — only this
+ * decision, recomputed on our own paired runs, counts toward promotion.
+ */
+export function ai4aiPairedDecision(
+  baseline: readonly number[],
+  candidate: readonly number[],
+  minimumEffect = 0.005,
+): PairedDecision {
+  for (const value of [...baseline, ...candidate]) {
+    if (!Number.isFinite(value)) {
+      throw new Error("ai4ai paired decision refuses non-finite samples (fail-loud)");
+    }
+  }
+  return pairedBootstrapDecision(baseline, candidate, minimumEffect);
+}
+
+/**
+ * A vetoes.ts-composable provider that REJECTS promotion when the lineage
+ * chain behind a candidate does not verify. Conjunctive like every provider:
+ * it can only object, never rescue. `lineageFor` maps the veto context to the
+ * manifest + records under evaluation, mirroring the `candidateFor` /
+ * `environmentFor` seams of the dream-machine and ADR-324 providers.
+ */
+export function ai4aiLineageVetoProvider(
+  lineageFor: (context: unknown) => {
+    manifest: Ai4aiTaskManifest;
+    records: readonly Ai4aiLineageRecord[];
+  } | Promise<{ manifest: Ai4aiTaskManifest; records: readonly Ai4aiLineageRecord[] }>,
+): PromotionVetoProvider {
+  return async (context) => {
+    const { manifest, records } = await lineageFor(context);
+    return verifyAi4aiLineage(manifest, records);
+  };
+}

--- a/crates/ruvector-sota-bench/harness/src/ai4aiBench.ts
+++ b/crates/ruvector-sota-bench/harness/src/ai4aiBench.ts
@@ -56,10 +56,16 @@
  * repository's learning algorithm is the benchmark's task definition executed
  * by an external evaluator on external hardware — it is not a weight update
  * performed by this harness, and no path in this module persists weights.
+ *
+ * KNOWN LIMITATION (accepted, exact parity with benchmark.ts): the command
+ * executor SIGKILLs only the spawned child, not its process group — an
+ * evaluator that forks can leave orphans past the timeout. Inherited from
+ * benchmark.ts's runner discipline; fixing it belongs to both call sites at
+ * once, not to this adapter alone.
  */
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash, randomBytes } from "node:crypto";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pairedBootstrapDecision, type PairedDecision } from "./statistics.js";
@@ -216,17 +222,54 @@ export function parseAi4aiEvaluatorOutput(value: unknown): Ai4aiEvaluation {
 
 /**
  * One link in the lineage chain. `parentDigest` is the previous record's
- * digest (the task identity for the root); `digest` commits to everything —
- * task, parent, diff, seed, executor identity, and the evaluation — so the
- * chain is tamper-evident and any run can be re-derived and audited.
+ * digest (the ROOT BINDING for the first record — see `ai4aiRunRoot`, which
+ * mixes a per-run nonce into the task identity so a chain is bound to the run
+ * that produced it and cannot be replayed as a fresh one). `digest` commits to
+ * everything — task, parent, diff, seed, executor identity, whether the
+ * executor was a declared wrapper, and the evaluation — so the chain is
+ * tamper-evident and any run can be re-derived and audited.
  */
 export interface Ai4aiLineageRecord {
   readonly taskIdentity: string;
   readonly parentDigest: string;
   readonly mutation: Ai4aiMutation;
   readonly executorIdentity: string;
+  /**
+   * True only when the caller EXPLICITLY declared that `executorIdentity`
+   * hashes a wrapper rather than the evaluator itself. Default false, so the
+   * evaluator-identity binding below is enforced unless someone opts out on
+   * the record, in the open, where an auditor sees it.
+   */
+  readonly wrapperIndirection: boolean;
   readonly evaluation: Ai4aiEvaluation;
   readonly digest: string;
+}
+
+/**
+ * The root binding a lineage chains from: the frozen task identity mixed with
+ * a per-run nonce. Without this a chain is fully deterministic — the same
+ * mutations against the same task always produce byte-identical records, so an
+ * old chain could be presented as a fresh run. The nonce makes each run's
+ * chain unique and unforgeable-as-fresh; it is carried alongside the records
+ * (see `Ai4aiLineage`) so verification can re-derive the root.
+ */
+export function ai4aiRunRoot(manifest: Ai4aiTaskManifest, runNonce: string): string {
+  if (!HEX64.test(runNonce)) throw new Error("ai4ai run nonce must be 64 lowercase hex chars");
+  return createHash("sha256")
+    .update("ruvector.ai4ai.run-root.v1\0")
+    .update(`${ai4aiTaskIdentity(manifest)}\0${runNonce}`)
+    .digest("hex");
+}
+
+/** Fresh per-run nonce. */
+export function newAi4aiRunNonce(): string {
+  return randomBytes(32).toString("hex");
+}
+
+/** A complete run: the nonce its chain is bound to, plus the records. */
+export interface Ai4aiLineage {
+  readonly runNonce: string;
+  readonly records: readonly Ai4aiLineageRecord[];
 }
 
 function lineageDigest(record: Omit<Ai4aiLineageRecord, "digest">): string {
@@ -250,7 +293,17 @@ function lineageDigest(record: Omit<Ai4aiLineageRecord, "digest">): string {
 export type Ai4aiExecutor = (
   manifest: Ai4aiTaskManifest,
   mutation: Ai4aiMutation,
-) => Promise<{ readonly raw: unknown; readonly executorIdentity: string }>;
+) => Promise<{
+  readonly raw: unknown;
+  readonly executorIdentity: string;
+  /**
+   * Set true ONLY when `executorIdentity` deliberately hashes a wrapper rather
+   * than the pinned evaluator itself. Absent/false means the identity IS
+   * claimed to be the evaluator's, and `runAi4aiMutation` then ENFORCES it
+   * against `manifest.evaluatorSha256`.
+   */
+  readonly wrapperIndirection?: boolean;
+}>;
 
 export interface Ai4aiCommandExecutorOptions {
   /** Absolute path to the evaluator entrypoint to spawn. */
@@ -259,6 +312,14 @@ export interface Ai4aiCommandExecutorOptions {
   readonly commandPrefixArgs?: readonly string[];
   readonly timeoutMs?: number;
   readonly maxOutputBytes?: number;
+  /**
+   * Declare that `executorPath` is a WRAPPER around the pinned evaluator, not
+   * the evaluator itself. Opting out of the evaluator-identity binding must be
+   * explicit and visible: it is recorded on every lineage record
+   * (`wrapperIndirection: true`) and committed to by the record digest, so an
+   * auditor sees exactly which runs waived the check. Default false.
+   */
+  readonly wrapperIndirection?: boolean;
 }
 
 /**
@@ -267,7 +328,10 @@ export interface Ai4aiCommandExecutorOptions {
  * temp workspace removed afterward. The entrypoint receives
  * `--task <manifest.json> --mutation <mutation.json> --output <result.json>`
  * and must write its evaluation JSON to the output path. Executor identity is
- * the SHA-256 of the entrypoint file's bytes, so lineage pins WHAT ran.
+ * the SHA-256 of the entrypoint file's bytes, so lineage pins WHAT ran — and
+ * the entrypoint is RE-HASHED after exit, failing loudly if its bytes changed
+ * between hashing and execution (time-of-check/time-of-use), so the recorded
+ * identity always names the code that actually ran.
  */
 export function commandAi4aiExecutor(options: Ai4aiCommandExecutorOptions): Ai4aiExecutor {
   return async (manifest, mutation) => {
@@ -322,7 +386,30 @@ export function commandAi4aiExecutor(options: Ai4aiCommandExecutorOptions): Ai4a
             : reject(new Error(limitFailure || `ai4ai executor exited ${code}: ${stderr}`));
         });
       });
-      return { raw: JSON.parse(await readFile(outputFile, "utf8")) as unknown, executorIdentity };
+      // TOCTOU: the entrypoint could have been swapped between hashing and
+      // spawning. Re-hash and refuse rather than record an identity for code
+      // that did not run.
+      const afterIdentity = createHash("sha256").update(await readFile(executorPath)).digest("hex");
+      if (afterIdentity !== executorIdentity) {
+        throw new Error(
+          `ai4ai executor bytes changed during the run (${executorIdentity} -> ${afterIdentity})`,
+        );
+      }
+      // The stdout/stderr ceiling does not cover the result file the evaluator
+      // writes; bound it before reading so an oversized artifact cannot be
+      // pulled into memory.
+      const maxOutputBytes = options.maxOutputBytes ?? 10 * 1024 * 1024;
+      const outputStat = await stat(outputFile);
+      if (outputStat.size > maxOutputBytes) {
+        throw new Error(
+          `ai4ai executor result exceeds output limit: ${outputStat.size} > ${maxOutputBytes} bytes`,
+        );
+      }
+      return {
+        raw: JSON.parse(await readFile(outputFile, "utf8")) as unknown,
+        executorIdentity,
+        wrapperIndirection: options.wrapperIndirection ?? false,
+      };
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
@@ -339,6 +426,12 @@ export function commandAi4aiExecutor(options: Ai4aiCommandExecutorOptions): Ai4a
  * An executor crash propagates as an error naming the mutation — it is NEVER
  * folded into a score (adapter-crash ≠ result, same discipline as the WP16
  * subprocess binder).
+ *
+ * EVALUATOR-IDENTITY BINDING: `manifest.evaluatorSha256` is not merely
+ * format-checked — unless the executor EXPLICITLY declares wrapper
+ * indirection, the identity of what actually ran must EQUAL it. Otherwise a
+ * lineage could claim evaluator X while running Y, which would make the
+ * manifest's evaluator pin a false safety claim rather than a real binding.
  */
 export async function runAi4aiMutation(
   manifest: Ai4aiTaskManifest,
@@ -360,13 +453,24 @@ export async function runAi4aiMutation(
         error instanceof Error ? error.message : String(error)}`,
     );
   }
-  if (!outcome.executorIdentity) throw new Error("ai4ai executor must report a non-empty identity");
+  if (!HEX64.test(outcome.executorIdentity)) {
+    throw new Error("ai4ai executor must report a lowercase SHA-256 identity");
+  }
+  const wrapperIndirection = outcome.wrapperIndirection ?? false;
+  if (!wrapperIndirection && outcome.executorIdentity !== manifest.evaluatorSha256) {
+    throw new Error(
+      `ai4ai executor identity does not match the manifest's pinned evaluator ` +
+      `(${outcome.executorIdentity} != ${manifest.evaluatorSha256}); declare ` +
+      `wrapperIndirection explicitly if the entrypoint wraps the evaluator`,
+    );
+  }
   const evaluation = parseAi4aiEvaluatorOutput(outcome.raw);
   const body = {
     taskIdentity: ai4aiTaskIdentity(manifest),
     parentDigest,
     mutation,
     executorIdentity: outcome.executorIdentity,
+    wrapperIndirection,
     evaluation,
   };
   return Object.freeze({ ...body, digest: lineageDigest(body) });
@@ -382,40 +486,51 @@ export async function runAi4aiLineage(
   manifest: Ai4aiTaskManifest,
   mutations: readonly Ai4aiMutation[],
   executor: Ai4aiExecutor,
-): Promise<readonly Ai4aiLineageRecord[]> {
+  runNonce: string = newAi4aiRunNonce(),
+): Promise<Ai4aiLineage> {
   assertAi4aiTaskManifest(manifest);
   if (mutations.length === 0) throw new Error("ai4ai lineage requires at least one mutation");
   const records: Ai4aiLineageRecord[] = [];
-  let parentDigest = ai4aiTaskIdentity(manifest);
+  let parentDigest = ai4aiRunRoot(manifest, runNonce);
   for (const mutation of mutations) {
     const record = await runAi4aiMutation(manifest, mutation, executor, parentDigest);
     records.push(record);
     parentDigest = record.digest;
   }
-  return Object.freeze(records);
+  return Object.freeze({ runNonce, records: Object.freeze(records) });
 }
 
 /**
- * Re-verify a lineage chain: every record must re-derive its own digest, name
- * the same frozen task, and chain to its predecessor. Returns veto-style
+ * Re-verify a lineage: every record must re-derive its own digest, name the
+ * same frozen task, chain to its predecessor from the run root (task identity
+ * + this run's nonce), and — unless it explicitly declares wrapper
+ * indirection — have run the evaluator the manifest pins. Returns veto-style
  * reasons (empty ⇒ intact). This is what the veto provider below consumes.
  */
 export function verifyAi4aiLineage(
   manifest: Ai4aiTaskManifest,
-  records: readonly Ai4aiLineageRecord[],
+  lineage: Ai4aiLineage,
 ): string[] {
   const reasons: string[] = [];
+  const { runNonce, records } = lineage;
   if (records.length === 0) {
     reasons.push("ai4ai_lineage_empty");
     return reasons;
   }
+  if (!HEX64.test(runNonce)) {
+    reasons.push("ai4ai_lineage_run_nonce_invalid");
+    return [...new Set(reasons)].sort();
+  }
   const taskIdentity = ai4aiTaskIdentity(manifest);
-  let expectedParent = taskIdentity;
+  let expectedParent = ai4aiRunRoot(manifest, runNonce);
   for (const record of records) {
     if (record.taskIdentity !== taskIdentity) reasons.push("ai4ai_lineage_task_mismatch");
     if (record.parentDigest !== expectedParent) reasons.push("ai4ai_lineage_broken_chain");
     const { digest, ...body } = record;
     if (lineageDigest(body) !== digest) reasons.push("ai4ai_lineage_digest_mismatch");
+    if (!record.wrapperIndirection && record.executorIdentity !== manifest.evaluatorSha256) {
+      reasons.push("ai4ai_evaluator_identity_mismatch");
+    }
     expectedParent = record.digest;
   }
   return [...new Set(reasons)].sort();
@@ -456,11 +571,11 @@ export function ai4aiPairedDecision(
 export function ai4aiLineageVetoProvider(
   lineageFor: (context: unknown) => {
     manifest: Ai4aiTaskManifest;
-    records: readonly Ai4aiLineageRecord[];
-  } | Promise<{ manifest: Ai4aiTaskManifest; records: readonly Ai4aiLineageRecord[] }>,
+    lineage: Ai4aiLineage;
+  } | Promise<{ manifest: Ai4aiTaskManifest; lineage: Ai4aiLineage }>,
 ): PromotionVetoProvider {
   return async (context) => {
-    const { manifest, records } = await lineageFor(context);
-    return verifyAi4aiLineage(manifest, records);
+    const { manifest, lineage } = await lineageFor(context);
+    return verifyAi4aiLineage(manifest, lineage);
   };
 }

--- a/crates/ruvector-sota-bench/harness/src/ai4aiBench.ts
+++ b/crates/ruvector-sota-bench/harness/src/ai4aiBench.ts
@@ -65,7 +65,7 @@
  */
 import { spawn } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, open, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pairedBootstrapDecision, type PairedDecision } from "./statistics.js";
@@ -235,10 +235,14 @@ export interface Ai4aiLineageRecord {
   readonly mutation: Ai4aiMutation;
   readonly executorIdentity: string;
   /**
+   * HOW `executorIdentity` was established (see `Ai4aiExecutorClass`). Inside
+   * the digest body, exactly like `wrapperIndirection`, so it cannot be
+   * flipped after the fact.
+   */
+  readonly executorClass: Ai4aiExecutorClass;
+  /**
    * True only when the caller EXPLICITLY declared that `executorIdentity`
-   * hashes a wrapper rather than the evaluator itself. Default false, so the
-   * evaluator-identity binding below is enforced unless someone opts out on
-   * the record, in the open, where an auditor sees it.
+   * hashes a wrapper rather than the evaluator itself.
    */
   readonly wrapperIndirection: boolean;
   readonly evaluation: Ai4aiEvaluation;
@@ -246,12 +250,18 @@ export interface Ai4aiLineageRecord {
 }
 
 /**
- * The root binding a lineage chains from: the frozen task identity mixed with
- * a per-run nonce. Without this a chain is fully deterministic — the same
- * mutations against the same task always produce byte-identical records, so an
- * old chain could be presented as a fresh run. The nonce makes each run's
- * chain unique and unforgeable-as-fresh; it is carried alongside the records
- * (see `Ai4aiLineage`) so verification can re-derive the root.
+ * The root a lineage chains from: the frozen task identity mixed with a
+ * per-run nonce.
+ *
+ * WHAT THE NONCE DELIVERS — and only this: two runs over identical inputs
+ * cannot produce byte-identical records, so runs are DISTINGUISHABLE. It is a
+ * run distinguisher, NOT anti-replay and NOT anti-forgery. There is no
+ * signature over the chain and no external record of issued nonces, so
+ * re-presenting a whole `{ runNonce, records }` pair still verifies, and
+ * `runAi4aiLineage` accepts a caller-supplied nonce whose FORMAT is validated
+ * but whose freshness is not. Chain forgery and replay detection are out of
+ * scope for this slice; they need a signing authority and an issued-nonce
+ * ledger, neither of which exists here.
  */
 export function ai4aiRunRoot(manifest: Ai4aiTaskManifest, runNonce: string): string {
   if (!HEX64.test(runNonce)) throw new Error("ai4ai run nonce must be 64 lowercase hex chars");
@@ -281,7 +291,43 @@ function lineageDigest(record: Omit<Ai4aiLineageRecord, "digest">): string {
 
 // ---------------------------------------------------------------------------
 // EXECUTOR SEAM — injected, never run in-repo (no GPU, no Docker here).
+//
+// TRUST IS ESTABLISHED, NEVER ASSUMED. A lineage defaults to "NOT
+// evaluator-bound evidence"; only this module's own construction can upgrade
+// it. `executorIdentity` alone is a self-reported string, and
+// `manifest.evaluatorSha256` is PUBLIC — it sits in the manifest every caller
+// already holds — so comparing the two proves nothing about what ran: an
+// executor that runs nothing, echoes the pinned hash, and returns a perfect
+// score would otherwise mint a clean-verifying lineage. Byte-derived identity
+// is therefore attested through a module-private registry (below) that only
+// `commandAi4aiExecutor` can write to, and the attestation is keyed on the
+// exact result object the adapter itself built, so a self-reported identity
+// from an arbitrary injected executor CANNOT be presented as byte-derived.
+// An injected executor may still run — it simply cannot claim byte-derived
+// identity, and its records say so.
 // ---------------------------------------------------------------------------
+
+/**
+ * How a record's `executorIdentity` was established:
+ *   - `byte-derived-command` — this module hashed the entrypoint's real bytes
+ *     and the hash equals the manifest's pinned evaluator. The only class that
+ *     is evidence OF THE EVALUATOR.
+ *   - `wrapper-waived` — the caller explicitly declared the entrypoint wraps
+ *     the evaluator, waiving the binding. Honest, but the identity names the
+ *     wrapper, not the pinned evaluator.
+ *   - `injected` — a caller-supplied executor self-reported an identity this
+ *     module cannot corroborate. Runnable, never evaluator-bound.
+ */
+export type Ai4aiExecutorClass = "byte-derived-command" | "wrapper-waived" | "injected";
+
+/**
+ * Module-private attestation registry: maps the exact result object this
+ * module constructed to the identity IT derived from real file bytes. Not
+ * exported and not reachable from outside — an arbitrary executor cannot add
+ * an entry, and mutating a returned object cannot change the attested value
+ * because the adapter reads the identity from here, never off the object.
+ */
+const BYTE_DERIVED_IDENTITY = new WeakMap<object, string>();
 
 /**
  * The injected executor: given a pinned task and one mutation, run the real
@@ -289,6 +335,10 @@ function lineageDigest(record: Omit<Ai4aiLineageRecord, "digest">): string {
  * return its RAW output plus a stable identity for the executor itself (so
  * lineage records name what produced each score). A crash must propagate —
  * the adapter re-throws with context and never scores a crash as a result.
+ *
+ * A self-reported `executorIdentity` is recorded but classed `injected`: this
+ * module cannot corroborate it, so it is never treated as evidence about the
+ * evaluator.
  */
 export type Ai4aiExecutor = (
   manifest: Ai4aiTaskManifest,
@@ -396,20 +446,33 @@ export function commandAi4aiExecutor(options: Ai4aiCommandExecutorOptions): Ai4a
         );
       }
       // The stdout/stderr ceiling does not cover the result file the evaluator
-      // writes; bound it before reading so an oversized artifact cannot be
-      // pulled into memory.
+      // writes. Bound it on the SAME open handle we then read from: a
+      // stat-then-read pair lets the child (same user, and both calls follow
+      // symlinks) swap the file in between and defeat the cap.
       const maxOutputBytes = options.maxOutputBytes ?? 10 * 1024 * 1024;
-      const outputStat = await stat(outputFile);
-      if (outputStat.size > maxOutputBytes) {
-        throw new Error(
-          `ai4ai executor result exceeds output limit: ${outputStat.size} > ${maxOutputBytes} bytes`,
-        );
+      const handle = await open(outputFile, "r");
+      let raw: unknown;
+      try {
+        const handleStat = await handle.stat();
+        if (handleStat.size > maxOutputBytes) {
+          throw new Error(
+            `ai4ai executor result exceeds output limit: ${handleStat.size} > ${maxOutputBytes} bytes`,
+          );
+        }
+        raw = JSON.parse(await handle.readFile("utf8")) as unknown;
+      } finally {
+        await handle.close();
       }
-      return {
-        raw: JSON.parse(await readFile(outputFile, "utf8")) as unknown,
+      // Attest byte-derived identity on the exact object we return. Only this
+      // module can make this entry; the adapter reads the identity from the
+      // registry, never off the (potentially mutated) object.
+      const outcome = {
+        raw,
         executorIdentity,
         wrapperIndirection: options.wrapperIndirection ?? false,
       };
+      BYTE_DERIVED_IDENTITY.set(outcome, executorIdentity);
+      return Object.freeze(outcome);
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
@@ -427,11 +490,14 @@ export function commandAi4aiExecutor(options: Ai4aiCommandExecutorOptions): Ai4a
  * folded into a score (adapter-crash ≠ result, same discipline as the WP16
  * subprocess binder).
  *
- * EVALUATOR-IDENTITY BINDING: `manifest.evaluatorSha256` is not merely
- * format-checked — unless the executor EXPLICITLY declares wrapper
- * indirection, the identity of what actually ran must EQUAL it. Otherwise a
- * lineage could claim evaluator X while running Y, which would make the
- * manifest's evaluator pin a false safety claim rather than a real binding.
+ * EVALUATOR-IDENTITY BINDING, established not assumed: a record is
+ * `byte-derived-command` ONLY when this module itself hashed the entrypoint's
+ * bytes (attested via the module-private registry) AND that hash equals
+ * `manifest.evaluatorSha256` — a mismatch there throws, because the module
+ * knows what actually ran. A caller-supplied executor's self-reported identity
+ * is recorded and classed `injected`; it is never checked against the public
+ * pin, because passing that check proves only that the caller can read the
+ * manifest. An explicitly declared wrapper is classed `wrapper-waived`.
  */
 export async function runAi4aiMutation(
   manifest: Ai4aiTaskManifest,
@@ -457,19 +523,39 @@ export async function runAi4aiMutation(
     throw new Error("ai4ai executor must report a lowercase SHA-256 identity");
   }
   const wrapperIndirection = outcome.wrapperIndirection ?? false;
-  if (!wrapperIndirection && outcome.executorIdentity !== manifest.evaluatorSha256) {
-    throw new Error(
-      `ai4ai executor identity does not match the manifest's pinned evaluator ` +
-      `(${outcome.executorIdentity} != ${manifest.evaluatorSha256}); declare ` +
-      `wrapperIndirection explicitly if the entrypoint wraps the evaluator`,
-    );
+  // The ONLY source of a byte-derived identity is this module's own registry.
+  // A self-reported string can never reach this variable.
+  const attestedIdentity = typeof outcome === "object" && outcome !== null
+    ? BYTE_DERIVED_IDENTITY.get(outcome)
+    : undefined;
+  let executorClass: Ai4aiExecutorClass;
+  let executorIdentity: string;
+  if (attestedIdentity !== undefined && !wrapperIndirection) {
+    // This module hashed real bytes: the pin is now a meaningful binding.
+    if (attestedIdentity !== manifest.evaluatorSha256) {
+      throw new Error(
+        `ai4ai executor identity does not match the manifest's pinned evaluator ` +
+        `(${attestedIdentity} != ${manifest.evaluatorSha256}); declare ` +
+        `wrapperIndirection explicitly if the entrypoint wraps the evaluator`,
+      );
+    }
+    executorClass = "byte-derived-command";
+    executorIdentity = attestedIdentity;
+  } else if (wrapperIndirection) {
+    executorClass = "wrapper-waived";
+    executorIdentity = attestedIdentity ?? outcome.executorIdentity;
+  } else {
+    // Self-reported and uncorroborated. Recorded honestly, never bound.
+    executorClass = "injected";
+    executorIdentity = outcome.executorIdentity;
   }
   const evaluation = parseAi4aiEvaluatorOutput(outcome.raw);
   const body = {
     taskIdentity: ai4aiTaskIdentity(manifest),
     parentDigest,
     mutation,
-    executorIdentity: outcome.executorIdentity,
+    executorIdentity,
+    executorClass,
     wrapperIndirection,
     evaluation,
   };
@@ -501,15 +587,43 @@ export async function runAi4aiLineage(
 }
 
 /**
+ * What a caller demands of a lineage's evidence class. Structural integrity
+ * (digest, chain, task, nonce) is ALWAYS checked; this governs only the
+ * evidence-strength question.
+ */
+export interface Ai4aiEvidencePolicy {
+  /**
+   * Demand that EVERY record be `byte-derived-command`. Off by default: real
+   * Docker/GPU runs legitimately use a wrapper entrypoint, and hard-blocking
+   * those would break them. A caller that needs evaluator-bound evidence turns
+   * this on and receives `ai4ai_evaluator_identity_waived` (wrapper) or
+   * `ai4ai_executor_not_byte_bound` (injected) — distinct reasons, so an
+   * automated gate can tell a bound run from a waived or uncorroborated one
+   * instead of seeing an indistinguishable clean verdict.
+   */
+  readonly requireEvaluatorBound?: boolean;
+}
+
+/** The weakest executor class present — the class of the lineage as a whole. */
+export function ai4aiEvidenceClass(lineage: Ai4aiLineage): Ai4aiExecutorClass {
+  if (lineage.records.some((record) => record.executorClass === "injected")) return "injected";
+  if (lineage.records.some((record) => record.executorClass === "wrapper-waived")) {
+    return "wrapper-waived";
+  }
+  return "byte-derived-command";
+}
+
+/**
  * Re-verify a lineage: every record must re-derive its own digest, name the
- * same frozen task, chain to its predecessor from the run root (task identity
- * + this run's nonce), and — unless it explicitly declares wrapper
- * indirection — have run the evaluator the manifest pins. Returns veto-style
+ * same frozen task, and chain to its predecessor from the run root (task
+ * identity + this run's nonce). Under `policy.requireEvaluatorBound`, records
+ * that are not byte-derived also draw a distinct reason. Returns veto-style
  * reasons (empty ⇒ intact). This is what the veto provider below consumes.
  */
 export function verifyAi4aiLineage(
   manifest: Ai4aiTaskManifest,
   lineage: Ai4aiLineage,
+  policy: Ai4aiEvidencePolicy = {},
 ): string[] {
   const reasons: string[] = [];
   const { runNonce, records } = lineage;
@@ -528,8 +642,18 @@ export function verifyAi4aiLineage(
     if (record.parentDigest !== expectedParent) reasons.push("ai4ai_lineage_broken_chain");
     const { digest, ...body } = record;
     if (lineageDigest(body) !== digest) reasons.push("ai4ai_lineage_digest_mismatch");
-    if (!record.wrapperIndirection && record.executorIdentity !== manifest.evaluatorSha256) {
+    // A byte-derived record is the only one whose identity this module
+    // established; for it, disagreement with the pin is a real mismatch.
+    if (record.executorClass === "byte-derived-command" &&
+        record.executorIdentity !== manifest.evaluatorSha256) {
       reasons.push("ai4ai_evaluator_identity_mismatch");
+    }
+    if (policy.requireEvaluatorBound) {
+      if (record.executorClass === "wrapper-waived") {
+        reasons.push("ai4ai_evaluator_identity_waived");
+      } else if (record.executorClass === "injected") {
+        reasons.push("ai4ai_executor_not_byte_bound");
+      }
     }
     expectedParent = record.digest;
   }
@@ -563,19 +687,23 @@ export function ai4aiPairedDecision(
 
 /**
  * A vetoes.ts-composable provider that REJECTS promotion when the lineage
- * chain behind a candidate does not verify. Conjunctive like every provider:
- * it can only object, never rescue. `lineageFor` maps the veto context to the
- * manifest + records under evaluation, mirroring the `candidateFor` /
- * `environmentFor` seams of the dream-machine and ADR-324 providers.
+ * behind a candidate does not verify. Conjunctive like every provider: it can
+ * only object, never rescue. `lineageFor` maps the veto context to the
+ * manifest + lineage under evaluation, mirroring the `candidateFor` /
+ * `environmentFor` seams of the dream-machine and ADR-324 providers. Pass
+ * `{ requireEvaluatorBound: true }` to also reject lineages that are not
+ * byte-derived — off by default so legitimate wrapper-entrypoint runs are not
+ * blocked, on when a gate needs evaluator-bound evidence specifically.
  */
 export function ai4aiLineageVetoProvider(
   lineageFor: (context: unknown) => {
     manifest: Ai4aiTaskManifest;
     lineage: Ai4aiLineage;
   } | Promise<{ manifest: Ai4aiTaskManifest; lineage: Ai4aiLineage }>,
+  policy: Ai4aiEvidencePolicy = {},
 ): PromotionVetoProvider {
   return async (context) => {
     const { manifest, lineage } = await lineageFor(context);
-    return verifyAi4aiLineage(manifest, lineage);
+    return verifyAi4aiLineage(manifest, lineage, policy);
   };
 }

--- a/crates/ruvector-sota-bench/harness/src/cli.ts
+++ b/crates/ruvector-sota-bench/harness/src/cli.ts
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 import { resolve } from "node:path";
 import { readFile } from "node:fs/promises";
+import {
+  assertAi4aiMutation,
+  assertAi4aiTaskManifest,
+  commandAi4aiExecutor,
+  runAi4aiLineage,
+} from "./ai4aiBench.js";
 import type { BenchmarkSuiteItem } from "./benchmark.js";
 import { capabilityStatus } from "./capabilities.js";
 import { runRuvectorDarwin, runRuvectorGepa } from "./darwin.js";
@@ -96,7 +102,43 @@ async function main(): Promise<void> {
     }, null, 2)}\n`);
     return;
   }
-  throw new Error("usage: ruvector-metaharness <doctor|flywheel|darwin|darwin-ann> [options]");
+  if (command === "darwin-ai4ai") {
+    // AI4AI-Bench (arXiv:2608.20318) lineage run against an injected external
+    // evaluator entrypoint. The real evaluator needs Docker + datacenter GPU
+    // hardware; --executor points at whatever entrypoint the caller pins
+    // (a fixture locally, the real evaluator on capable hardware).
+    const manifestPath = value("--manifest");
+    const mutationsPath = value("--mutations");
+    const executorPath = value("--executor");
+    if (!manifestPath || !mutationsPath || !executorPath) {
+      throw new Error("darwin-ai4ai requires --manifest, --mutations, and --executor");
+    }
+    const manifest = JSON.parse(await readFile(resolve(manifestPath), "utf8")) as unknown;
+    assertAi4aiTaskManifest(manifest);
+    const mutations = JSON.parse(await readFile(resolve(mutationsPath), "utf8")) as unknown;
+    if (!Array.isArray(mutations)) throw new Error("--mutations must be a JSON array");
+    for (const mutation of mutations) assertAi4aiMutation(mutation);
+    // JS entrypoints (fixtures, node-based wrappers) are run via this node;
+    // anything else must be directly executable.
+    const resolvedExecutor = resolve(executorPath);
+    const records = await runAi4aiLineage(
+      manifest,
+      mutations,
+      commandAi4aiExecutor({
+        executorPath: resolvedExecutor,
+        ...(/\.(mjs|cjs|js)$/.test(resolvedExecutor)
+          ? { commandPrefixArgs: [process.execPath] }
+          : {}),
+      }),
+    );
+    process.stdout.write(`${JSON.stringify({
+      task: manifest.taskId,
+      records,
+      bestScore: Math.max(...records.map((record) => record.evaluation.score)),
+    }, null, 2)}\n`);
+    return;
+  }
+  throw new Error("usage: ruvector-metaharness <doctor|flywheel|darwin|darwin-ann|darwin-ai4ai> [options]");
 }
 
 main().catch((error: unknown) => {

--- a/crates/ruvector-sota-bench/harness/src/cli.ts
+++ b/crates/ruvector-sota-bench/harness/src/cli.ts
@@ -2,6 +2,7 @@
 import { resolve } from "node:path";
 import { readFile } from "node:fs/promises";
 import {
+  ai4aiEvidenceClass,
   assertAi4aiMutation,
   assertAi4aiTaskManifest,
   commandAi4aiExecutor,
@@ -137,13 +138,20 @@ async function main(): Promise<void> {
           : {}),
       }),
     );
+    // --require-evaluator-bound demands byte-derived evidence for every record.
+    const vetoReasons = verifyAi4aiLineage(manifest, lineage, {
+      requireEvaluatorBound: process.argv.includes("--require-evaluator-bound"),
+    });
     process.stdout.write(`${JSON.stringify({
       task: manifest.taskId,
       runNonce: lineage.runNonce,
+      evidenceClass: ai4aiEvidenceClass(lineage),
       records: lineage.records,
-      vetoReasons: verifyAi4aiLineage(manifest, lineage),
+      vetoReasons,
       bestScore: Math.max(...lineage.records.map((record) => record.evaluation.score)),
     }, null, 2)}\n`);
+    // A vetoed run must not read as success to automation keying on exit status.
+    if (vetoReasons.length > 0) process.exitCode = 1;
     return;
   }
   throw new Error("usage: ruvector-metaharness <doctor|flywheel|darwin|darwin-ann|darwin-ai4ai> [options]");

--- a/crates/ruvector-sota-bench/harness/src/cli.ts
+++ b/crates/ruvector-sota-bench/harness/src/cli.ts
@@ -6,6 +6,7 @@ import {
   assertAi4aiTaskManifest,
   commandAi4aiExecutor,
   runAi4aiLineage,
+  verifyAi4aiLineage,
 } from "./ai4aiBench.js";
 import type { BenchmarkSuiteItem } from "./benchmark.js";
 import { capabilityStatus } from "./capabilities.js";
@@ -121,11 +122,16 @@ async function main(): Promise<void> {
     // JS entrypoints (fixtures, node-based wrappers) are run via this node;
     // anything else must be directly executable.
     const resolvedExecutor = resolve(executorPath);
-    const records = await runAi4aiLineage(
+    // --wrapper-indirection declares that the pinned entrypoint WRAPS the
+    // evaluator, waiving the evaluator-identity binding. It must be asked for
+    // explicitly and is recorded on every lineage record.
+    const wrapperIndirection = process.argv.includes("--wrapper-indirection");
+    const lineage = await runAi4aiLineage(
       manifest,
       mutations,
       commandAi4aiExecutor({
         executorPath: resolvedExecutor,
+        ...(wrapperIndirection ? { wrapperIndirection: true } : {}),
         ...(/\.(mjs|cjs|js)$/.test(resolvedExecutor)
           ? { commandPrefixArgs: [process.execPath] }
           : {}),
@@ -133,8 +139,10 @@ async function main(): Promise<void> {
     );
     process.stdout.write(`${JSON.stringify({
       task: manifest.taskId,
-      records,
-      bestScore: Math.max(...records.map((record) => record.evaluation.score)),
+      runNonce: lineage.runNonce,
+      records: lineage.records,
+      vetoReasons: verifyAi4aiLineage(manifest, lineage),
+      bestScore: Math.max(...lineage.records.map((record) => record.evaluation.score)),
     }, null, 2)}\n`);
     return;
   }

--- a/crates/ruvector-sota-bench/harness/test/ai4aiBench.test.ts
+++ b/crates/ruvector-sota-bench/harness/test/ai4aiBench.test.ts
@@ -5,11 +5,13 @@ import { resolve } from "node:path";
 import test from "node:test";
 import {
   AI4AI_BENCH_CITATION,
+  ai4aiContentDigest,
   ai4aiEvidenceClass,
   ai4aiLineageVetoProvider,
   ai4aiPairedDecision,
   ai4aiRunRoot,
   ai4aiTaskIdentity,
+  assertAi4aiContentUnchanged,
   assertAi4aiTaskManifest,
   commandAi4aiExecutor,
   newAi4aiRunNonce,
@@ -184,6 +186,55 @@ test("the scored payload cannot be edited after execution", async () => {
   // And the untouched genuine run records the evaluator's real score.
   assert.equal(honest.records[0]!.executorClass, "byte-derived-command");
   assert.equal(honest.records[0]!.evaluation.score, honestScore);
+});
+
+test("content digest detects a mutated payload and the guard actually throws", () => {
+  // DORMANT-GUARD COVERAGE. On every constructible path the deep-freeze stops
+  // an edit before the comparison runs, so without these direct tests someone
+  // could invert `!==` to `===` and leave the whole suite green while
+  // disabling the content guarantee.
+  const honest = { score: 0.12, algorithm_changed: true };
+  const digest = ai4aiContentDigest(honest);
+  assert.match(digest, /^[0-9a-f]{64}$/);
+  assert.equal(ai4aiContentDigest({ ...honest }), digest, "digest must be stable for equal content");
+  assert.notEqual(ai4aiContentDigest({ ...honest, score: 0.99 }), digest);
+  assert.notEqual(ai4aiContentDigest({ ...honest, algorithm_changed: false }), digest);
+  assert.notEqual(ai4aiContentDigest({ ...honest, extra: 1 }), digest);
+
+  // Key order must not change the digest; nested payloads must still differ.
+  assert.equal(
+    ai4aiContentDigest({ algorithm_changed: true, score: 0.12 }),
+    digest,
+    "canonical encoding must be key-order independent",
+  );
+  assert.notEqual(
+    ai4aiContentDigest({ detail: { a: 1 } }),
+    ai4aiContentDigest({ detail: { a: 2 } }),
+  );
+
+  // The detection path itself: passes on match, throws on mismatch.
+  assert.doesNotThrow(() => assertAi4aiContentUnchanged(honest, digest, "mut-001"));
+  assert.throws(
+    () => assertAi4aiContentUnchanged({ ...honest, score: 0.99 }, digest, "mut-001"),
+    /modified after execution.*mut-001.*not a score/s,
+  );
+});
+
+test("canonical key order is locale-independent", () => {
+  // localeCompare would order these differently under sv_SE than en_US, so a
+  // chain could stop verifying across machines with different LANG.
+  const payload = { z_metric: 1, "ä_metric": 2, a_metric: 3 };
+  const expected = ai4aiContentDigest(payload);
+  const original = Intl.Collator;
+  try {
+    // Force any locale-sensitive comparison to disagree with code-unit order.
+    (Intl as { Collator: unknown }).Collator = class {
+      compare = (a: string, b: string) => (a > b ? -1 : a < b ? 1 : 0);
+    };
+    assert.equal(ai4aiContentDigest({ a_metric: 3, "ä_metric": 2, z_metric: 1 }), expected);
+  } finally {
+    (Intl as { Collator: unknown }).Collator = original;
+  }
 });
 
 test("an empty lineage is the weakest class, never the strongest", () => {

--- a/crates/ruvector-sota-bench/harness/test/ai4aiBench.test.ts
+++ b/crates/ruvector-sota-bench/harness/test/ai4aiBench.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+import test from "node:test";
+import {
+  AI4AI_BENCH_CITATION,
+  ai4aiLineageVetoProvider,
+  ai4aiPairedDecision,
+  ai4aiTaskIdentity,
+  assertAi4aiTaskManifest,
+  commandAi4aiExecutor,
+  parseAi4aiEvaluatorOutput,
+  runAi4aiLineage,
+  runAi4aiMutation,
+  verifyAi4aiLineage,
+  type Ai4aiExecutor,
+  type Ai4aiMutation,
+  type Ai4aiTaskManifest,
+} from "../src/ai4aiBench.js";
+
+const hex = (seed: string) => createHash("sha256").update(seed).digest("hex");
+const fixture = resolve(import.meta.dirname, "../../test/fixtures/fake-ai4ai-evaluator.mjs");
+
+const manifest: Ai4aiTaskManifest = {
+  benchmark: "einsia-ai4ai-bench",
+  taskId: "task-03-policy-gradient",
+  algorithmFamily: "policy-gradient",
+  repoSnapshotSha256: hex("repo"),
+  evaluatorSha256: hex("evaluator"),
+  citation: AI4AI_BENCH_CITATION,
+};
+
+const mutation = (id: string, seed: number, description = "reshape the update rule"): Ai4aiMutation => ({
+  id, seed, description, diffSha256: hex(`diff-${id}`),
+});
+
+const okExecutor: Ai4aiExecutor = async () => ({
+  raw: { score: 0.18, algorithm_changed: true },
+  executorIdentity: hex("executor-ok"),
+});
+
+test("manifest without hashes is refused", () => {
+  assert.throws(
+    () => assertAi4aiTaskManifest({ ...manifest, repoSnapshotSha256: "" }),
+    /SHA-256 repo snapshot identity/,
+  );
+  assert.throws(
+    () => assertAi4aiTaskManifest({ ...manifest, evaluatorSha256: "DEADBEEF" }),
+    /SHA-256 evaluator identity/,
+  );
+  assert.throws(
+    () => assertAi4aiTaskManifest({ ...manifest, citation: "AI4AI" }),
+    /exact citation/,
+  );
+});
+
+test("fixture end-to-end lineage chains parent digests from the task identity", async () => {
+  const executor = commandAi4aiExecutor({
+    executorPath: fixture,
+    commandPrefixArgs: [process.execPath],
+  });
+  const records = await runAi4aiLineage(
+    manifest,
+    [mutation("mut-001", 3), mutation("mut-002", 7), mutation("mut-003", 5, "tuning sweep only")],
+    executor,
+  );
+  assert.equal(records.length, 3);
+  assert.equal(records[0]!.parentDigest, ai4aiTaskIdentity(manifest));
+  assert.equal(records[1]!.parentDigest, records[0]!.digest);
+  assert.equal(records[2]!.parentDigest, records[1]!.digest);
+  assert.equal(records[0]!.evaluation.submissionKind, "algorithm-change");
+  assert.equal(records[2]!.evaluation.submissionKind, "tuning-only");
+  assert.ok(records.every((record) => record.executorIdentity === records[0]!.executorIdentity));
+  assert.deepEqual(verifyAi4aiLineage(manifest, records), []);
+});
+
+test("executor crash throws and is never scored", async () => {
+  const executor = commandAi4aiExecutor({
+    executorPath: fixture,
+    commandPrefixArgs: [process.execPath],
+  });
+  await assert.rejects(
+    runAi4aiMutation(manifest, mutation("mut-bad", 1, "crash on purpose"), executor, ai4aiTaskIdentity(manifest)),
+    /crash is not a score/,
+  );
+});
+
+test("non-finite and out-of-range scores are refused at ingest", async () => {
+  assert.throws(() => parseAi4aiEvaluatorOutput({ score: Number.NaN }), /finite/);
+  assert.throws(() => parseAi4aiEvaluatorOutput({ score: Number.POSITIVE_INFINITY }), /finite/);
+  assert.throws(() => parseAi4aiEvaluatorOutput({ score: 1.5 }), /out of range/);
+  assert.throws(() => parseAi4aiEvaluatorOutput({ score: "0.2" }), /finite/);
+  const nanExecutor: Ai4aiExecutor = async () => ({
+    raw: { score: Number.NaN },
+    executorIdentity: hex("executor-nan"),
+  });
+  await assert.rejects(
+    runAi4aiMutation(manifest, mutation("mut-nan", 2), nanExecutor, ai4aiTaskIdentity(manifest)),
+    /finite/,
+  );
+});
+
+test("classification is ingested only when reported, never fabricated", () => {
+  assert.equal(parseAi4aiEvaluatorOutput({ score: 0.2 }).submissionKind, "unreported");
+  assert.equal(
+    parseAi4aiEvaluatorOutput({ score: 0.2, algorithm_changed: false }).submissionKind,
+    "tuning-only",
+  );
+  assert.throws(() => parseAi4aiEvaluatorOutput({ score: 0.2, algorithm_changed: "yes" }), /boolean/);
+});
+
+test("lineage verification detects tampering and the veto provider objects", async () => {
+  const records = await runAi4aiLineage(manifest, [mutation("mut-001", 3), mutation("mut-002", 7)], okExecutor);
+  const tampered = [
+    records[0]!,
+    { ...records[1]!, evaluation: { ...records[1]!.evaluation, score: 0.99 } },
+  ];
+  assert.deepEqual(verifyAi4aiLineage(manifest, tampered), ["ai4ai_lineage_digest_mismatch"]);
+  const broken = [records[1]!];
+  assert.ok(verifyAi4aiLineage(manifest, broken).includes("ai4ai_lineage_broken_chain"));
+
+  const provider = ai4aiLineageVetoProvider(() => ({ manifest, records: tampered }));
+  assert.deepEqual(
+    await provider({ policy: {}, suite: { id: "s", items: [] }, observations: [] } as never),
+    ["ai4ai_lineage_digest_mismatch"],
+  );
+  const clean = ai4aiLineageVetoProvider(() => ({ manifest, records }));
+  assert.deepEqual(
+    await clean({ policy: {}, suite: { id: "s", items: [] }, observations: [] } as never),
+    [],
+  );
+});
+
+test("paired decision refuses non-finite samples and otherwise defers to the bootstrap", () => {
+  assert.throws(() => ai4aiPairedDecision([0.1, Number.NaN], [0.2, 0.2]), /non-finite/);
+  const decision = ai4aiPairedDecision(
+    [0.10, 0.11, 0.10, 0.12, 0.11],
+    [0.18, 0.19, 0.17, 0.20, 0.18],
+  );
+  assert.equal(decision.outcome, "pass");
+  const flat = ai4aiPairedDecision([0.1, 0.1, 0.1], [0.1, 0.1, 0.1]);
+  assert.notEqual(flat.outcome, "pass");
+});

--- a/crates/ruvector-sota-bench/harness/test/ai4aiBench.test.ts
+++ b/crates/ruvector-sota-bench/harness/test/ai4aiBench.test.ts
@@ -144,6 +144,56 @@ test("a real command run is byte-derived and bound to the pinned evaluator", asy
   );
 });
 
+test("the scored payload cannot be edited after execution", async () => {
+  // The probe: let the genuine command executor run, then overwrite the score
+  // in the result it returned. Object.freeze is shallow, so `raw` used to stay
+  // writable and this landed a fabricated 0.99 in the trusted class.
+  const honest = await runAi4aiLineage(manifest, [mutation("mut-001", 1)], fixtureExecutor);
+  const honestScore = honest.records[0]!.evaluation.score;
+  assert.ok(honestScore < 0.9, "fixture must produce a modest honest score for this probe");
+
+  const tamper: Ai4aiExecutor = async (m, mu) => {
+    const genuine = await fixtureExecutor(m, mu);
+    // Deep-freeze (defense-in-depth) makes this throw in ESM strict mode; if a
+    // refactor ever rebuilds the payload unfrozen, the content digest below is
+    // what still catches it.
+    (genuine.raw as { score: number }).score = 0.99;
+    (genuine.raw as { algorithm_changed: boolean }).algorithm_changed = true;
+    return genuine;
+  };
+  await assert.rejects(
+    runAi4aiLineage(manifest, [mutation("mut-tamper", 1)], tamper),
+    (error: unknown) =>
+      error instanceof TypeError ||
+      /modified after execution|not a score/.test((error as Error).message),
+  );
+
+  // A payload swapped wholesale rides a different object, so it is not
+  // attested at all and can never reach the trusted class.
+  const swap: Ai4aiExecutor = async (m, mu) => ({
+    ...(await fixtureExecutor(m, mu)),
+    raw: { score: 0.99, algorithm_changed: true },
+  });
+  const swapped = await runAi4aiLineage(manifest, [mutation("mut-swap", 1)], swap);
+  assert.equal(swapped.records[0]!.executorClass, "injected");
+  assert.deepEqual(
+    verifyAi4aiLineage(manifest, swapped, { requireEvaluatorBound: true }),
+    ["ai4ai_executor_not_byte_bound"],
+  );
+
+  // And the untouched genuine run records the evaluator's real score.
+  assert.equal(honest.records[0]!.executorClass, "byte-derived-command");
+  assert.equal(honest.records[0]!.evaluation.score, honestScore);
+});
+
+test("an empty lineage is the weakest class, never the strongest", () => {
+  assert.equal(ai4aiEvidenceClass({ runNonce: newAi4aiRunNonce(), records: [] }), "injected");
+  assert.deepEqual(
+    verifyAi4aiLineage(manifest, { runNonce: newAi4aiRunNonce(), records: [] }),
+    ["ai4ai_lineage_empty"],
+  );
+});
+
 test("a declared wrapper is honestly classed and distinguishable under policy", async () => {
   const wrapped: Ai4aiExecutor = async () => ({
     raw: { score: 0.2, algorithm_changed: true },

--- a/crates/ruvector-sota-bench/harness/test/ai4aiBench.test.ts
+++ b/crates/ruvector-sota-bench/harness/test/ai4aiBench.test.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 import {
   AI4AI_BENCH_CITATION,
+  ai4aiEvidenceClass,
   ai4aiLineageVetoProvider,
   ai4aiPairedDecision,
   ai4aiRunRoot,
@@ -86,25 +87,64 @@ test("fixture end-to-end lineage chains parent digests from the run root", async
   assert.deepEqual(verifyAi4aiLineage(manifest, lineage), []);
 });
 
-test("executor identity is bound to the manifest's pinned evaluator", async () => {
-  // Run-time: an executor reporting a different identity is refused outright.
-  const impostor: Ai4aiExecutor = async () => ({
-    raw: { score: 0.42, algorithm_changed: true },
-    executorIdentity: hex("some-other-evaluator"),
+test("byte-derived identity cannot be self-reported: the echo-executor probe fails", async () => {
+  // The probe: an executor that runs NOTHING, echoes the manifest's public
+  // pin, and returns a perfect score. It must not be able to mint a lineage
+  // that passes as evaluator-bound evidence.
+  const echo: Ai4aiExecutor = async () => ({
+    raw: { score: 0.99, algorithm_changed: true },
+    executorIdentity: manifest.evaluatorSha256,
   });
+  const minted = await runAi4aiLineage(manifest, [mutation("mut-echo", 1)], echo);
+
+  // It runs and records honestly — but as `injected`, never byte-derived.
+  assert.equal(minted.records[0]!.executorClass, "injected");
+  assert.equal(ai4aiEvidenceClass(minted), "injected");
+  // A gate demanding evaluator-bound evidence gets a distinct, actionable reason
+  // instead of the indistinguishable clean verdict this used to return.
+  assert.deepEqual(
+    verifyAi4aiLineage(manifest, minted, { requireEvaluatorBound: true }),
+    ["ai4ai_executor_not_byte_bound"],
+  );
+  const strict = ai4aiLineageVetoProvider(
+    () => ({ manifest, lineage: minted }),
+    { requireEvaluatorBound: true },
+  );
+  assert.deepEqual(
+    await strict({ policy: {}, suite: { id: "s", items: [] }, observations: [] } as never),
+    ["ai4ai_executor_not_byte_bound"],
+  );
+  // The class is inside the digest body, so it cannot be flipped after the fact.
+  const forged = {
+    runNonce: minted.runNonce,
+    records: [{ ...minted.records[0]!, executorClass: "byte-derived-command" as const }],
+  };
+  assert.ok(verifyAi4aiLineage(manifest, forged).includes("ai4ai_lineage_digest_mismatch"));
+});
+
+test("a real command run is byte-derived and bound to the pinned evaluator", async () => {
+  const lineage = await runAi4aiLineage(manifest, [mutation("mut-001", 3)], fixtureExecutor);
+  assert.equal(lineage.records[0]!.executorClass, "byte-derived-command");
+  assert.equal(lineage.records[0]!.executorIdentity, evaluatorSha256);
+  assert.equal(ai4aiEvidenceClass(lineage), "byte-derived-command");
+  // Passes even under the strictest policy — this is what real evidence looks like.
+  assert.deepEqual(verifyAi4aiLineage(manifest, lineage, { requireEvaluatorBound: true }), []);
+
+  // A manifest pinning a different evaluator is refused at run time, because
+  // here the module itself knows what ran.
+  const wrongManifest: Ai4aiTaskManifest = { ...manifest, evaluatorSha256: hex("declared-but-not-run") };
   await assert.rejects(
-    runAi4aiMutation(manifest, mutation("mut-x", 1), impostor, ai4aiRunRoot(manifest, newAi4aiRunNonce())),
+    runAi4aiMutation(
+      wrongManifest,
+      mutation("mut-x", 1),
+      fixtureExecutor,
+      ai4aiRunRoot(wrongManifest, newAi4aiRunNonce()),
+    ),
     /does not match the manifest's pinned evaluator/,
   );
+});
 
-  // Verification: a record claiming evaluator X while running Y is vetoed.
-  const lineage = await runAi4aiLineage(manifest, [mutation("mut-001", 3)], okExecutor);
-  const wrongManifest: Ai4aiTaskManifest = { ...manifest, evaluatorSha256: hex("declared-but-not-run") };
-  assert.ok(
-    verifyAi4aiLineage(wrongManifest, lineage).includes("ai4ai_evaluator_identity_mismatch"),
-  );
-
-  // The escape hatch must be explicitly declared, and is visible on the record.
+test("a declared wrapper is honestly classed and distinguishable under policy", async () => {
   const wrapped: Ai4aiExecutor = async () => ({
     raw: { score: 0.2, algorithm_changed: true },
     executorIdentity: hex("a-declared-wrapper"),
@@ -112,14 +152,24 @@ test("executor identity is bound to the manifest's pinned evaluator", async () =
   });
   const wrappedLineage = await runAi4aiLineage(manifest, [mutation("mut-w", 2)], wrapped);
   assert.equal(wrappedLineage.records[0]!.wrapperIndirection, true);
+  assert.equal(wrappedLineage.records[0]!.executorClass, "wrapper-waived");
+  // Not blocked by default — real Docker/GPU runs legitimately wrap.
   assert.deepEqual(verifyAi4aiLineage(manifest, wrappedLineage), []);
+  // But a gate that needs evaluator-bound evidence can tell it apart.
+  assert.deepEqual(
+    verifyAi4aiLineage(manifest, wrappedLineage, { requireEvaluatorBound: true }),
+    ["ai4ai_evaluator_identity_waived"],
+  );
+  assert.equal(ai4aiEvidenceClass(wrappedLineage), "wrapper-waived");
 });
 
-test("run nonce binds a chain to its run so it cannot replay as fresh", async () => {
+test("run nonce distinguishes runs: identical inputs cannot be byte-identical", async () => {
   const nonce = newAi4aiRunNonce();
   const first = await runAi4aiLineage(manifest, [mutation("mut-001", 3)], okExecutor, nonce);
   const replay = await runAi4aiLineage(manifest, [mutation("mut-001", 3)], okExecutor);
-  // Identical inputs, different runs: digests must differ.
+  // Identical inputs, different runs: digests must differ. This is a run
+  // DISTINGUISHER only — re-presenting a whole {runNonce, records} pair still
+  // verifies; anti-replay is out of scope for this slice.
   assert.notEqual(first.records[0]!.digest, replay.records[0]!.digest);
   // A chain presented under someone else's nonce does not verify.
   assert.ok(

--- a/crates/ruvector-sota-bench/harness/test/ai4aiBench.test.ts
+++ b/crates/ruvector-sota-bench/harness/test/ai4aiBench.test.ts
@@ -1,14 +1,17 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import test from "node:test";
 import {
   AI4AI_BENCH_CITATION,
   ai4aiLineageVetoProvider,
   ai4aiPairedDecision,
+  ai4aiRunRoot,
   ai4aiTaskIdentity,
   assertAi4aiTaskManifest,
   commandAi4aiExecutor,
+  newAi4aiRunNonce,
   parseAi4aiEvaluatorOutput,
   runAi4aiLineage,
   runAi4aiMutation,
@@ -21,12 +24,16 @@ import {
 const hex = (seed: string) => createHash("sha256").update(seed).digest("hex");
 const fixture = resolve(import.meta.dirname, "../../test/fixtures/fake-ai4ai-evaluator.mjs");
 
+// The manifest pins the evaluator by its REAL content hash: the adapter binds
+// what actually ran to this value, so a stand-in constant would not run.
+const evaluatorSha256 = createHash("sha256").update(await readFile(fixture)).digest("hex");
+
 const manifest: Ai4aiTaskManifest = {
   benchmark: "einsia-ai4ai-bench",
   taskId: "task-03-policy-gradient",
   algorithmFamily: "policy-gradient",
   repoSnapshotSha256: hex("repo"),
-  evaluatorSha256: hex("evaluator"),
+  evaluatorSha256,
   citation: AI4AI_BENCH_CITATION,
 };
 
@@ -34,9 +41,15 @@ const mutation = (id: string, seed: number, description = "reshape the update ru
   id, seed, description, diffSha256: hex(`diff-${id}`),
 });
 
+const fixtureExecutor = commandAi4aiExecutor({
+  executorPath: fixture,
+  commandPrefixArgs: [process.execPath],
+});
+
+/** An in-process executor that reports the pinned evaluator identity. */
 const okExecutor: Ai4aiExecutor = async () => ({
   raw: { score: 0.18, algorithm_changed: true },
-  executorIdentity: hex("executor-ok"),
+  executorIdentity: evaluatorSha256,
 });
 
 test("manifest without hashes is refused", () => {
@@ -54,33 +67,79 @@ test("manifest without hashes is refused", () => {
   );
 });
 
-test("fixture end-to-end lineage chains parent digests from the task identity", async () => {
-  const executor = commandAi4aiExecutor({
-    executorPath: fixture,
-    commandPrefixArgs: [process.execPath],
-  });
-  const records = await runAi4aiLineage(
+test("fixture end-to-end lineage chains parent digests from the run root", async () => {
+  const lineage = await runAi4aiLineage(
     manifest,
     [mutation("mut-001", 3), mutation("mut-002", 7), mutation("mut-003", 5, "tuning sweep only")],
-    executor,
+    fixtureExecutor,
   );
+  const { records } = lineage;
   assert.equal(records.length, 3);
-  assert.equal(records[0]!.parentDigest, ai4aiTaskIdentity(manifest));
+  assert.equal(records[0]!.parentDigest, ai4aiRunRoot(manifest, lineage.runNonce));
+  assert.notEqual(records[0]!.parentDigest, ai4aiTaskIdentity(manifest));
   assert.equal(records[1]!.parentDigest, records[0]!.digest);
   assert.equal(records[2]!.parentDigest, records[1]!.digest);
   assert.equal(records[0]!.evaluation.submissionKind, "algorithm-change");
   assert.equal(records[2]!.evaluation.submissionKind, "tuning-only");
-  assert.ok(records.every((record) => record.executorIdentity === records[0]!.executorIdentity));
-  assert.deepEqual(verifyAi4aiLineage(manifest, records), []);
+  assert.ok(records.every((record) => record.executorIdentity === evaluatorSha256));
+  assert.ok(records.every((record) => record.wrapperIndirection === false));
+  assert.deepEqual(verifyAi4aiLineage(manifest, lineage), []);
+});
+
+test("executor identity is bound to the manifest's pinned evaluator", async () => {
+  // Run-time: an executor reporting a different identity is refused outright.
+  const impostor: Ai4aiExecutor = async () => ({
+    raw: { score: 0.42, algorithm_changed: true },
+    executorIdentity: hex("some-other-evaluator"),
+  });
+  await assert.rejects(
+    runAi4aiMutation(manifest, mutation("mut-x", 1), impostor, ai4aiRunRoot(manifest, newAi4aiRunNonce())),
+    /does not match the manifest's pinned evaluator/,
+  );
+
+  // Verification: a record claiming evaluator X while running Y is vetoed.
+  const lineage = await runAi4aiLineage(manifest, [mutation("mut-001", 3)], okExecutor);
+  const wrongManifest: Ai4aiTaskManifest = { ...manifest, evaluatorSha256: hex("declared-but-not-run") };
+  assert.ok(
+    verifyAi4aiLineage(wrongManifest, lineage).includes("ai4ai_evaluator_identity_mismatch"),
+  );
+
+  // The escape hatch must be explicitly declared, and is visible on the record.
+  const wrapped: Ai4aiExecutor = async () => ({
+    raw: { score: 0.2, algorithm_changed: true },
+    executorIdentity: hex("a-declared-wrapper"),
+    wrapperIndirection: true,
+  });
+  const wrappedLineage = await runAi4aiLineage(manifest, [mutation("mut-w", 2)], wrapped);
+  assert.equal(wrappedLineage.records[0]!.wrapperIndirection, true);
+  assert.deepEqual(verifyAi4aiLineage(manifest, wrappedLineage), []);
+});
+
+test("run nonce binds a chain to its run so it cannot replay as fresh", async () => {
+  const nonce = newAi4aiRunNonce();
+  const first = await runAi4aiLineage(manifest, [mutation("mut-001", 3)], okExecutor, nonce);
+  const replay = await runAi4aiLineage(manifest, [mutation("mut-001", 3)], okExecutor);
+  // Identical inputs, different runs: digests must differ.
+  assert.notEqual(first.records[0]!.digest, replay.records[0]!.digest);
+  // A chain presented under someone else's nonce does not verify.
+  assert.ok(
+    verifyAi4aiLineage(manifest, { runNonce: replay.runNonce, records: first.records })
+      .includes("ai4ai_lineage_broken_chain"),
+  );
+  assert.deepEqual(
+    verifyAi4aiLineage(manifest, { runNonce: "not-a-nonce", records: first.records }),
+    ["ai4ai_lineage_run_nonce_invalid"],
+  );
 });
 
 test("executor crash throws and is never scored", async () => {
-  const executor = commandAi4aiExecutor({
-    executorPath: fixture,
-    commandPrefixArgs: [process.execPath],
-  });
   await assert.rejects(
-    runAi4aiMutation(manifest, mutation("mut-bad", 1, "crash on purpose"), executor, ai4aiTaskIdentity(manifest)),
+    runAi4aiMutation(
+      manifest,
+      mutation("mut-bad", 1, "crash on purpose"),
+      fixtureExecutor,
+      ai4aiRunRoot(manifest, newAi4aiRunNonce()),
+    ),
     /crash is not a score/,
   );
 });
@@ -92,10 +151,10 @@ test("non-finite and out-of-range scores are refused at ingest", async () => {
   assert.throws(() => parseAi4aiEvaluatorOutput({ score: "0.2" }), /finite/);
   const nanExecutor: Ai4aiExecutor = async () => ({
     raw: { score: Number.NaN },
-    executorIdentity: hex("executor-nan"),
+    executorIdentity: evaluatorSha256,
   });
   await assert.rejects(
-    runAi4aiMutation(manifest, mutation("mut-nan", 2), nanExecutor, ai4aiTaskIdentity(manifest)),
+    runAi4aiMutation(manifest, mutation("mut-nan", 2), nanExecutor, ai4aiRunRoot(manifest, newAi4aiRunNonce())),
     /finite/,
   );
 });
@@ -110,25 +169,32 @@ test("classification is ingested only when reported, never fabricated", () => {
 });
 
 test("lineage verification detects tampering and the veto provider objects", async () => {
-  const records = await runAi4aiLineage(manifest, [mutation("mut-001", 3), mutation("mut-002", 7)], okExecutor);
-  const tampered = [
-    records[0]!,
-    { ...records[1]!, evaluation: { ...records[1]!.evaluation, score: 0.99 } },
-  ];
+  const lineage = await runAi4aiLineage(
+    manifest,
+    [mutation("mut-001", 3), mutation("mut-002", 7)],
+    okExecutor,
+  );
+  const tampered = {
+    runNonce: lineage.runNonce,
+    records: [
+      lineage.records[0]!,
+      {
+        ...lineage.records[1]!,
+        evaluation: { ...lineage.records[1]!.evaluation, score: 0.99 },
+      },
+    ],
+  };
   assert.deepEqual(verifyAi4aiLineage(manifest, tampered), ["ai4ai_lineage_digest_mismatch"]);
-  const broken = [records[1]!];
-  assert.ok(verifyAi4aiLineage(manifest, broken).includes("ai4ai_lineage_broken_chain"));
+  assert.ok(
+    verifyAi4aiLineage(manifest, { runNonce: lineage.runNonce, records: [lineage.records[1]!] })
+      .includes("ai4ai_lineage_broken_chain"),
+  );
 
-  const provider = ai4aiLineageVetoProvider(() => ({ manifest, records: tampered }));
-  assert.deepEqual(
-    await provider({ policy: {}, suite: { id: "s", items: [] }, observations: [] } as never),
-    ["ai4ai_lineage_digest_mismatch"],
-  );
-  const clean = ai4aiLineageVetoProvider(() => ({ manifest, records }));
-  assert.deepEqual(
-    await clean({ policy: {}, suite: { id: "s", items: [] }, observations: [] } as never),
-    [],
-  );
+  const context = { policy: {}, suite: { id: "s", items: [] }, observations: [] } as never;
+  const provider = ai4aiLineageVetoProvider(() => ({ manifest, lineage: tampered }));
+  assert.deepEqual(await provider(context), ["ai4ai_lineage_digest_mismatch"]);
+  const clean = ai4aiLineageVetoProvider(() => ({ manifest, lineage }));
+  assert.deepEqual(await clean(context), []);
 });
 
 test("paired decision refuses non-finite samples and otherwise defers to the bootstrap", () => {

--- a/crates/ruvector-sota-bench/harness/test/fixtures/fake-ai4ai-evaluator.mjs
+++ b/crates/ruvector-sota-bench/harness/test/fixtures/fake-ai4ai-evaluator.mjs
@@ -1,0 +1,23 @@
+// First-party fixture standing in for the AI4AI-Bench (arXiv:2608.20318)
+// evaluator. Reads --task/--mutation, writes an evaluation JSON to --output.
+// The mutation description steers behavior so tests can exercise the
+// adapter's fail-loud paths: "crash" exits non-zero, "tuning" reports a
+// tuning-only submission, anything else reports a genuine algorithm change
+// whose score grows with the seed (deterministic, bounded).
+import { readFile, writeFile } from "node:fs/promises";
+
+const flag = (name) => {
+  const index = process.argv.indexOf(name);
+  return process.argv[index + 1];
+};
+const mutation = JSON.parse(await readFile(flag("--mutation"), "utf8"));
+if (mutation.description.includes("crash")) {
+  process.stderr.write("fixture evaluator: deliberate crash\n");
+  process.exit(3);
+}
+const tuningOnly = mutation.description.includes("tuning");
+const score = Math.min(0.9, 0.1 + (mutation.seed % 10) * 0.02);
+await writeFile(
+  flag("--output"),
+  JSON.stringify({ score, algorithm_changed: !tuningOnly }),
+);


### PR DESCRIPTION
## Summary

First shippable slice of the Wave-4 AI4AI-Bench work package (PIR WP25, ADR-328 — Wave-4 ADR PR to follow; epic #837). AI4AI-Bench (arXiv:2608.20318, github.com/Einsia/AI4AI-Bench, Apache-2.0) freezes ten research repositories spanning ten learning-algorithm families and asks an agent to rewrite the learning algorithm itself — tuning and data collection do not count. This adapter lets MetaHarness run those tasks as an **external published benchmark** with reproducible mutation lineage.

### What's in the slice
- **`src/ai4aiBench.ts`** — frozen task identity (`Ai4aiTaskManifest` with mandatory lowercase SHA-256 over repo snapshot + evaluator; refused otherwise, mirroring `benchmark.ts` dataset-identity discipline), injected-executor seam, fail-loud score ingest, tamper-evident lineage chain, `verifyAi4aiLineage` + `ai4aiLineageVetoProvider` (composes conjunctively into `vetoes.ts`), and `ai4aiPairedDecision` (defers to `statistics.ts` `pairedBootstrapDecision`, re-refusing non-finite samples at the choke point).
- **`darwin-ai4ai` CLI subcommand** — validates manifest + mutations, runs a lineage against a pinned executor entrypoint with `benchmark.ts`-style isolation (scrubbed env, timeout, output cap, temp workspace); executor identity = SHA-256 of the entrypoint bytes.
- **Fixture evaluator + 7 tests** — manifest refusal, fixture end-to-end lineage chain, crash-throws-not-scores, NaN/out-of-range refusal, no fabricated genuine-vs-tuning classification, tamper detection + veto, paired-decision finiteness.

### Invariants held
- **Preprint-reproduction rule**: the paper's 0.250 best / 0.166 mean are targets for reporting, never acceptance bars — promotion routes only through our own paired-bootstrap + veto path.
- **Fail-loud metric integrity** (Wave-3 #888): crash ≠ score; non-finite ≠ score.
- **No caching**: every evaluator call is a real call — replaying a cached stochastic run would be evidence laundering.
- Closed policy lever set, `flywheel.ts` research-artifact refusal under injected adapters, and `PINNED_CAPABILITIES` all untouched. `scripts/frozen-weights-check.mjs` passes (35 files, 0 hits).

### Honest scope — what a real run still requires
The AI4AI-Bench (arXiv:2608.20318) evaluator runs frozen training pipelines in Docker on a B300-class GPU. Nothing here executes that: CI exercises the seam against a first-party fixture only. Beating the published 0.250 requires wiring `commandAi4aiExecutor` to the real evaluator on capable hardware and generating candidate mutations via the Darwin/dream-machine path — follow-up WP25 work.

## Test plan
- `npm run check` ✅  `npm test` ✅ (114 tests: 113 pass, 1 pre-existing skip)  `npm run doctor` ✅
- `cargo check -p ruvector-sota-bench --bin sota-all` ✅
- `node scripts/frozen-weights-check.mjs` ✅
- Manual `darwin-ai4ai` smoke run: 2-mutation lineage, chain digests verified

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_016QSCkKnxDjqU49NVVpWMK5