### PR TITLE
feat(agent-memory): CAMA-pattern correlation-aware memory arbitration (PIR WP27, ADR-330)

### DIFF
--- a/crates/ruvector-agent-memory/src/arbitration.rs
+++ b/crates/ruvector-agent-memory/src/arbitration.rs
@@ -7,13 +7,44 @@
 //!
 //! # Memory Correlation Bias
 //!
-//! N retrieved memories that all derive from one original source are **one
-//! observation repeated N times, not N independent observations**. A naive
-//! confidence vote (`sum of supporting memories`) lets twenty agents repeating
-//! one rumor outvote three genuinely independent witnesses. This module
-//! arbitrates a retrieved memory set by clustering it into **evidence
-//! lineages** using the causal provenance the ADR-320 layer already records,
-//! then scoring effective evidence per *lineage*, not per memory.
+//! N retrieved memories that all **declare** derivation from one original
+//! source are **one observation repeated N times, not N independent
+//! observations**. A naive confidence vote (`sum of supporting memories`) lets
+//! twenty agents relaying one rumor outvote three genuinely independent
+//! witnesses. This module arbitrates a retrieved memory set by clustering it
+//! into **evidence lineages** using the causal provenance the ADR-320 layer
+//! already records, then scoring effective evidence per *lineage*, not per
+//! memory.
+//!
+//! # Known limitation: declared derivation only (READ BEFORE USE)
+//!
+//! **Correlation is detected from declared `causal_parents`, never from
+//! content.** A memory that copies another memory's *content* while declaring
+//! no parent is, to this module, a fresh root — it mints an independent
+//! lineage. Twenty agents that each re-assert one rumor's content without
+//! citing it therefore arbitrate to twenty lineages with **zero downgrade**
+//! against the naive vote, and a sufficiency check at any threshold ≤ 20
+//! returns [`ArbitrationOutcome::Sufficient`].
+//!
+//! The shipped scope deliberately **under-detects** correlation rather than
+//! pretending otherwise (ADR-330, Negative consequences). The consequences
+//! for an integrator:
+//!
+//! - [`ArbitrationConfig::sufficiency_threshold`] and
+//!   [`ArbitrationOutcome::InsufficientIndependentEvidence`] are **not a trust
+//!   gate against repeated-claim or sybil attacks**. They answer "how many
+//!   *declared-independent* lineages support this?", which is a corroboration
+//!   signal under cooperative provenance, not an adversarial one.
+//!   Wiring them as an anti-astroturfing control is materially wrong.
+//! - The guarantee holds only as far as provenance discipline holds upstream.
+//!   Deployments that need adversarial robustness must pair this with content-
+//!   level near-duplicate detection or authenticated citation at ingest, so
+//!   that copied content cannot enter as a parentless observation.
+//!
+//! The bench in `agent-memory-bench` (900 derived memories collapsing to 100
+//! origin lineages) exercises **declared-parent chains — the mechanism's best
+//! case** — and is a demonstration of the clustering math, not evidence of
+//! adversarial robustness.
 //!
 //! # The lineage-sharing rule (precise definition)
 //!
@@ -52,6 +83,17 @@
 //! Arbitration operates on one tenant-bound [`CausalEpisodicGraph`]; a node id
 //! from another tenant's graph is simply unknown here and is a hard error.
 //! Cross-tenant lineage clustering is impossible by construction.
+//!
+//! # Input sizing (caller's responsibility)
+//!
+//! [`arbitrate`] bounds neither the memory-set size nor total ancestry-
+//! traversal work: cost scales with the retrieved set and the size of its
+//! ancestry closure. Traversal is iterative and heap-bounded (no stack
+//! overflow on deep chains — a 10 000-deep chain measures ~35 ms, a
+//! 1 000-root/2 000-derived merge ~27 ms, union-find memory O(distinct
+//! roots)), so this is a throughput consideration, not a crash risk. A service
+//! that arbitrates per retrieval should still impose its own cap on the number
+//! of memories admitted to one call.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -196,6 +238,13 @@ pub enum ArbitrationError {
     /// The downgrade-only invariant was violated — a bug, surfaced loudly
     /// rather than clamped silently.
     DowngradeInvariantViolated { naive: f64, arbitrated: f64 },
+    /// A memory resolved to no provenance root, or to a root with no lineage
+    /// component. Unreachable while the ADR-320 layer's guarantees hold;
+    /// refused rather than panicked so a future change degrades safely.
+    ProvenanceRootMissing(NodeRef),
+    /// Ancestry traversal exceeded its cycle/size guard — the `causal_parents`
+    /// relation is not the DAG the fusion layer guarantees.
+    AncestryNotAcyclic(ObservationId),
     /// Provenance resolution failed inside the graph.
     Graph(FusionError),
 }
@@ -215,6 +264,14 @@ impl std::fmt::Display for ArbitrationError {
             ArbitrationError::DowngradeInvariantViolated { naive, arbitrated } => write!(
                 f,
                 "downgrade-only invariant violated: arbitrated {arbitrated} > naive {naive}"
+            ),
+            ArbitrationError::ProvenanceRootMissing(node) => {
+                write!(f, "memory {node:?} resolved to no provenance root")
+            }
+            ArbitrationError::AncestryNotAcyclic(id) => write!(
+                f,
+                "ancestry traversal from {} exceeded its acyclicity guard",
+                id.to_hex()
             ),
             ArbitrationError::Graph(e) => write!(f, "provenance resolution failed: {e}"),
         }
@@ -264,8 +321,14 @@ pub fn arbitrate(
             return Err(ArbitrationError::ConfidenceInvalid(*node));
         }
 
-        // Weakest-link reliability and freshness over the node's atomic set;
-        // per-atomic confidences also pass the choke point here.
+        // Weakest-link reliability and freshness over the node's atomic set.
+        // The per-atomic confidence check below is NOT redundant with the
+        // node-level check above: for a `NodeRef::Cluster` the node-level value
+        // is `FusedCluster::confidence`, a *folded* number. `fuse()` now
+        // rejects non-finite members at the source, but `confidence` is a
+        // public field on a public struct, so a cluster carrying a laundered
+        // NaN can still be constructed or mutated outside that constructor.
+        // This loop is the last check between such a value and the score.
         let mut reliability = 1.0f64;
         let mut freshness = 1.0f64;
         let mut roots: BTreeSet<ObservationId> = BTreeSet::new();
@@ -333,9 +396,19 @@ pub fn arbitrate(
     let mut naive = 0.0f64;
     for f in &facts {
         naive += f.confidence;
-        // Any root works: the memory's whole root set is one component.
-        let comp = uf.find(root_index[f.roots.iter().next().expect("non-empty root set")]);
-        let lineage = by_component.get_mut(&comp).expect("component exists");
+        // Any root works: the memory's whole root set is one component. An
+        // empty root set is unreachable (every resolved atomic contributes at
+        // least itself), but this returns an error rather than panicking so a
+        // future change to the provenance layer degrades to a refusal.
+        let first_root = f
+            .roots
+            .iter()
+            .next()
+            .ok_or(ArbitrationError::ProvenanceRootMissing(f.node))?;
+        let comp = uf.find(root_index[first_root]);
+        let lineage = by_component
+            .get_mut(&comp)
+            .ok_or(ArbitrationError::ProvenanceRootMissing(f.node))?;
         lineage.members.push(f.node);
         lineage.weight = lineage.weight.max(f.weight);
     }
@@ -348,7 +421,10 @@ pub fn arbitrate(
         l.members.sort_unstable();
         l.members.dedup();
     }
-    lineages.sort_by_key(|l| l.roots[0]);
+    // Deterministic order by minimal root. Every retained lineage has at least
+    // one root by construction; `first()` keeps that from being a panic if the
+    // construction above ever changes.
+    lineages.sort_by_key(|l| l.roots.first().copied());
 
     let arbitrated: f64 = lineages.iter().map(|l| l.weight).sum();
 
@@ -410,15 +486,23 @@ fn node_confidence(
     }
 }
 
-/// Memoized, iterative root-set computation over `causal_parents` (the graph
-/// guarantees parents pre-exist and are acyclic; iteration keeps deep chains
-/// off the call stack, same posture as `resolve_provenance`).
+/// Memoized, iterative root-set computation over `causal_parents`. Iteration
+/// keeps deep chains off the call stack, same posture as `resolve_provenance`.
+///
+/// The fusion layer guarantees the parent relation is a DAG (parents must
+/// pre-exist at ingest, and content addressing makes a cycle cryptographically
+/// infeasible to mint), and `resolve_provenance` nonetheless carries its own
+/// `visited` guard — this walk matches that posture rather than resting on the
+/// invariant: a node whose parents are *still* unresolved after it has already
+/// been expanded once can only mean a cycle, and is refused as
+/// [`ArbitrationError::AncestryNotAcyclic`] instead of spinning forever.
 fn root_set(
     graph: &CausalEpisodicGraph,
     id: ObservationId,
     memo: &mut BTreeMap<ObservationId, BTreeSet<ObservationId>>,
 ) -> Result<BTreeSet<ObservationId>, ArbitrationError> {
     let mut stack = vec![id];
+    let mut expanded: BTreeSet<ObservationId> = BTreeSet::new();
     while let Some(top) = stack.last().copied() {
         if memo.contains_key(&top) {
             stack.pop();
@@ -441,15 +525,24 @@ fn root_set(
         if unresolved.is_empty() {
             let mut roots = BTreeSet::new();
             for p in &obs.causal_parents {
-                roots.extend(memo[p].iter().copied());
+                let parent_roots = memo
+                    .get(p)
+                    .ok_or(ArbitrationError::UnknownObservation(*p))?;
+                roots.extend(parent_roots.iter().copied());
             }
             memo.insert(top, roots);
             stack.pop();
+        } else if !expanded.insert(top) {
+            // Second visit with parents still unresolved ⇒ the walk is going in
+            // a circle: this node is (transitively) its own ancestor.
+            return Err(ArbitrationError::AncestryNotAcyclic(top));
         } else {
             stack.extend(unresolved);
         }
     }
-    Ok(memo[&id].clone())
+    memo.get(&id)
+        .cloned()
+        .ok_or(ArbitrationError::UnknownObservation(id))
 }
 
 /// Minimal union-find with path compression + union by size.

--- a/crates/ruvector-agent-memory/src/arbitration.rs
+++ b/crates/ruvector-agent-memory/src/arbitration.rs
@@ -1,0 +1,494 @@
+//! Correlation-aware memory arbitration (ADR-330, PIR WP27), informed by
+//! **CAMA — "Beyond Memory Majority: Latent-Source Reasoning for Multi-Agent
+//! Memory Arbitration" (arXiv:2608.19701)**. No upstream code exists and the
+//! paper's abstract reports no quantitative results, so this is a first-party
+//! build of the described *mechanism* with this program's own acceptance bar,
+//! not a port and not a number-chase.
+//!
+//! # Memory Correlation Bias
+//!
+//! N retrieved memories that all derive from one original source are **one
+//! observation repeated N times, not N independent observations**. A naive
+//! confidence vote (`sum of supporting memories`) lets twenty agents repeating
+//! one rumor outvote three genuinely independent witnesses. This module
+//! arbitrates a retrieved memory set by clustering it into **evidence
+//! lineages** using the causal provenance the ADR-320 layer already records,
+//! then scoring effective evidence per *lineage*, not per memory.
+//!
+//! # The lineage-sharing rule (precise definition)
+//!
+//! Every memory node resolves to its atomic observations
+//! ([`CausalEpisodicGraph::resolve_provenance`]); every atomic observation has
+//! a **root set**: the parentless ancestors reachable through
+//! `causal_parents` (a parentless observation is its own root). Two memories
+//! belong to the same lineage **iff** their root sets are connected — i.e.
+//! lineages are the connected components of the bipartite memory↔root graph.
+//! A memory whose ancestry bridges two roots merges those roots into one
+//! lineage (conservative: shared ancestry anywhere collapses independence).
+//!
+//! # Downgrade-only effective evidence (binding invariant)
+//!
+//! `arbitrated_confidence = Σ_lineages max_member(confidence × reliability ×
+//! freshness)` with every factor in `[0, 1]`. Because each lineage contributes
+//! at most its single strongest member, and the naive score is the sum of raw
+//! confidences over *all* members, the arbitrated score can only be **less
+//! than or equal to** the naive score — correlation adjustment can never
+//! manufacture evidence (Wave-3 lesson: metric-integrity gates must be
+//! downgrade-only + fail-loud). The invariant is re-checked at runtime and a
+//! violation is a hard error, never a silent clamp.
+//!
+//! # Non-finite choke point
+//!
+//! Every confidence and reliability is checked finite-in-`[0,1]` **before**
+//! any comparison or aggregation (the Wave-3 #888 lesson: every `<` against
+//! NaN is false, so a single NaN silently defeats comparison-based gates).
+//! [`AtomicObservation::new_signed`] already rejects non-finite confidence,
+//! but the field is public and a signature over a NaN bit-pattern *does*
+//! verify — so ingest alone is not a sufficient guard, and this module
+//! re-checks at its own boundary.
+//!
+//! # Tenant isolation
+//!
+//! Arbitration operates on one tenant-bound [`CausalEpisodicGraph`]; a node id
+//! from another tenant's graph is simply unknown here and is a hard error.
+//! Cross-tenant lineage clustering is impossible by construction.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::fusion::{CausalEpisodicGraph, ClusterId, FusionError, NodeRef};
+use crate::observation::ObservationId;
+
+/// Per-source-kind reliability model, keyed by [`SourceKind::code`]
+/// (`crate::observation::SourceKind`). All values must be finite in `[0, 1]`;
+/// [`arbitrate`] validates this before use.
+#[derive(Debug, Clone)]
+pub struct ReliabilityModel {
+    /// Reliability applied to any source kind without an explicit override.
+    pub default: f64,
+    /// Overrides keyed by `SourceKind::code()`.
+    pub overrides: BTreeMap<u16, f64>,
+}
+
+impl Default for ReliabilityModel {
+    /// Conservative default: every source kind at `0.9` — reliability shades
+    /// the score, the lineage structure does the heavy lifting.
+    fn default() -> Self {
+        ReliabilityModel {
+            default: 0.9,
+            overrides: BTreeMap::new(),
+        }
+    }
+}
+
+impl ReliabilityModel {
+    fn for_code(&self, code: u16) -> f64 {
+        *self.overrides.get(&code).unwrap_or(&self.default)
+    }
+
+    fn validate(&self) -> Result<(), ArbitrationError> {
+        let ok = |v: f64| v.is_finite() && (0.0..=1.0).contains(&v);
+        if !ok(self.default) {
+            return Err(ArbitrationError::InvalidConfig(
+                "reliability default must be finite in [0, 1]",
+            ));
+        }
+        if !self.overrides.values().all(|v| ok(*v)) {
+            return Err(ArbitrationError::InvalidConfig(
+                "every reliability override must be finite in [0, 1]",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Configuration for one arbitration pass.
+#[derive(Debug, Clone)]
+pub struct ArbitrationConfig {
+    /// "Now" in nanoseconds, same clock as `AtomicObservation::time_ns`.
+    /// Observation timestamps in the future clamp to age zero (freshness 1.0).
+    pub now_ns: u64,
+    /// Exponential freshness half-life: `freshness = 0.5^(age_ns / half_life_ns)`.
+    /// Must be non-zero.
+    pub half_life_ns: u64,
+    /// Minimum number of independent lineages for the evidence to count as
+    /// sufficient; below it the outcome is
+    /// [`ArbitrationOutcome::InsufficientIndependentEvidence`] — the CAMA
+    /// active-search hook, telling the caller to go find evidence *outside*
+    /// the over-represented lineages rather than silently passing.
+    pub sufficiency_threshold: usize,
+    /// Per-source-kind reliability.
+    pub reliability: ReliabilityModel,
+}
+
+/// One independent evidence lineage: the memories that share causal ancestry,
+/// the provenance roots that bind them, and the lineage's effective weight
+/// (its single strongest member's `confidence × reliability × freshness`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct EvidenceLineage {
+    /// Parentless ancestor observations this lineage traces to (sorted).
+    pub roots: Vec<ObservationId>,
+    /// The arbitrated memory nodes in this lineage (sorted, de-duplicated).
+    pub members: Vec<NodeRef>,
+    /// Effective weight in `[0, 1]`: max over members of the member's
+    /// `confidence × min_atomic(reliability) × min_atomic(freshness)`.
+    pub weight: f64,
+}
+
+/// The full arbitration result.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ArbitrationVerdict {
+    /// Lineages, sorted by their minimal root id (deterministic).
+    pub lineages: Vec<EvidenceLineage>,
+    /// What a correlation-blind vote would score: Σ raw member confidences.
+    pub naive_confidence: f64,
+    /// Σ lineage weights. Guaranteed ≤ `naive_confidence` (downgrade-only).
+    pub arbitrated_confidence: f64,
+}
+
+impl ArbitrationVerdict {
+    /// Number of independent evidence lineages.
+    pub fn independent_lineages(&self) -> usize {
+        self.lineages.len()
+    }
+}
+
+/// Outcome of an arbitration pass.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ArbitrationOutcome {
+    /// At least `sufficiency_threshold` independent lineages support the claim.
+    Sufficient(ArbitrationVerdict),
+    /// Fewer independent lineages than required. Carries the roots of every
+    /// lineage holding more than one member — the over-represented origins the
+    /// caller's evidence search should look *away from* (CAMA's active
+    /// independent-evidence recovery step).
+    InsufficientIndependentEvidence {
+        verdict: ArbitrationVerdict,
+        required: usize,
+        over_represented_roots: Vec<ObservationId>,
+    },
+}
+
+impl ArbitrationOutcome {
+    /// The verdict regardless of sufficiency.
+    pub fn verdict(&self) -> &ArbitrationVerdict {
+        match self {
+            ArbitrationOutcome::Sufficient(v) => v,
+            ArbitrationOutcome::InsufficientIndependentEvidence { verdict, .. } => verdict,
+        }
+    }
+}
+
+/// Errors from [`arbitrate`]. Every error is a hard refusal — this module
+/// never degrades to a partial or naive score.
+#[derive(Debug)]
+pub enum ArbitrationError {
+    /// No memories were supplied.
+    EmptyMemorySet,
+    /// A supplied node id is not in this graph (wrong tenant or never
+    /// ingested).
+    UnknownObservation(ObservationId),
+    /// A supplied cluster id is not in this graph.
+    UnknownCluster(ClusterId),
+    /// A confidence reached the choke point non-finite or outside `[0, 1]`.
+    ConfidenceInvalid(NodeRef),
+    /// Configuration failed validation.
+    InvalidConfig(&'static str),
+    /// The downgrade-only invariant was violated — a bug, surfaced loudly
+    /// rather than clamped silently.
+    DowngradeInvariantViolated { naive: f64, arbitrated: f64 },
+    /// Provenance resolution failed inside the graph.
+    Graph(FusionError),
+}
+
+impl std::fmt::Display for ArbitrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ArbitrationError::EmptyMemorySet => write!(f, "cannot arbitrate an empty memory set"),
+            ArbitrationError::UnknownObservation(id) => {
+                write!(f, "unknown observation {}", id.to_hex())
+            }
+            ArbitrationError::UnknownCluster(id) => write!(f, "unknown cluster {}", id.0),
+            ArbitrationError::ConfidenceInvalid(node) => {
+                write!(f, "non-finite or out-of-range confidence at {node:?}")
+            }
+            ArbitrationError::InvalidConfig(msg) => write!(f, "invalid arbitration config: {msg}"),
+            ArbitrationError::DowngradeInvariantViolated { naive, arbitrated } => write!(
+                f,
+                "downgrade-only invariant violated: arbitrated {arbitrated} > naive {naive}"
+            ),
+            ArbitrationError::Graph(e) => write!(f, "provenance resolution failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ArbitrationError {}
+
+/// Arbitrate a retrieved memory set against its causal provenance.
+///
+/// Duplicate node refs in `memories` are de-duplicated first (the same memory
+/// listed twice is still one memory). See the module docs for the lineage
+/// rule, the downgrade-only invariant, and the non-finite choke point.
+pub fn arbitrate(
+    graph: &CausalEpisodicGraph,
+    memories: &[NodeRef],
+    config: &ArbitrationConfig,
+) -> Result<ArbitrationOutcome, ArbitrationError> {
+    // ── Config choke point ──────────────────────────────────────────────────
+    if config.half_life_ns == 0 {
+        return Err(ArbitrationError::InvalidConfig("half_life_ns must be non-zero"));
+    }
+    config.reliability.validate()?;
+
+    let mut nodes: Vec<NodeRef> = memories.to_vec();
+    nodes.sort_unstable();
+    nodes.dedup();
+    if nodes.is_empty() {
+        return Err(ArbitrationError::EmptyMemorySet);
+    }
+
+    // ── Per-memory provenance + weight (choke point on every confidence) ────
+    let mut root_memo: BTreeMap<ObservationId, BTreeSet<ObservationId>> = BTreeMap::new();
+    struct MemoryFacts {
+        node: NodeRef,
+        roots: BTreeSet<ObservationId>,
+        confidence: f64,
+        weight: f64,
+    }
+    let mut facts: Vec<MemoryFacts> = Vec::with_capacity(nodes.len());
+
+    for node in &nodes {
+        let atomics = graph.resolve_provenance(*node).map_err(map_fusion)?;
+
+        let confidence = node_confidence(graph, *node)?;
+        if !confidence.is_finite() || !(0.0..=1.0).contains(&confidence) {
+            return Err(ArbitrationError::ConfidenceInvalid(*node));
+        }
+
+        // Weakest-link reliability and freshness over the node's atomic set;
+        // per-atomic confidences also pass the choke point here.
+        let mut reliability = 1.0f64;
+        let mut freshness = 1.0f64;
+        let mut roots: BTreeSet<ObservationId> = BTreeSet::new();
+        for atomic in &atomics {
+            let obs = graph
+                .observation(*atomic)
+                .ok_or(ArbitrationError::UnknownObservation(*atomic))?;
+            let c = obs.confidence as f64;
+            if !c.is_finite() || !(0.0..=1.0).contains(&c) {
+                return Err(ArbitrationError::ConfidenceInvalid(NodeRef::Observation(*atomic)));
+            }
+            reliability = reliability.min(config.reliability.for_code(obs.source.kind.code()));
+            freshness = freshness.min(freshness_of(obs.time_ns, config));
+            roots.extend(root_set(graph, *atomic, &mut root_memo)?);
+        }
+
+        // Defense in depth: the factors above are each finite in [0, 1] by
+        // construction, so the product must be too — refuse loudly if not.
+        let weight = confidence * reliability * freshness;
+        if !weight.is_finite() {
+            return Err(ArbitrationError::ConfidenceInvalid(*node));
+        }
+        facts.push(MemoryFacts {
+            node: *node,
+            roots,
+            confidence,
+            weight,
+        });
+    }
+
+    // ── Union-find over roots: connected components = lineages ──────────────
+    let all_roots: Vec<ObservationId> = facts
+        .iter()
+        .flat_map(|f| f.roots.iter().copied())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let root_index: BTreeMap<ObservationId, usize> =
+        all_roots.iter().enumerate().map(|(i, r)| (*r, i)).collect();
+    let mut uf = UnionFind::new(all_roots.len());
+    for f in &facts {
+        let mut iter = f.roots.iter();
+        if let Some(first) = iter.next() {
+            let a = root_index[first];
+            for other in iter {
+                uf.union(a, root_index[other]);
+            }
+        }
+    }
+
+    // ── Assemble lineages ───────────────────────────────────────────────────
+    let mut by_component: BTreeMap<usize, EvidenceLineage> = BTreeMap::new();
+    for (root, idx) in &root_index {
+        let comp = uf.find(*idx);
+        by_component
+            .entry(comp)
+            .or_insert_with(|| EvidenceLineage {
+                roots: Vec::new(),
+                members: Vec::new(),
+                weight: 0.0,
+            })
+            .roots
+            .push(*root);
+    }
+    let mut naive = 0.0f64;
+    for f in &facts {
+        naive += f.confidence;
+        // Any root works: the memory's whole root set is one component.
+        let comp = uf.find(root_index[f.roots.iter().next().expect("non-empty root set")]);
+        let lineage = by_component.get_mut(&comp).expect("component exists");
+        lineage.members.push(f.node);
+        lineage.weight = lineage.weight.max(f.weight);
+    }
+    let mut lineages: Vec<EvidenceLineage> = by_component
+        .into_values()
+        .filter(|l| !l.members.is_empty()) // roots only reachable via members, so always true
+        .collect();
+    for l in &mut lineages {
+        l.roots.sort_unstable();
+        l.members.sort_unstable();
+        l.members.dedup();
+    }
+    lineages.sort_by_key(|l| l.roots[0]);
+
+    let arbitrated: f64 = lineages.iter().map(|l| l.weight).sum();
+
+    // ── Fail-loud downgrade-only invariant ──────────────────────────────────
+    // Deliberately the negated form: `arbitrated > bound` is false for NaN and
+    // would let a (theoretically unreachable) non-finite sum pass silently;
+    // `!(arbitrated <= bound)` sends NaN into the error path instead.
+    #[allow(clippy::neg_cmp_op_on_partial_ord)]
+    if !(arbitrated <= naive + 1e-9) {
+        return Err(ArbitrationError::DowngradeInvariantViolated {
+            naive,
+            arbitrated,
+        });
+    }
+
+    let verdict = ArbitrationVerdict {
+        naive_confidence: naive,
+        arbitrated_confidence: arbitrated,
+        lineages,
+    };
+
+    if verdict.independent_lineages() >= config.sufficiency_threshold {
+        Ok(ArbitrationOutcome::Sufficient(verdict))
+    } else {
+        let over_represented_roots: Vec<ObservationId> = verdict
+            .lineages
+            .iter()
+            .filter(|l| l.members.len() > 1)
+            .flat_map(|l| l.roots.iter().copied())
+            .collect();
+        let required = config.sufficiency_threshold;
+        Ok(ArbitrationOutcome::InsufficientIndependentEvidence {
+            verdict,
+            required,
+            over_represented_roots,
+        })
+    }
+}
+
+/// `0.5^(age / half_life)` in `f64`; future timestamps clamp to age zero.
+fn freshness_of(time_ns: u64, config: &ArbitrationConfig) -> f64 {
+    let age = config.now_ns.saturating_sub(time_ns) as f64;
+    (0.5f64).powf(age / config.half_life_ns as f64)
+}
+
+fn node_confidence(
+    graph: &CausalEpisodicGraph,
+    node: NodeRef,
+) -> Result<f64, ArbitrationError> {
+    match node {
+        NodeRef::Observation(id) => graph
+            .observation(id)
+            .map(|o| o.confidence as f64)
+            .ok_or(ArbitrationError::UnknownObservation(id)),
+        NodeRef::Cluster(id) => graph
+            .cluster(id)
+            .map(|c| c.confidence as f64)
+            .ok_or(ArbitrationError::UnknownCluster(id)),
+    }
+}
+
+/// Memoized, iterative root-set computation over `causal_parents` (the graph
+/// guarantees parents pre-exist and are acyclic; iteration keeps deep chains
+/// off the call stack, same posture as `resolve_provenance`).
+fn root_set(
+    graph: &CausalEpisodicGraph,
+    id: ObservationId,
+    memo: &mut BTreeMap<ObservationId, BTreeSet<ObservationId>>,
+) -> Result<BTreeSet<ObservationId>, ArbitrationError> {
+    let mut stack = vec![id];
+    while let Some(top) = stack.last().copied() {
+        if memo.contains_key(&top) {
+            stack.pop();
+            continue;
+        }
+        let obs = graph
+            .observation(top)
+            .ok_or(ArbitrationError::UnknownObservation(top))?;
+        if obs.causal_parents.is_empty() {
+            memo.insert(top, BTreeSet::from([top]));
+            stack.pop();
+            continue;
+        }
+        let unresolved: Vec<ObservationId> = obs
+            .causal_parents
+            .iter()
+            .filter(|p| !memo.contains_key(*p))
+            .copied()
+            .collect();
+        if unresolved.is_empty() {
+            let mut roots = BTreeSet::new();
+            for p in &obs.causal_parents {
+                roots.extend(memo[p].iter().copied());
+            }
+            memo.insert(top, roots);
+            stack.pop();
+        } else {
+            stack.extend(unresolved);
+        }
+    }
+    Ok(memo[&id].clone())
+}
+
+/// Minimal union-find with path compression + union by size.
+struct UnionFind {
+    parent: Vec<usize>,
+    size: Vec<usize>,
+}
+
+impl UnionFind {
+    fn new(n: usize) -> Self {
+        UnionFind {
+            parent: (0..n).collect(),
+            size: vec![1; n],
+        }
+    }
+    fn find(&mut self, mut x: usize) -> usize {
+        while self.parent[x] != x {
+            self.parent[x] = self.parent[self.parent[x]];
+            x = self.parent[x];
+        }
+        x
+    }
+    fn union(&mut self, a: usize, b: usize) {
+        let (mut ra, mut rb) = (self.find(a), self.find(b));
+        if ra == rb {
+            return;
+        }
+        if self.size[ra] < self.size[rb] {
+            std::mem::swap(&mut ra, &mut rb);
+        }
+        self.parent[rb] = ra;
+        self.size[ra] += self.size[rb];
+    }
+}
+
+fn map_fusion(e: FusionError) -> ArbitrationError {
+    match e {
+        FusionError::UnknownObservation(id) => ArbitrationError::UnknownObservation(id),
+        FusionError::UnknownCluster(id) => ArbitrationError::UnknownCluster(id),
+        other => ArbitrationError::Graph(other),
+    }
+}

--- a/crates/ruvector-agent-memory/src/arbitration.rs
+++ b/crates/ruvector-agent-memory/src/arbitration.rs
@@ -22,9 +22,21 @@
 //! content.** A memory that copies another memory's *content* while declaring
 //! no parent is, to this module, a fresh root — it mints an independent
 //! lineage. Twenty agents that each re-assert one rumor's content without
-//! citing it therefore arbitrate to twenty lineages with **zero downgrade**
-//! against the naive vote, and a sufficiency check at any threshold ≤ 20
-//! returns [`ArbitrationOutcome::Sufficient`].
+//! citing it therefore arbitrate to twenty lineages with **no *correlation*
+//! downgrade** against the naive vote, and a sufficiency check at any
+//! threshold ≤ 20 returns [`ArbitrationOutcome::Sufficient`].
+//!
+//! **Do not read a smaller arbitrated score as correlation having been
+//! caught.** Any reduction observed with a reliability or freshness factor
+//! below `1.0` comes from *those multipliers*, which carry no correlation
+//! information whatsoever. Concretely, under the shipped
+//! [`ReliabilityModel::default`] (`0.9`) that same twenty-agent astroturfed
+//! set scores naive `18.0` vs arbitrated `16.2` — a ~10% reduction that is
+//! entirely the reliability multiplier and reflects *zero* detected
+//! correlation. **The diagnostic to watch is the lineage count, not the score
+//! delta**: [`ArbitrationVerdict::independent_lineages`] equalling the number
+//! of arbitrated memories means nothing was clustered, whatever the score
+//! says.
 //!
 //! The shipped scope deliberately **under-detects** correlation rather than
 //! pretending otherwise (ADR-330, Negative consequences). The consequences
@@ -368,13 +380,23 @@ pub fn arbitrate(
         .collect();
     let root_index: BTreeMap<ObservationId, usize> =
         all_roots.iter().enumerate().map(|(i, r)| (*r, i)).collect();
+    // `root_index` is built from exactly these root sets a few lines above, so
+    // every lookup below is present by construction; they still resolve
+    // through `ok_or` so this module has no panic sites at all.
+    let index_of = |root: &ObservationId, node: NodeRef| {
+        root_index
+            .get(root)
+            .copied()
+            .ok_or(ArbitrationError::ProvenanceRootMissing(node))
+    };
     let mut uf = UnionFind::new(all_roots.len());
     for f in &facts {
         let mut iter = f.roots.iter();
         if let Some(first) = iter.next() {
-            let a = root_index[first];
+            let a = index_of(first, f.node)?;
             for other in iter {
-                uf.union(a, root_index[other]);
+                let b = index_of(other, f.node)?;
+                uf.union(a, b);
             }
         }
     }
@@ -405,7 +427,7 @@ pub fn arbitrate(
             .iter()
             .next()
             .ok_or(ArbitrationError::ProvenanceRootMissing(f.node))?;
-        let comp = uf.find(root_index[first_root]);
+        let comp = uf.find(index_of(first_root, f.node)?);
         let lineage = by_component
             .get_mut(&comp)
             .ok_or(ArbitrationError::ProvenanceRootMissing(f.node))?;

--- a/crates/ruvector-agent-memory/src/fusion.rs
+++ b/crates/ruvector-agent-memory/src/fusion.rs
@@ -93,6 +93,10 @@ pub enum FusionError {
     UnknownCluster(ClusterId),
     /// A fusion was requested with no members.
     EmptyCluster,
+    /// A fusion member's confidence was not finite in `[0, 1]`, so the
+    /// weakest-link fold would have produced a value outside this layer's
+    /// documented contract (or silently dropped a NaN).
+    MemberConfidenceInvalid(NodeRef),
     /// A governed ingest referenced a parent that has no ledger entry (it was
     /// not itself admitted through the ledger).
     ParentNotGoverned(ObservationId),
@@ -132,6 +136,10 @@ impl std::fmt::Display for FusionError {
             }
             FusionError::UnknownCluster(id) => write!(f, "unknown cluster {}", id.0),
             FusionError::EmptyCluster => write!(f, "cannot fuse an empty member set"),
+            FusionError::MemberConfidenceInvalid(node) => write!(
+                f,
+                "fusion member {node:?} has non-finite or out-of-range confidence"
+            ),
             FusionError::ParentNotGoverned(id) => write!(
                 f,
                 "governed ingest parent {} has no ledger entry",
@@ -228,8 +236,18 @@ impl CausalEpisodicGraph {
 
     /// Fuse `members` (event-layer observations and/or sub-clusters, all of
     /// this graph's tenant) into a new cluster-layer node. Confidence is the
-    /// weakest-link minimum over members. Rejects an empty set or any member
-    /// not present in the graph.
+    /// weakest-link minimum over members. Rejects an empty set, any member not
+    /// present in the graph, and any member whose confidence is not finite in
+    /// `[0, 1]`.
+    ///
+    /// The finiteness check is load-bearing, not decorative: `f32::min` returns
+    /// the *non-NaN* operand per IEEE 754, so folding with an `INFINITY` seed
+    /// would give a single-NaN-member cluster `confidence = +inf` (violating
+    /// this type's documented `[0, 1]` contract) and would let a NaN member of
+    /// `[NaN, 0.9]` vanish without trace into a `0.9` cluster. Because
+    /// [`AtomicObservation::new_signed`]'s range check can be bypassed — the
+    /// field is public and a signature over a NaN bit-pattern verifies — the
+    /// rejection has to happen here, before the fold.
     pub fn fuse(
         &mut self,
         members: &[NodeRef],
@@ -238,9 +256,15 @@ impl CausalEpisodicGraph {
         if members.is_empty() {
             return Err(FusionError::EmptyCluster);
         }
-        let mut confidence = f32::INFINITY;
+        let mut confidence = 1.0f32;
         for member in members {
-            confidence = confidence.min(self.node_confidence(*member)?);
+            let c = self.node_confidence(*member)?;
+            if !c.is_finite() || !(0.0..=1.0).contains(&c) {
+                return Err(FusionError::MemberConfidenceInvalid(*member));
+            }
+            if c < confidence {
+                confidence = c;
+            }
         }
         let id = ClusterId(self.next_cluster);
         self.next_cluster += 1;

--- a/crates/ruvector-agent-memory/src/fusion.rs
+++ b/crates/ruvector-agent-memory/src/fusion.rs
@@ -72,7 +72,12 @@ pub struct FusedCluster {
 }
 
 /// Errors from fusion-graph operations.
+///
+/// `#[non_exhaustive]`: new gates get new variants (this enum gained
+/// `MemberConfidenceInvalid` in ADR-330), so external consumers must carry a
+/// wildcard arm rather than have a future gate break their build.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum FusionError {
     /// The observation's signature did not verify (per-observation gate).
     SignatureInvalid(ObservationId),

--- a/crates/ruvector-agent-memory/src/lib.rs
+++ b/crates/ruvector-agent-memory/src/lib.rs
@@ -33,12 +33,20 @@
 //! SHA-256/Ed25519 for content addressing and per-observation signatures — no
 //! new hash or signature scheme is introduced.
 //!
+//! The `arbitration` module adds correlation-aware memory arbitration
+//! (ADR-330, PIR WP27), informed by CAMA (arXiv:2608.19701): retrieved
+//! memories are clustered into independent evidence lineages by causal
+//! ancestry, and effective confidence is scored per lineage
+//! (downgrade-only relative to a naive per-memory vote), so N memories
+//! repeating one origin count as one observation, not N.
+//!
 //! - Park et al. 2023, "Generative Agents" (arXiv:2304.03442)
 //! - Zhong et al. 2023, "MemoryBank" (arXiv:2305.10250)
 //! - Xu 2026, "Self-Aware Vector Embeddings for RAG" (arXiv:2604.20598)
 //! - Karhade 2026, "Not All Memories Age the Same" (arXiv:2604.26970)
 //! - Survey 2026, "From Storage to Experience" (arXiv:2605.06716)
 
+pub mod arbitration;
 pub mod compaction;
 pub mod diagnostic;
 pub mod fusion;
@@ -48,6 +56,10 @@ pub mod observation;
 pub mod ops;
 pub mod scoring;
 
+pub use arbitration::{
+    arbitrate, ArbitrationConfig, ArbitrationError, ArbitrationOutcome, ArbitrationVerdict,
+    EvidenceLineage, ReliabilityModel,
+};
 pub use compaction::{CoherencePolicy, CoherenceWeights, CompactionPolicy, LfuPolicy, LruPolicy};
 pub use diagnostic::{
     apply_gated_promotion, diagnostic_coverage, evaluate_promotion, gate_and_apply,

--- a/crates/ruvector-agent-memory/src/main.rs
+++ b/crates/ruvector-agent-memory/src/main.rs
@@ -324,6 +324,99 @@ fn main() {
         println!("→ BENCHMARK FAILED");
         std::process::exit(1);
     }
+
+    run_arbitration_bench();
+}
+
+/// CAMA-pattern arbitration bench (ADR-330, PIR WP27): naive vote counting
+/// vs provenance-clustered arbitration over a synthetic 1 000-memory causal
+/// graph (100 independent origins, 900 derived memories). The correctness
+/// assertion — arbitration collapses the 1 000 memories to exactly the 100
+/// origin lineages, at a score no higher than the naive vote — is checked
+/// here as well as in the test suite.
+fn run_arbitration_bench() {
+    use rand::rngs::OsRng;
+    use ruvector_agent_memory::{
+        arbitrate, ArbitrationConfig, AtomicObservation, CausalEpisodicGraph, NodeRef,
+        ObservationId, ObservationSource, ReliabilityModel, SourceKind, Tenant,
+    };
+    use rvf_types::Ed25519Keypair;
+
+    const N_ROOTS: usize = 100;
+    const N_DERIVED: usize = 900;
+
+    println!("\nArbitration bench (ADR-330): naive vote vs provenance-clustered arbitration");
+    let keypair = Ed25519Keypair::generate(&mut OsRng);
+    let mut rng = StdRng::seed_from_u64(330);
+    let mut graph = CausalEpisodicGraph::new(Tenant::new("bench"));
+
+    let sign = |payload: &[u8], t: u64, parents: Vec<ObservationId>, kp: &Ed25519Keypair| {
+        AtomicObservation::new_signed(
+            ObservationSource {
+                kind: SourceKind::AgentObservation,
+                id: "bench".to_string(),
+                public_key: [0u8; 32],
+            },
+            t,
+            0.9,
+            Tenant::new("bench"),
+            parents,
+            payload.to_vec(),
+            kp,
+        )
+        .unwrap()
+    };
+
+    let roots: Vec<ObservationId> = (0..N_ROOTS)
+        .map(|i| graph.ingest(sign(&(i as u32).to_le_bytes(), 0, vec![], &keypair)).unwrap())
+        .collect();
+    // Per-root latest descendant, so derivation chains deepen over time.
+    let mut latest: Vec<ObservationId> = roots.clone();
+    let mut memories: Vec<NodeRef> = Vec::with_capacity(N_DERIVED);
+    for i in 0..N_DERIVED {
+        let r = rng.gen_range(0..N_ROOTS);
+        let parent = latest[r];
+        let id = graph
+            .ingest(sign(&(1_000_000 + i as u32).to_le_bytes(), 1 + i as u64, vec![parent], &keypair))
+            .unwrap();
+        latest[r] = id;
+        memories.push(NodeRef::Observation(id));
+    }
+
+    let config = ArbitrationConfig {
+        now_ns: 1_000_000,
+        half_life_ns: u64::MAX,
+        sufficiency_threshold: 1,
+        reliability: ReliabilityModel::default(),
+    };
+
+    // Naive vote: sum of raw confidences (the correlation-blind baseline).
+    let t0 = Instant::now();
+    let naive: f64 = memories
+        .iter()
+        .map(|m| match m {
+            NodeRef::Observation(id) => graph.observation(*id).unwrap().confidence as f64,
+            NodeRef::Cluster(_) => unreachable!(),
+        })
+        .sum();
+    let naive_us = t0.elapsed().as_micros();
+
+    let t1 = Instant::now();
+    let outcome = arbitrate(&graph, &memories, &config).expect("arbitration succeeds");
+    let arb_us = t1.elapsed().as_micros();
+    let verdict = outcome.verdict();
+
+    println!("  Memories        : {} ({} origins, {} derived)", N_DERIVED, N_ROOTS, N_DERIVED);
+    println!("  Naive vote      : {naive:.1} supporting confidence ({naive_us} µs)");
+    println!(
+        "  Arbitrated      : {:.1} effective confidence across {} lineages ({} µs)",
+        verdict.arbitrated_confidence,
+        verdict.independent_lineages(),
+        arb_us
+    );
+    assert_eq!(verdict.independent_lineages(), N_ROOTS);
+    assert!(verdict.arbitrated_confidence <= verdict.naive_confidence + 1e-9);
+    println!("  → {} correlated memories collapse to {} independent evidence lineages", N_DERIVED, N_ROOTS);
 }
 
 fn rustc_version_string() -> String {

--- a/crates/ruvector-agent-memory/src/main.rs
+++ b/crates/ruvector-agent-memory/src/main.rs
@@ -334,6 +334,11 @@ fn main() {
 /// assertion — arbitration collapses the 1 000 memories to exactly the 100
 /// origin lineages, at a score no higher than the naive vote — is checked
 /// here as well as in the test suite.
+///
+/// Every derived memory here **declares** its parent, so this measures the
+/// clustering math on the mechanism's best case. It is not an adversarial
+/// benchmark: content-copying memories that declare no parent mint their own
+/// lineages by design (see `arbitration`'s "Known limitation" docs).
 fn run_arbitration_bench() {
     use rand::rngs::OsRng;
     use ruvector_agent_memory::{
@@ -416,7 +421,10 @@ fn run_arbitration_bench() {
     );
     assert_eq!(verdict.independent_lineages(), N_ROOTS);
     assert!(verdict.arbitrated_confidence <= verdict.naive_confidence + 1e-9);
-    println!("  → {} correlated memories collapse to {} independent evidence lineages", N_DERIVED, N_ROOTS);
+    println!(
+        "  → {N_DERIVED} declared-derivation memories collapse to {N_ROOTS} independent lineages"
+    );
+    println!("    (declared-parent chains — the mechanism's best case, not an adversarial test)");
 }
 
 fn rustc_version_string() -> String {

--- a/crates/ruvector-agent-memory/tests/arbitration.rs
+++ b/crates/ruvector-agent-memory/tests/arbitration.rs
@@ -317,6 +317,49 @@ fn invalid_config_and_empty_set_rejected() {
     ));
 }
 
+/// Locks the Known-limitation numbers in the module rustdoc so the honesty
+/// text cannot silently drift from behavior: twenty agents re-asserting one
+/// claim's content **without declaring a parent** mint twenty lineages, and
+/// under the shipped `ReliabilityModel::default()` (0.9) score naive 18.0 vs
+/// arbitrated 16.2 — a reduction that is entirely the reliability multiplier
+/// and reflects zero detected correlation. The diagnostic is the lineage
+/// count equalling the memory count, not the score delta.
+#[test]
+fn content_copying_yields_no_correlation_downgrade_under_default_reliability() {
+    let keypair = kp();
+    let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
+
+    // One genuine origin, then 20 agents asserting the same claim with no
+    // declared derivation — the astroturfing shape the module cannot detect.
+    graph.ingest(signed(&keypair, "origin", "acme", 0.9, 0, vec![], b"rumor")).unwrap();
+    let copies: Vec<NodeRef> = (0..20u8)
+        .map(|i| {
+            NodeRef::Observation(
+                graph
+                    .ingest(signed(&keypair, "copier", "acme", 0.9, 1, vec![], &[i]))
+                    .unwrap(),
+            )
+        })
+        .collect();
+
+    let cfg = ArbitrationConfig {
+        now_ns: 1,
+        half_life_ns: u64::MAX, // freshness 1.0, isolating the reliability factor
+        sufficiency_threshold: 3,
+        reliability: ReliabilityModel::default(), // the SHIPPED default: 0.9
+    };
+    let outcome = arbitrate(&graph, &copies, &cfg).unwrap();
+
+    // Nothing was clustered: lineages == memories is the real diagnostic.
+    let verdict = outcome.verdict();
+    assert_eq!(verdict.independent_lineages(), copies.len());
+    assert!((verdict.naive_confidence - 18.0).abs() < 1e-6);
+    assert!((verdict.arbitrated_confidence - 16.2).abs() < 1e-6);
+    // And the sufficiency gate passes, which is exactly why the docs warn it
+    // is not a trust gate against repeated-claim attacks.
+    assert!(matches!(outcome, ArbitrationOutcome::Sufficient(_)));
+}
+
 /// `fuse()` must reject a non-finite member confidence at the source, rather
 /// than folding it away. `f32::min` returns the non-NaN operand, so the old
 /// `INFINITY`-seeded fold gave a lone-NaN cluster `confidence = +inf` and let

--- a/crates/ruvector-agent-memory/tests/arbitration.rs
+++ b/crates/ruvector-agent-memory/tests/arbitration.rs
@@ -1,0 +1,339 @@
+//! Integration tests for CAMA-pattern correlation-aware arbitration
+//! (ADR-330, PIR WP27), exercised through the crate's public API only.
+
+use std::collections::BTreeMap;
+
+use rand::rngs::OsRng;
+use ruvector_agent_memory::{
+    arbitrate, ArbitrationConfig, ArbitrationError, ArbitrationOutcome, AtomicObservation,
+    CausalEpisodicGraph, NodeRef, ObservationId, ObservationSource, ReliabilityModel, SourceKind,
+    Tenant,
+};
+use rvf_types::{ed25519_sign, Ed25519Keypair};
+
+fn kp() -> Ed25519Keypair {
+    Ed25519Keypair::generate(&mut OsRng)
+}
+
+fn source(id: &str) -> ObservationSource {
+    ObservationSource {
+        kind: SourceKind::AgentObservation,
+        id: id.to_string(),
+        public_key: [0u8; 32],
+    }
+}
+
+fn signed(
+    keypair: &Ed25519Keypair,
+    src: &str,
+    tenant: &str,
+    confidence: f32,
+    time_ns: u64,
+    parents: Vec<ObservationId>,
+    payload: &[u8],
+) -> AtomicObservation {
+    AtomicObservation::new_signed(
+        source(src),
+        time_ns,
+        confidence,
+        Tenant::new(tenant),
+        parents,
+        payload.to_vec(),
+        keypair,
+    )
+    .unwrap()
+}
+
+fn config() -> ArbitrationConfig {
+    ArbitrationConfig {
+        now_ns: 1_000,
+        half_life_ns: u64::MAX, // effectively no decay unless a test wants it
+        sufficiency_threshold: 1,
+        reliability: ReliabilityModel {
+            default: 1.0,
+            overrides: BTreeMap::new(),
+        },
+    }
+}
+
+/// The Wave-4 acceptance test, literal: ten memories all derived from ONE
+/// atomic source arbitrate to exactly one effective evidence lineage, and
+/// score strictly below ten genuinely independent memories.
+#[test]
+fn ten_memories_one_source_is_one_lineage() {
+    let keypair = kp();
+    let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
+
+    // One original source observation.
+    let root = graph
+        .ingest(signed(&keypair, "origin", "acme", 0.9, 0, vec![], b"rumor"))
+        .unwrap();
+
+    // Ten memories derived from it (some via chains, some directly).
+    let mut derived: Vec<NodeRef> = Vec::new();
+    let mut prev = root;
+    for i in 0..10u8 {
+        let parents = if i % 2 == 0 { vec![root] } else { vec![prev] };
+        let id = graph
+            .ingest(signed(&keypair, "agent", "acme", 0.9, 10 + i as u64, parents, &[i]))
+            .unwrap();
+        derived.push(NodeRef::Observation(id));
+        prev = id;
+    }
+
+    let outcome = arbitrate(&graph, &derived, &config()).unwrap();
+    let verdict = outcome.verdict();
+    assert_eq!(
+        verdict.independent_lineages(),
+        1,
+        "ten memories from one origin must be ONE evidence lineage"
+    );
+    assert_eq!(verdict.lineages[0].roots, vec![root]);
+    assert_eq!(verdict.lineages[0].members.len(), 10);
+    // Naive vote says ~9.0; arbitrated must collapse to a single lineage ≤ 1.
+    assert!((verdict.naive_confidence - 9.0).abs() < 1e-6);
+    assert!(verdict.arbitrated_confidence <= 1.0 + 1e-9);
+
+    // Contrast: ten genuinely independent memories (no shared ancestry).
+    let mut graph2 = CausalEpisodicGraph::new(Tenant::new("acme"));
+    let independent: Vec<NodeRef> = (0..10u8)
+        .map(|i| {
+            NodeRef::Observation(
+                graph2
+                    .ingest(signed(&keypair, "witness", "acme", 0.9, 10, vec![], &[i, 0xff]))
+                    .unwrap(),
+            )
+        })
+        .collect();
+    let outcome2 = arbitrate(&graph2, &independent, &config()).unwrap();
+    let verdict2 = outcome2.verdict();
+    assert_eq!(verdict2.independent_lineages(), 10);
+    assert!(
+        verdict.arbitrated_confidence < verdict2.arbitrated_confidence,
+        "one correlated lineage ({}) must score strictly below ten independent ones ({})",
+        verdict.arbitrated_confidence,
+        verdict2.arbitrated_confidence
+    );
+}
+
+/// Mixed case: 10 memories tracing to 3 disjoint origins form 3 lineages,
+/// and a bridging memory (ancestry in two origins) merges lineages.
+#[test]
+fn mixed_ancestry_clusters_and_bridges() {
+    let keypair = kp();
+    let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
+
+    let roots: Vec<ObservationId> = (0..3u8)
+        .map(|i| graph.ingest(signed(&keypair, "origin", "acme", 0.8, 0, vec![], &[i])).unwrap())
+        .collect();
+
+    // 4 memories from root 0, 3 from root 1, 3 from root 2.
+    let mut memories: Vec<NodeRef> = Vec::new();
+    for (r, count) in roots.iter().zip([4u8, 3, 3]) {
+        for i in 0..count {
+            let id = graph
+                .ingest(signed(&keypair, "agent", "acme", 0.8, 5, vec![*r], &[i, r.0[0]]))
+                .unwrap();
+            memories.push(NodeRef::Observation(id));
+        }
+    }
+    let outcome = arbitrate(&graph, &memories, &config()).unwrap();
+    assert_eq!(outcome.verdict().independent_lineages(), 3);
+
+    // A bridging memory citing roots 0 and 1 merges them into one lineage.
+    let bridge = graph
+        .ingest(signed(&keypair, "agent", "acme", 0.8, 6, vec![roots[0], roots[1]], b"bridge"))
+        .unwrap();
+    let mut with_bridge = memories.clone();
+    with_bridge.push(NodeRef::Observation(bridge));
+    let outcome = arbitrate(&graph, &with_bridge, &config()).unwrap();
+    assert_eq!(
+        outcome.verdict().independent_lineages(),
+        2,
+        "shared ancestry anywhere must collapse independence"
+    );
+}
+
+/// Downgrade-only: over randomized graphs, arbitrated ≤ naive, always.
+#[test]
+fn downgrade_only_over_random_graphs() {
+    use rand::{Rng, SeedableRng};
+    let mut rng = rand::rngs::StdRng::seed_from_u64(0xCA4A);
+    let keypair = kp();
+
+    for round in 0..20 {
+        let mut graph = CausalEpisodicGraph::new(Tenant::new("t"));
+        let n_roots = rng.gen_range(1..=5usize);
+        let roots: Vec<ObservationId> = (0..n_roots)
+            .map(|i| {
+                graph
+                    .ingest(signed(
+                        &keypair,
+                        "o",
+                        "t",
+                        rng.gen_range(0.0..=1.0),
+                        rng.gen_range(0..500),
+                        vec![],
+                        &[round, i as u8],
+                    ))
+                    .unwrap()
+            })
+            .collect();
+        let mut all: Vec<ObservationId> = roots.clone();
+        let mut memories: Vec<NodeRef> = Vec::new();
+        for i in 0..rng.gen_range(1..=20usize) {
+            let n_parents = rng.gen_range(1..=2usize).min(all.len());
+            let parents: Vec<ObservationId> = (0..n_parents)
+                .map(|_| all[rng.gen_range(0..all.len())])
+                .collect();
+            let id = graph
+                .ingest(signed(
+                    &keypair,
+                    "a",
+                    "t",
+                    rng.gen_range(0.0..=1.0),
+                    rng.gen_range(0..1000),
+                    parents,
+                    &[round, 0x80, i as u8],
+                ))
+                .unwrap();
+            all.push(id);
+            memories.push(NodeRef::Observation(id));
+        }
+        let mut cfg = config();
+        cfg.half_life_ns = rng.gen_range(1..=2000u64);
+        cfg.reliability.default = rng.gen_range(0.0..=1.0);
+        let verdict = arbitrate(&graph, &memories, &cfg).unwrap();
+        let v = verdict.verdict();
+        assert!(
+            v.arbitrated_confidence <= v.naive_confidence + 1e-9,
+            "round {round}: arbitrated {} exceeded naive {}",
+            v.arbitrated_confidence,
+            v.naive_confidence
+        );
+        assert!(
+            v.arbitrated_confidence <= v.independent_lineages() as f64 + 1e-9,
+            "arbitrated must also be bounded by the lineage count"
+        );
+    }
+}
+
+/// The non-finite choke point: a NaN confidence that *passes ingest* (the
+/// signature covers the NaN bit pattern, and ingest checks only signatures,
+/// tenancy, duplicates, and parents) must be rejected here, not compared.
+#[test]
+fn nan_confidence_rejected_at_choke_point() {
+    let keypair = kp();
+    let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
+
+    let mut obs = signed(&keypair, "evil", "acme", 0.5, 0, vec![], b"nan");
+    obs.confidence = f32::NAN;
+    // Re-sign the mutated content so it verifies and ingests cleanly.
+    obs.signature = ed25519_sign(&keypair.secret_key(), &obs.id().0);
+    let id = graph.ingest(obs).expect("ingest does not range-check confidence");
+
+    let err = arbitrate(&graph, &[NodeRef::Observation(id)], &config()).unwrap_err();
+    match err {
+        ArbitrationError::ConfidenceInvalid(_) => {}
+        other => panic!("expected ConfidenceInvalid, got {other:?}"),
+    }
+}
+
+/// Tenant isolation is inherited from the graph binding: a node from another
+/// tenant's graph is unknown here — a hard error, never a silent skip.
+#[test]
+fn cross_tenant_node_is_unknown() {
+    let keypair = kp();
+    let mut acme = CausalEpisodicGraph::new(Tenant::new("acme"));
+    let mut globex = CausalEpisodicGraph::new(Tenant::new("globex"));
+    let a = acme.ingest(signed(&keypair, "a", "acme", 0.9, 0, vec![], b"a")).unwrap();
+    let g = globex.ingest(signed(&keypair, "g", "globex", 0.9, 0, vec![], b"g")).unwrap();
+
+    let err = arbitrate(&acme, &[NodeRef::Observation(a), NodeRef::Observation(g)], &config())
+        .unwrap_err();
+    match err {
+        ArbitrationError::UnknownObservation(id) => assert_eq!(id, g),
+        other => panic!("expected UnknownObservation, got {other:?}"),
+    }
+}
+
+/// Below the sufficiency threshold the outcome is the typed insufficient
+/// variant naming the over-represented roots — the CAMA active-search hook.
+#[test]
+fn insufficient_independent_evidence_names_over_represented_roots() {
+    let keypair = kp();
+    let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
+    let root = graph.ingest(signed(&keypair, "o", "acme", 0.9, 0, vec![], b"r")).unwrap();
+    let memories: Vec<NodeRef> = (0..5u8)
+        .map(|i| {
+            NodeRef::Observation(
+                graph.ingest(signed(&keypair, "a", "acme", 0.9, 1, vec![root], &[i])).unwrap(),
+            )
+        })
+        .collect();
+
+    let mut cfg = config();
+    cfg.sufficiency_threshold = 3;
+    match arbitrate(&graph, &memories, &cfg).unwrap() {
+        ArbitrationOutcome::InsufficientIndependentEvidence {
+            verdict,
+            required,
+            over_represented_roots,
+        } => {
+            assert_eq!(required, 3);
+            assert_eq!(verdict.independent_lineages(), 1);
+            assert_eq!(over_represented_roots, vec![root]);
+        }
+        other => panic!("expected InsufficientIndependentEvidence, got {other:?}"),
+    }
+}
+
+/// Config choke point: non-finite reliability and a zero half-life are
+/// refused before any scoring happens; an empty memory set is refused too.
+#[test]
+fn invalid_config_and_empty_set_rejected() {
+    let keypair = kp();
+    let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
+    let id = graph.ingest(signed(&keypair, "a", "acme", 0.9, 0, vec![], b"x")).unwrap();
+    let node = [NodeRef::Observation(id)];
+
+    let mut cfg = config();
+    cfg.reliability.default = f64::NAN;
+    assert!(matches!(
+        arbitrate(&graph, &node, &cfg),
+        Err(ArbitrationError::InvalidConfig(_))
+    ));
+
+    let mut cfg = config();
+    cfg.half_life_ns = 0;
+    assert!(matches!(
+        arbitrate(&graph, &node, &cfg),
+        Err(ArbitrationError::InvalidConfig(_))
+    ));
+
+    assert!(matches!(
+        arbitrate(&graph, &[], &config()),
+        Err(ArbitrationError::EmptyMemorySet)
+    ));
+}
+
+/// Clusters participate as memories: a fused cluster resolves to its atomic
+/// constituents and clusters with anything sharing those origins.
+#[test]
+fn fused_cluster_shares_lineage_with_its_origins() {
+    let keypair = kp();
+    let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
+    let root = graph.ingest(signed(&keypair, "o", "acme", 0.9, 0, vec![], b"r")).unwrap();
+    let child = graph
+        .ingest(signed(&keypair, "a", "acme", 0.8, 1, vec![root], b"c"))
+        .unwrap();
+    let cluster = graph.fuse(&[NodeRef::Observation(child)], "topic").unwrap();
+
+    let outcome = arbitrate(
+        &graph,
+        &[NodeRef::Cluster(cluster), NodeRef::Observation(child)],
+        &config(),
+    )
+    .unwrap();
+    assert_eq!(outcome.verdict().independent_lineages(), 1);
+}

--- a/crates/ruvector-agent-memory/tests/arbitration.rs
+++ b/crates/ruvector-agent-memory/tests/arbitration.rs
@@ -6,8 +6,8 @@ use std::collections::BTreeMap;
 use rand::rngs::OsRng;
 use ruvector_agent_memory::{
     arbitrate, ArbitrationConfig, ArbitrationError, ArbitrationOutcome, AtomicObservation,
-    CausalEpisodicGraph, NodeRef, ObservationId, ObservationSource, ReliabilityModel, SourceKind,
-    Tenant,
+    CausalEpisodicGraph, FusionError, NodeRef, ObservationId, ObservationSource, ReliabilityModel,
+    SourceKind, Tenant,
 };
 use rvf_types::{ed25519_sign, Ed25519Keypair};
 
@@ -315,6 +315,37 @@ fn invalid_config_and_empty_set_rejected() {
         arbitrate(&graph, &[], &config()),
         Err(ArbitrationError::EmptyMemorySet)
     ));
+}
+
+/// `fuse()` must reject a non-finite member confidence at the source, rather
+/// than folding it away. `f32::min` returns the non-NaN operand, so the old
+/// `INFINITY`-seeded fold gave a lone-NaN cluster `confidence = +inf` and let
+/// a NaN in `[NaN, 0.9]` vanish into `0.9` — both violating the documented
+/// weakest-link `[0, 1]` contract on a public field.
+#[test]
+fn fuse_rejects_non_finite_member_confidence() {
+    let keypair = kp();
+    let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
+
+    let mut poisoned = signed(&keypair, "evil", "acme", 0.5, 0, vec![], b"nan");
+    poisoned.confidence = f32::NAN;
+    poisoned.signature = ed25519_sign(&keypair.secret_key(), &poisoned.id().0);
+    let bad = graph.ingest(poisoned).expect("ingest does not range-check confidence");
+    let good = graph.ingest(signed(&keypair, "ok", "acme", 0.9, 0, vec![], b"ok")).unwrap();
+
+    // Lone NaN member: must not become +inf.
+    assert!(matches!(
+        graph.fuse(&[NodeRef::Observation(bad)], "lone"),
+        Err(FusionError::MemberConfidenceInvalid(_))
+    ));
+    // NaN alongside a valid member: must not silently vanish into 0.9.
+    assert!(matches!(
+        graph.fuse(&[NodeRef::Observation(bad), NodeRef::Observation(good)], "mixed"),
+        Err(FusionError::MemberConfidenceInvalid(_))
+    ));
+    // A well-formed fusion still succeeds and keeps the weakest link.
+    let ok = graph.fuse(&[NodeRef::Observation(good)], "fine").unwrap();
+    assert!((graph.cluster(ok).unwrap().confidence - 0.9).abs() < 1e-6);
 }
 
 /// Clusters participate as memories: a fused cluster resolves to its atomic


### PR DESCRIPTION
## Summary

Implements the CAMA pattern (arXiv:2608.19701 — "Beyond Memory Majority: Latent-Source Reasoning for Multi-Agent Memory Arbitration") for PIR Wave 4: **N memories citing one origin are ONE observation, not N**. Part of the PIR program (epic #837), work package WP27, ADR-330.

No upstream code exists for the paper and its abstract carries no quantitative results — this is a first-party build of the described mechanism with this program's own acceptance bar, on top of the existing ADR-320 provenance layer (`observation.rs`/`fusion.rs`), not a port.

## What's new — `crates/ruvector-agent-memory/src/arbitration.rs`

- **Lineage clustering**: retrieved memories resolve to atomic observations (`resolve_provenance`), each observation to its parentless ancestor roots via `causal_parents`; lineages are the connected components of the memory↔root graph (union-find). A memory bridging two roots conservatively merges them.
- **Effective evidence**: `Σ_lineages max_member(confidence × reliability × freshness)` — **downgrade-only** relative to the naive per-memory sum, re-checked at runtime and fail-loud on violation (Wave-3 metric-integrity lesson).
- **Non-finite choke point**: NaN/±inf confidence rejected before any comparison (Wave-3 #888 lesson). Notably, a signature over a NaN bit-pattern *does* verify and passes graph ingest — the test suite proves this and proves the choke point catches it.
- **CAMA active-search hook**: below a caller-set sufficiency threshold, a typed `InsufficientIndependentEvidence` outcome names the over-represented lineage roots instead of silently passing.
- **Tenant isolation** inherited from the tenant-bound graph; cross-tenant node ids are hard errors.

## Tests (8 new, all passing; 55 total in crate)

- **Wave-4 acceptance test, literal**: ten memories derived from one atomic source arbitrate to exactly **one** lineage and score strictly below ten independent memories.
- Mixed ancestry (3 lineages from 10 memories) + bridge-merge, downgrade-only over 20 randomized graphs, NaN choke point, tenant separation, insufficiency outcome, config validation, cluster participation.

## Bench (extends `agent-memory-bench`)

Synthetic 1 000-memory graph (100 origins, 900 derived): naive vote **810.0** supporting confidence vs arbitrated **81.0** across exactly **100** lineages — 900 correlated memories collapse to 100 independent evidence lineages. Arbitration cost ~1.0 ms (naive sum 42 µs).

`cargo check`, `cargo test -p ruvector-agent-memory` (55 passed), and `cargo clippy --all-targets` all clean.

Refs: ADR-330 (Wave-4 ADR PR), epic #837, ADR-320 (provenance layer), ADR-325 (sibling memory gate).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_016QSCkKnxDjqU49NVVpWMK5