### PR TITLE
feat(tiny-dancer): Pandora-pattern value-of-information routing — closed-form Gaussian VoI estimator purchasing (PIR WP28, ADR-331)

### DIFF
--- a/crates/ruvector-tiny-dancer-core/benches/routing_inference.rs
+++ b/crates/ruvector-tiny-dancer-core/benches/routing_inference.rs
@@ -119,11 +119,51 @@ fn bench_batch_inference(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_voi_decision(c: &mut Criterion) {
+    use ruvector_tiny_dancer_core::voi::{decide, Belief, EstimatorSpec, VoiConfig};
+
+    let belief = Belief::new(0.5, 0.3).unwrap();
+    let ladder = [
+        EstimatorSpec {
+            cost: 0.001,
+            latency_us: 200.0,
+            noise_std: 0.5,
+        },
+        EstimatorSpec {
+            cost: 0.01,
+            latency_us: 2_000.0,
+            noise_std: 0.1,
+        },
+        EstimatorSpec {
+            cost: 0.1,
+            latency_us: 20_000.0,
+            noise_std: 0.01,
+        },
+    ];
+    let config = VoiConfig {
+        value_of_success: 1.0,
+        latency_price: 1e-6,
+    };
+
+    c.bench_function("voi_decision_3_estimators", |b| {
+        b.iter(|| {
+            decide(
+                black_box(belief),
+                black_box(0.55),
+                black_box(&ladder),
+                black_box(&config),
+            )
+            .unwrap()
+        })
+    });
+}
+
 criterion_group!(
     benches,
     bench_routing_latency,
     bench_feature_extraction,
     bench_model_inference,
-    bench_batch_inference
+    bench_batch_inference,
+    bench_voi_decision
 );
 criterion_main!(benches);

--- a/crates/ruvector-tiny-dancer-core/examples/admin-server.rs
+++ b/crates/ruvector-tiny-dancer-core/examples/admin-server.rs
@@ -33,6 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         circuit_breaker_threshold: 5,
         enable_quantization: true,
         database_path: None,
+        voi: None,
     };
 
     println!("Creating router with config:");

--- a/crates/ruvector-tiny-dancer-core/examples/full_observability.rs
+++ b/crates/ruvector-tiny-dancer-core/examples/full_observability.rs
@@ -24,6 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         circuit_breaker_threshold: 3,
         enable_quantization: true,
         database_path: None,
+        voi: None,
     };
 
     let router = Router::new(config)?;

--- a/crates/ruvector-tiny-dancer-core/src/lib.rs
+++ b/crates/ruvector-tiny-dancer-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod storage;
 pub mod training;
 pub mod types;
 pub mod uncertainty;
+pub mod voi;
 
 // Re-exports for convenience
 pub use error::{Result, TinyDancerError};
@@ -34,7 +35,9 @@ pub use training::{
 };
 pub use types::{
     Candidate, RouterConfig, RoutingDecision, RoutingMetrics, RoutingRequest, RoutingResponse,
+    VoiGateConfig,
 };
+pub use voi::{decide, observe, Belief, EstimatorSpec, VoiConfig, VoiDecision};
 
 /// Version of the Tiny Dancer library
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/ruvector-tiny-dancer-core/src/router.rs
+++ b/crates/ruvector-tiny-dancer-core/src/router.rs
@@ -101,7 +101,20 @@ impl Router {
                     // outweighs its cost (PIR WP28, ADR-331). Otherwise the
                     // legacy threshold rule applies unchanged.
                     let use_lightweight = match &self.config.voi {
-                        Some(gate) => self.voi_use_lightweight(gate, score, uncertainty)?,
+                        Some(gate) => match self.voi_use_lightweight(gate, score, uncertainty) {
+                            Ok(lightweight) => lightweight,
+                            // A non-finite model output is a model failure, so
+                            // it must reach the circuit breaker before the
+                            // error propagates — otherwise a degenerate model
+                            // can be hammered indefinitely through the gated
+                            // path without ever tripping the breaker.
+                            Err(e) => {
+                                if let Some(ref cb) = self.circuit_breaker {
+                                    cb.record_failure();
+                                }
+                                return Err(e);
+                            }
+                        },
                         None => {
                             score >= self.config.confidence_threshold
                                 && uncertainty <= self.config.max_uncertainty
@@ -348,6 +361,49 @@ mod tests {
                 "failed to escalate: cost={cost} noise={noise_std} score={score} uncertainty={uncertainty}"
             );
         }
+    }
+
+    #[test]
+    fn voi_gate_failures_trip_the_circuit_breaker() {
+        // A model emitting non-finite scores must reach the breaker through
+        // the gated path: without record_failure on that branch, a degenerate
+        // model can be hammered indefinitely because the errors return before
+        // the breaker is ever told.
+        let router = gated_router(0.01, 0.1);
+        let threshold = router.config().circuit_breaker_threshold;
+
+        // Poison a bias so every forward() yields NaN.
+        {
+            let mut model = router.model.write();
+            for bias in model.biases_mut() {
+                bias.fill(f32::NAN);
+            }
+        }
+
+        let request = RoutingRequest {
+            query_embedding: vec![0.5; 384],
+            candidates: vec![Candidate {
+                id: "1".to_string(),
+                embedding: vec![0.5; 384],
+                metadata: HashMap::new(),
+                created_at: Utc::now().timestamp(),
+                access_count: 1,
+                success_rate: 0.9,
+            }],
+            metadata: None,
+        };
+
+        assert!(router.circuit_breaker_status().unwrap(), "starts closed");
+        for i in 0..threshold {
+            assert!(
+                router.route(request.clone()).is_err(),
+                "non-finite score must error on attempt {i}"
+            );
+        }
+        assert!(
+            !router.circuit_breaker_status().unwrap(),
+            "breaker must open after {threshold} consecutive non-finite outputs"
+        );
     }
 
     #[test]

--- a/crates/ruvector-tiny-dancer-core/src/router.rs
+++ b/crates/ruvector-tiny-dancer-core/src/router.rs
@@ -6,6 +6,7 @@ use crate::feature_engineering::FeatureEngineer;
 use crate::model::FastGRNN;
 use crate::types::{RouterConfig, RoutingDecision, RoutingRequest, RoutingResponse};
 use crate::uncertainty::UncertaintyEstimator;
+use crate::voi::{self, Belief, VoiConfig, VoiDecision};
 use parking_lot::RwLock;
 use std::sync::Arc;
 use std::time::Instant;
@@ -34,6 +35,17 @@ impl Router {
         } else {
             None
         };
+
+        // Validate the optional VoI gate at construction so route() can
+        // trust it (PIR WP28, ADR-331).
+        if let Some(gate) = &config.voi {
+            gate.escalation.validate()?;
+            VoiConfig {
+                value_of_success: gate.value_of_success,
+                latency_price: gate.latency_price,
+            }
+            .validate()?;
+        }
 
         Ok(Self {
             config,
@@ -83,9 +95,18 @@ impl Router {
                         .uncertainty_estimator
                         .estimate(&features.features, score);
 
-                    // Determine routing decision
-                    let use_lightweight = score >= self.config.confidence_threshold
-                        && uncertainty <= self.config.max_uncertainty;
+                    // Determine routing decision. With a VoI gate configured,
+                    // escalation to the powerful model is an estimator
+                    // purchase: buy it only when the expected quality gain
+                    // outweighs its cost (PIR WP28, ADR-331). Otherwise the
+                    // legacy threshold rule applies unchanged.
+                    let use_lightweight = match &self.config.voi {
+                        Some(gate) => self.voi_use_lightweight(gate, score, uncertainty)?,
+                        None => {
+                            score >= self.config.confidence_threshold
+                                && uncertainty <= self.config.max_uncertainty
+                        }
+                    };
 
                     decisions.push(RoutingDecision {
                         candidate_id: candidate.id.clone(),
@@ -120,6 +141,36 @@ impl Router {
             candidates_processed: request.candidates.len(),
             feature_time_us,
         })
+    }
+
+    /// VoI escalation decision for one scored candidate: belief mean is the
+    /// model score, belief std is the conformal uncertainty (floored so the
+    /// prior stays proper), and the outside option is the configured
+    /// confidence threshold. Non-finite scores are rejected here, BEFORE any
+    /// comparison — a NaN score must fail loudly rather than silently pick a
+    /// route.
+    fn voi_use_lightweight(
+        &self,
+        gate: &crate::types::VoiGateConfig,
+        score: f32,
+        uncertainty: f32,
+    ) -> Result<bool> {
+        if !score.is_finite() || !uncertainty.is_finite() {
+            return Err(TinyDancerError::InvalidInput(format!(
+                "non-finite model output reached the VoI gate: score={score}, uncertainty={uncertainty}"
+            )));
+        }
+        let belief = Belief::new(score as f64, f64::from(uncertainty).max(1e-6))?;
+        let decision = voi::decide(
+            belief,
+            f64::from(self.config.confidence_threshold),
+            std::slice::from_ref(&gate.escalation),
+            &VoiConfig {
+                value_of_success: gate.value_of_success,
+                latency_price: gate.latency_price,
+            },
+        )?;
+        Ok(decision == VoiDecision::Route)
     }
 
     /// Reload the model from disk
@@ -188,5 +239,74 @@ mod tests {
         let response = router.route(request).unwrap();
         assert_eq!(response.decisions.len(), 2);
         assert!(response.inference_time_us > 0);
+    }
+
+    #[test]
+    fn test_routing_with_voi_gate() {
+        use crate::types::VoiGateConfig;
+        use crate::voi::EstimatorSpec;
+
+        let request = |candidates| RoutingRequest {
+            query_embedding: vec![0.5; 384],
+            candidates,
+            metadata: None,
+        };
+        let candidate = Candidate {
+            id: "1".to_string(),
+            embedding: vec![0.5; 384],
+            metadata: HashMap::new(),
+            created_at: Utc::now().timestamp(),
+            access_count: 10,
+            success_rate: 0.95,
+        };
+
+        // A prohibitively expensive escalation estimator is never bought:
+        // every decision must fall back to the lightweight route.
+        let mut config = RouterConfig::default();
+        config.voi = Some(VoiGateConfig {
+            value_of_success: 1.0,
+            latency_price: 0.0,
+            escalation: EstimatorSpec {
+                cost: 1e9,
+                latency_us: 0.0,
+                noise_std: 0.0,
+            },
+        });
+        let router = Router::new(config).unwrap();
+        let response = router.route(request(vec![candidate.clone()])).unwrap();
+        assert!(response.decisions[0].use_lightweight);
+
+        // A free perfect estimator is always bought: escalate.
+        let mut config = RouterConfig::default();
+        config.voi = Some(VoiGateConfig {
+            value_of_success: 1.0,
+            latency_price: 0.0,
+            escalation: EstimatorSpec {
+                cost: 0.0,
+                latency_us: 0.0,
+                noise_std: 0.0,
+            },
+        });
+        let router = Router::new(config).unwrap();
+        let response = router.route(request(vec![candidate])).unwrap();
+        assert!(!response.decisions[0].use_lightweight);
+    }
+
+    #[test]
+    fn test_invalid_voi_gate_rejected_at_construction() {
+        use crate::types::VoiGateConfig;
+        use crate::voi::EstimatorSpec;
+
+        let mut config = RouterConfig::default();
+        config.voi = Some(VoiGateConfig {
+            value_of_success: f64::NAN,
+            latency_price: 0.0,
+            escalation: EstimatorSpec {
+                cost: 0.0,
+                latency_us: 0.0,
+                noise_std: 0.1,
+            },
+        });
+        assert!(Router::new(config).is_err());
     }
 }

--- a/crates/ruvector-tiny-dancer-core/src/router.rs
+++ b/crates/ruvector-tiny-dancer-core/src/router.rs
@@ -149,6 +149,17 @@ impl Router {
     /// confidence threshold. Non-finite scores are rejected here, BEFORE any
     /// comparison — a NaN score must fail loudly rather than silently pick a
     /// route.
+    ///
+    /// The gate is **escalate-only** — the downgrade-only analog used
+    /// elsewhere in the program for metric-integrity gates. A positive-VoI
+    /// purchase can flip a would-be-lightweight route into an escalation, but
+    /// [`VoiDecision::Route`] (no purchase worth making) falls back to the
+    /// legacy threshold rule rather than asserting "lightweight". Reading
+    /// `Route` as "use the cheap model" would make the gate fail open:
+    /// `confidence_threshold` and `max_uncertainty` would never be consulted
+    /// on the gated path, so the least-confident queries — exactly the ones
+    /// escalation exists for — would silently take the cheap model whenever
+    /// escalation is priced above the VoI.
     fn voi_use_lightweight(
         &self,
         gate: &crate::types::VoiGateConfig,
@@ -170,7 +181,15 @@ impl Router {
                 latency_price: gate.latency_price,
             },
         )?;
-        Ok(decision == VoiDecision::Route)
+        Ok(match decision {
+            // Escalation is worth buying.
+            VoiDecision::Buy(_) => false,
+            // Nothing worth buying — the legacy rule still governs.
+            VoiDecision::Route => {
+                score >= self.config.confidence_threshold
+                    && uncertainty <= self.config.max_uncertainty
+            }
+        })
     }
 
     /// Reload the model from disk
@@ -241,11 +260,29 @@ mod tests {
         assert!(response.inference_time_us > 0);
     }
 
-    #[test]
-    fn test_routing_with_voi_gate() {
+    fn gated_router(cost: f64, noise_std: f64) -> Router {
         use crate::types::VoiGateConfig;
         use crate::voi::EstimatorSpec;
 
+        let mut config = RouterConfig::default();
+        config.voi = Some(VoiGateConfig {
+            value_of_success: 1.0,
+            latency_price: 0.0,
+            escalation: EstimatorSpec {
+                cost,
+                latency_us: 0.0,
+                noise_std,
+            },
+        });
+        Router::new(config).unwrap()
+    }
+
+    fn legacy_lightweight(config: &RouterConfig, score: f32, uncertainty: f32) -> bool {
+        score >= config.confidence_threshold && uncertainty <= config.max_uncertainty
+    }
+
+    #[test]
+    fn test_routing_with_voi_gate() {
         let request = |candidates| RoutingRequest {
             query_embedding: vec![0.5; 384],
             candidates,
@@ -260,36 +297,69 @@ mod tests {
             success_rate: 0.95,
         };
 
-        // A prohibitively expensive escalation estimator is never bought:
-        // every decision must fall back to the lightweight route.
-        let mut config = RouterConfig::default();
-        config.voi = Some(VoiGateConfig {
-            value_of_success: 1.0,
-            latency_price: 0.0,
-            escalation: EstimatorSpec {
-                cost: 1e9,
-                latency_us: 0.0,
-                noise_std: 0.0,
-            },
-        });
-        let router = Router::new(config).unwrap();
-        let response = router.route(request(vec![candidate.clone()])).unwrap();
-        assert!(response.decisions[0].use_lightweight);
-
         // A free perfect estimator is always bought: escalate.
-        let mut config = RouterConfig::default();
-        config.voi = Some(VoiGateConfig {
-            value_of_success: 1.0,
-            latency_price: 0.0,
-            escalation: EstimatorSpec {
-                cost: 0.0,
-                latency_us: 0.0,
-                noise_std: 0.0,
-            },
-        });
-        let router = Router::new(config).unwrap();
+        let router = gated_router(0.0, 0.0);
         let response = router.route(request(vec![candidate])).unwrap();
         assert!(!response.decisions[0].use_lightweight);
+    }
+
+    #[test]
+    fn voi_gate_is_escalate_only_not_fail_open() {
+        // Regression: reading VoiDecision::Route as "use lightweight" made
+        // the gate fail open, voiding confidence_threshold and
+        // max_uncertainty on the gated path. An unpurchasable escalation
+        // must leave the legacy rule exactly as it was.
+        let router = gated_router(1e9, 0.0);
+        let config = router.config();
+        for &(score, uncertainty) in &[
+            (0.10f32, 0.05f32), // far below threshold — must escalate
+            (0.90, 0.90),       // confident but 6x over max_uncertainty
+            (0.90, 0.05),       // genuinely safe for the cheap model
+            (0.85, 0.15),       // exactly on both boundaries
+            (0.84, 0.15),       // a hair under the confidence threshold
+        ] {
+            let gate = config.voi.as_ref().unwrap();
+            let gated = router
+                .voi_use_lightweight(gate, score, uncertainty)
+                .unwrap();
+            assert_eq!(
+                gated,
+                legacy_lightweight(config, score, uncertainty),
+                "gated path diverged from legacy at score={score} uncertainty={uncertainty}"
+            );
+        }
+    }
+
+    #[test]
+    fn voi_gate_escalates_the_low_confidence_tail() {
+        // The three audited scenarios: each must escalate (use_lightweight
+        // == false), whatever the escalation is priced at.
+        let cases = [
+            // (cost, noise_std, score, uncertainty)
+            (0.01, 0.1, 0.10f32, 0.05f32), // cheap escalation, unconfident
+            (0.0, 0.0, 0.10, 0.05),        // free perfect oracle, unconfident
+            (0.50, 0.1, 0.90, 0.90),       // pricey escalation, over-uncertain
+        ];
+        for &(cost, noise_std, score, uncertainty) in &cases {
+            let router = gated_router(cost, noise_std);
+            let gate = router.config().voi.as_ref().unwrap();
+            assert!(
+                !router.voi_use_lightweight(gate, score, uncertainty).unwrap(),
+                "failed to escalate: cost={cost} noise={noise_std} score={score} uncertainty={uncertainty}"
+            );
+        }
+    }
+
+    #[test]
+    fn voi_gate_rejects_non_finite_model_output() {
+        // Fail loud rather than resolving NaN to a route in either direction.
+        let router = gated_router(0.01, 0.1);
+        let gate = router.config().voi.as_ref().unwrap();
+        assert!(router.voi_use_lightweight(gate, f32::NAN, 0.05).is_err());
+        assert!(router.voi_use_lightweight(gate, 0.5, f32::NAN).is_err());
+        assert!(router
+            .voi_use_lightweight(gate, f32::INFINITY, 0.05)
+            .is_err());
     }
 
     #[test]

--- a/crates/ruvector-tiny-dancer-core/src/types.rs
+++ b/crates/ruvector-tiny-dancer-core/src/types.rs
@@ -1,5 +1,6 @@
 //! Core types for Tiny Dancer routing system
 
+use crate::voi::EstimatorSpec;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -105,6 +106,21 @@ impl Default for RoutingMetrics {
     }
 }
 
+/// Optional value-of-information gate for the escalation decision
+/// (PIR WP28, ADR-331; arXiv:2608.20316). When set, the lightweight-vs-
+/// powerful choice is made by [`crate::voi::decide`]: the powerful model is
+/// modeled as a purchasable estimator, and it is invoked only when the
+/// expected quality gain (priced by `value_of_success`) exceeds its cost.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct VoiGateConfig {
+    /// Currency value of one unit of routing utility.
+    pub value_of_success: f64,
+    /// Currency price per microsecond of added latency.
+    pub latency_price: f64,
+    /// Cost/latency/noise model of escalating to the powerful model.
+    pub escalation: EstimatorSpec,
+}
+
 /// Configuration for the router
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RouterConfig {
@@ -122,6 +138,10 @@ pub struct RouterConfig {
     pub enable_quantization: bool,
     /// Database path for AgentDB
     pub database_path: Option<String>,
+    /// Optional VoI escalation gate (off by default; absent in older
+    /// serialized configs, hence `serde(default)`).
+    #[serde(default)]
+    pub voi: Option<VoiGateConfig>,
 }
 
 impl Default for RouterConfig {
@@ -134,6 +154,7 @@ impl Default for RouterConfig {
             circuit_breaker_threshold: 5,
             enable_quantization: true,
             database_path: None,
+            voi: None,
         }
     }
 }

--- a/crates/ruvector-tiny-dancer-core/src/types.rs
+++ b/crates/ruvector-tiny-dancer-core/src/types.rs
@@ -108,12 +108,32 @@ impl Default for RoutingMetrics {
 
 /// Optional value-of-information gate for the escalation decision
 /// (PIR WP28, ADR-331; arXiv:2608.20316). When set, the lightweight-vs-
-/// powerful choice is made by [`crate::voi::decide`]: the powerful model is
-/// modeled as a purchasable estimator, and it is invoked only when the
-/// expected quality gain (priced by `value_of_success`) exceeds its cost.
+/// powerful choice consults [`crate::voi::decide`]: the powerful model is
+/// modeled as a purchasable estimator, and it is invoked when the expected
+/// quality gain (priced by `value_of_success`) exceeds its cost. The gate is
+/// **escalate-only** — when no purchase is worth making it falls back to the
+/// `confidence_threshold` / `max_uncertainty` rule, so it can add
+/// escalations but never rescue a below-threshold candidate into the cheap
+/// model.
+///
+/// # Calibration hazard
+///
+/// VoI is bounded above by `s·φ(0) ≈ 0.399·σ`, and in this router `σ` is a
+/// conformal uncertainty on a `[0, 1]` score — typically `σ ≈ 0.05`, so the
+/// most any escalation can be worth is `value_of_success × ~0.02`. With
+/// `value_of_success = 1.0` **no escalation costing more than about $0.02 is
+/// ever purchasable at any score**, and the gate silently degenerates into a
+/// permanent never-escalate switch that still looks configured and healthy.
+/// `value_of_success` must therefore be set to the currency value of a
+/// *correct route* (what a good answer is worth, e.g. dollars of avoided
+/// rework), not left at a nominal 1.0. Sanity-check a candidate
+/// configuration with [`crate::voi::voi_upper_bound`]: if
+/// `value_of_success × voi_upper_bound(σ, τ)` is below `escalation.cost`,
+/// this gate will never fire.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct VoiGateConfig {
-    /// Currency value of one unit of routing utility.
+    /// Currency value of one unit of routing utility. See the calibration
+    /// hazard above — this is the value of a correct route, not a nominal 1.
     pub value_of_success: f64,
     /// Currency price per microsecond of added latency.
     pub latency_price: f64,

--- a/crates/ruvector-tiny-dancer-core/src/voi.rs
+++ b/crates/ruvector-tiny-dancer-core/src/voi.rs
@@ -1,0 +1,475 @@
+//! Value-of-information (VoI) routing primitive (PIR WP28, ADR-331).
+//!
+//! Routing as information economics, after "Pandora's AI Model Routing Box:
+//! Efficient Allocation with Costly Value Estimation" (arXiv:2608.20316): a
+//! cheap estimator may already predict which candidate will succeed, while a
+//! stronger estimator gives a better routing decision but costs tokens and
+//! latency. The router purchases the better estimate only when the purchase
+//! has positive expected value:
+//!
+//! ```text
+//! buy  ⇔  expected_quality_gain × value_of_success  >  estimator_cost + latency_cost
+//! ```
+//!
+//! # Closed-form Gaussian case
+//!
+//! Belief over a candidate's utility is `U ~ N(μ, σ²)`. An estimator observes
+//! `y = U + ε` with `ε ~ N(0, τ²)`. After observing `y`, the posterior mean is
+//! `m′ = μ + k·(y − μ)` with gain `k = σ²/(σ² + τ²)`. Before the observation,
+//! `m′` is itself Gaussian under the prior predictive: `m′ ~ N(μ, s²)` with
+//!
+//! ```text
+//! s² = σ⁴ / (σ² + τ²)
+//! ```
+//!
+//! Routing against a known outside option `a` (the best alternative's value),
+//! the decision value without the estimate is `max(μ, a)`; with it, the router
+//! decides after seeing `m′`, so the expected value is `E[max(m′, a)]`. For
+//! `X ~ N(μ, s²)` the Gaussian expected-improvement integral gives the closed
+//! form (with `z = (a − μ)/s`, standard normal cdf `Φ` and pdf `φ`):
+//!
+//! ```text
+//! E[max(X, a)] = a·Φ(z) + μ·(1 − Φ(z)) + s·φ(z)
+//! VoI(μ, σ, τ, a) = E[max(m′, a)] − max(μ, a)  ≥ 0
+//! ```
+//!
+//! `VoI` is maximized at `a = μ`, giving the upper bound `s·φ(0) = s/√(2π)` —
+//! no estimator purchase can ever be worth more than that in utility units.
+//!
+//! # Intended call sites
+//!
+//! [`decide`] is a standalone pure function so the same primitive can gate
+//! model selection (this crate's [`Router`](crate::Router) integration, via
+//! [`crate::types::RouterConfig`]), retrieval depth, verifier invocations,
+//! agent spawning, and escalation. Only the router integration is implemented
+//! here; the others are expected to construct their own [`EstimatorSpec`]
+//! ladders over the same API.
+//!
+//! # Numerical discipline
+//!
+//! Every input crosses [`Belief::new`] / [`EstimatorSpec::validate`] /
+//! [`VoiConfig::validate`], which reject non-finite values *before* any
+//! comparison is made — a NaN must never reach the decision inequality
+//! (comparison-based gates silently pass NaN; see PIR Wave-3 finding on
+//! non-finite bypass).
+
+use crate::error::{Result, TinyDancerError};
+use serde::{Deserialize, Serialize};
+
+/// 1/√(2π), the standard normal density at zero.
+const INV_SQRT_2PI: f64 = 0.398_942_280_401_432_7;
+
+fn invalid(msg: impl Into<String>) -> TinyDancerError {
+    TinyDancerError::InvalidInput(msg.into())
+}
+
+fn require_finite(name: &str, value: f64) -> Result<f64> {
+    if value.is_finite() {
+        Ok(value)
+    } else {
+        Err(invalid(format!("{name} must be finite, got {value}")))
+    }
+}
+
+/// Standard normal pdf.
+fn norm_pdf(x: f64) -> f64 {
+    INV_SQRT_2PI * (-0.5 * x * x).exp()
+}
+
+/// Standard normal cdf via the Abramowitz–Stegun 7.1.26 erf approximation
+/// (absolute error ≤ 1.5e-7, ample for a purchase decision).
+fn norm_cdf(x: f64) -> f64 {
+    let z = x / std::f64::consts::SQRT_2;
+    let (sign, z) = if z < 0.0 { (-1.0, -z) } else { (1.0, z) };
+    let t = 1.0 / (1.0 + 0.327_591_1 * z);
+    let poly = t
+        * (0.254_829_592
+            + t * (-0.284_496_736 + t * (1.421_413_741 + t * (-1.453_152_027 + t * 1.061_405_429))));
+    let erf = sign * (1.0 - poly * (-z * z).exp());
+    0.5 * (1.0 + erf)
+}
+
+/// Gaussian belief `N(mean, std_dev²)` over a candidate's utility.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Belief {
+    mean: f64,
+    std_dev: f64,
+}
+
+impl Belief {
+    /// Create a belief. Rejects non-finite inputs and `std_dev <= 0` — a
+    /// degenerate (certain) prior leaves nothing for an estimator to reveal.
+    pub fn new(mean: f64, std_dev: f64) -> Result<Self> {
+        require_finite("belief mean", mean)?;
+        require_finite("belief std_dev", std_dev)?;
+        if std_dev <= 0.0 {
+            return Err(invalid(format!("belief std_dev must be > 0, got {std_dev}")));
+        }
+        Ok(Self { mean, std_dev })
+    }
+
+    /// Posterior mean of the belief.
+    pub fn mean(&self) -> f64 {
+        self.mean
+    }
+
+    /// Posterior standard deviation of the belief.
+    pub fn std_dev(&self) -> f64 {
+        self.std_dev
+    }
+}
+
+/// A purchasable estimator: pay `cost` and `latency_us`, observe the true
+/// utility corrupted by `N(0, noise_std²)` noise. `noise_std == 0` models a
+/// perfect oracle.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct EstimatorSpec {
+    /// Direct cost of one invocation, in the same currency as
+    /// [`VoiConfig::value_of_success`] (e.g. dollars or token-dollars).
+    pub cost: f64,
+    /// Added latency of one invocation, in microseconds.
+    pub latency_us: f64,
+    /// Observation noise standard deviation, in utility units.
+    pub noise_std: f64,
+}
+
+impl EstimatorSpec {
+    /// Reject non-finite or negative fields before any comparison.
+    pub fn validate(&self) -> Result<()> {
+        for (name, v) in [
+            ("estimator cost", self.cost),
+            ("estimator latency_us", self.latency_us),
+            ("estimator noise_std", self.noise_std),
+        ] {
+            require_finite(name, v)?;
+            if v < 0.0 {
+                return Err(invalid(format!("{name} must be >= 0, got {v}")));
+            }
+        }
+        Ok(())
+    }
+
+    /// Total monetized cost of one invocation under `config`.
+    fn monetized_cost(&self, config: &VoiConfig) -> f64 {
+        self.cost + self.latency_us * config.latency_price
+    }
+}
+
+/// Economic parameters for the purchase decision.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct VoiConfig {
+    /// Currency value of one unit of routing utility (converts VoI from
+    /// utility units into the same currency as [`EstimatorSpec::cost`]).
+    pub value_of_success: f64,
+    /// Currency price per microsecond of added latency.
+    pub latency_price: f64,
+}
+
+impl VoiConfig {
+    /// Reject non-finite, non-positive `value_of_success`, or negative
+    /// `latency_price` before any comparison.
+    pub fn validate(&self) -> Result<()> {
+        require_finite("value_of_success", self.value_of_success)?;
+        require_finite("latency_price", self.latency_price)?;
+        if self.value_of_success <= 0.0 {
+            return Err(invalid(format!(
+                "value_of_success must be > 0, got {}",
+                self.value_of_success
+            )));
+        }
+        if self.latency_price < 0.0 {
+            return Err(invalid(format!(
+                "latency_price must be >= 0, got {}",
+                self.latency_price
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Outcome of one VoI evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VoiDecision {
+    /// Purchase estimator `estimators[idx]`; observe, update the belief with
+    /// [`observe`], and re-evaluate.
+    Buy(usize),
+    /// No estimator purchase has positive expected value — route on the
+    /// current belief.
+    Route,
+}
+
+/// Standard deviation `s` of the prior-predictive posterior mean:
+/// `s² = σ⁴/(σ² + τ²)`. `τ = 0` gives `s = σ` (a perfect estimator reveals
+/// the full prior uncertainty).
+fn predictive_mean_std(sigma: f64, tau: f64) -> f64 {
+    let s2 = sigma * sigma;
+    (s2 * s2 / (s2 + tau * tau)).sqrt()
+}
+
+/// `E[max(X, alt)]` for `X ~ N(mean, std²)`.
+fn expected_max(mean: f64, std: f64, alt: f64) -> f64 {
+    let z = (alt - mean) / std;
+    alt * norm_cdf(z) + mean * (1.0 - norm_cdf(z)) + std * norm_pdf(z)
+}
+
+/// Value of information (utility units) of purchasing one observation with
+/// noise `noise_std`, given `belief` and a known outside option `alternative`.
+/// Non-negative by construction; clamped at 0 to absorb approximation error.
+pub fn value_of_information(belief: Belief, alternative: f64, noise_std: f64) -> Result<f64> {
+    require_finite("alternative", alternative)?;
+    require_finite("noise_std", noise_std)?;
+    if noise_std < 0.0 {
+        return Err(invalid(format!("noise_std must be >= 0, got {noise_std}")));
+    }
+    let s = predictive_mean_std(belief.std_dev, noise_std);
+    let voi = expected_max(belief.mean, s, alternative) - belief.mean.max(alternative);
+    Ok(voi.max(0.0))
+}
+
+/// Upper bound on [`value_of_information`] over every possible `alternative`:
+/// `s·φ(0) = s/√(2π)`, attained at `alternative = mean`.
+pub fn voi_upper_bound(belief: Belief, noise_std: f64) -> Result<f64> {
+    require_finite("noise_std", noise_std)?;
+    if noise_std < 0.0 {
+        return Err(invalid(format!("noise_std must be >= 0, got {noise_std}")));
+    }
+    Ok(predictive_mean_std(belief.std_dev, noise_std) * INV_SQRT_2PI)
+}
+
+/// One greedy step of the index policy: evaluate every estimator's net value
+/// (`value_of_success × VoI − monetized cost`) and buy the best strictly
+/// positive one; otherwise route. Ties break to the lowest index, so the
+/// decision is deterministic for identical inputs. When the alternative is
+/// many standard deviations from the mean, the mathematically-positive VoI
+/// underflows to exactly 0 — a free estimator is then value-indifferent and
+/// the policy routes rather than buys.
+///
+/// The caller purchases the returned estimator, feeds its observation through
+/// [`observe`], and calls `decide` again — the posterior tightens each round
+/// (see [`observe`]), so the loop terminates: VoI shrinks toward zero while
+/// costs stay fixed.
+pub fn decide(
+    belief: Belief,
+    alternative: f64,
+    estimators: &[EstimatorSpec],
+    config: &VoiConfig,
+) -> Result<VoiDecision> {
+    require_finite("alternative", alternative)?;
+    config.validate()?;
+    let mut best: Option<(usize, f64)> = None;
+    for (idx, est) in estimators.iter().enumerate() {
+        est.validate()?;
+        let voi = value_of_information(belief, alternative, est.noise_std)?;
+        let net = config.value_of_success * voi - est.monetized_cost(config);
+        if net > 0.0 && best.map_or(true, |(_, b)| net > b) {
+            best = Some((idx, net));
+        }
+    }
+    Ok(match best {
+        Some((idx, _)) => VoiDecision::Buy(idx),
+        None => VoiDecision::Route,
+    })
+}
+
+/// Bayesian update after purchasing `estimator` and observing `observation`:
+/// gain `k = σ²/(σ² + τ²)`, posterior mean `μ + k·(y − μ)`, posterior
+/// variance `σ²τ²/(σ² + τ²) ≤ σ²` (never increases). Requires
+/// `noise_std > 0`; a perfect (`τ = 0`) observation leaves no residual
+/// uncertainty to represent — the caller already holds the exact utility.
+pub fn observe(belief: Belief, estimator: &EstimatorSpec, observation: f64) -> Result<Belief> {
+    estimator.validate()?;
+    require_finite("observation", observation)?;
+    if estimator.noise_std <= 0.0 {
+        return Err(invalid(
+            "observe requires noise_std > 0; a noiseless observation is the exact utility",
+        ));
+    }
+    let s2 = belief.std_dev * belief.std_dev;
+    let t2 = estimator.noise_std * estimator.noise_std;
+    let k = s2 / (s2 + t2);
+    Belief::new(
+        belief.mean + k * (observation - belief.mean),
+        (s2 * t2 / (s2 + t2)).sqrt(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn cfg() -> VoiConfig {
+        VoiConfig {
+            value_of_success: 1.0,
+            latency_price: 0.0,
+        }
+    }
+
+    #[test]
+    fn rejects_non_finite_at_the_choke_point() {
+        assert!(Belief::new(f64::NAN, 1.0).is_err());
+        assert!(Belief::new(0.0, f64::INFINITY).is_err());
+        assert!(Belief::new(0.0, 0.0).is_err());
+        assert!(Belief::new(0.0, -1.0).is_err());
+        let b = Belief::new(0.5, 0.2).unwrap();
+        assert!(value_of_information(b, f64::NAN, 0.1).is_err());
+        assert!(value_of_information(b, 0.5, f64::NAN).is_err());
+        let bad = EstimatorSpec {
+            cost: f64::NAN,
+            latency_us: 0.0,
+            noise_std: 0.1,
+        };
+        assert!(decide(b, 0.5, &[bad], &cfg()).is_err());
+        assert!(VoiConfig {
+            value_of_success: f64::NAN,
+            latency_price: 0.0
+        }
+        .validate()
+        .is_err());
+        assert!(observe(b, &bad, 0.5).is_err());
+    }
+
+    #[test]
+    fn zero_cost_perfect_estimator_always_buys() {
+        // Property (b): zero-noise, zero-cost estimator has strictly positive
+        // net value for any uncertain prior, so it is always purchased —
+        // whenever the VoI is floating-point representable (an alternative
+        // dozens of σ away underflows VoI to exactly 0 = indifference).
+        let free_oracle = EstimatorSpec {
+            cost: 0.0,
+            latency_us: 0.0,
+            noise_std: 0.0,
+        };
+        for mean in [-2.0, 0.0, 0.5, 3.0] {
+            for alt in [-1.0, 0.0, 0.5, 2.0] {
+                let b = Belief::new(mean, 1.0).unwrap();
+                assert_eq!(
+                    decide(b, alt, &[free_oracle], &cfg()).unwrap(),
+                    VoiDecision::Buy(0),
+                    "mean={mean} alt={alt}"
+                );
+            }
+        }
+    }
+
+    proptest! {
+        // Property (a): never buys when the cost exceeds the VoI upper bound
+        // value_of_success × s·φ(0).
+        #[test]
+        fn never_buys_above_the_voi_upper_bound(
+            mean in -10.0f64..10.0,
+            sigma in 0.01f64..5.0,
+            alt in -10.0f64..10.0,
+            tau in 0.0f64..5.0,
+        ) {
+            let b = Belief::new(mean, sigma).unwrap();
+            let bound = voi_upper_bound(b, tau).unwrap();
+            let est = EstimatorSpec { cost: bound + 1e-9, latency_us: 0.0, noise_std: tau };
+            prop_assert_eq!(decide(b, alt, &[est], &cfg()).unwrap(), VoiDecision::Route);
+        }
+
+        // Property (a) corollary: VoI never exceeds its closed-form bound.
+        #[test]
+        fn voi_respects_its_upper_bound(
+            mean in -10.0f64..10.0,
+            sigma in 0.01f64..5.0,
+            alt in -10.0f64..10.0,
+            tau in 0.0f64..5.0,
+        ) {
+            let b = Belief::new(mean, sigma).unwrap();
+            let voi = value_of_information(b, alt, tau).unwrap();
+            prop_assert!(voi >= 0.0);
+            prop_assert!(voi <= voi_upper_bound(b, tau).unwrap() + 1e-9);
+        }
+
+        // Property (c): posterior variance is monotonically non-increasing
+        // across a chain of purchases.
+        #[test]
+        fn posterior_variance_never_increases(
+            mean in -5.0f64..5.0,
+            sigma in 0.01f64..3.0,
+            taus in prop::collection::vec(0.01f64..3.0, 1..6),
+            ys in prop::collection::vec(-5.0f64..5.0, 6),
+        ) {
+            let mut b = Belief::new(mean, sigma).unwrap();
+            for (tau, y) in taus.iter().zip(ys.iter()) {
+                let est = EstimatorSpec { cost: 0.0, latency_us: 0.0, noise_std: *tau };
+                let next = observe(b, &est, *y).unwrap();
+                prop_assert!(next.std_dev() <= b.std_dev() + 1e-12);
+                b = next;
+            }
+        }
+
+        // Property (d): decisions are deterministic for identical inputs.
+        #[test]
+        fn decisions_are_deterministic(
+            mean in -5.0f64..5.0,
+            sigma in 0.01f64..3.0,
+            alt in -5.0f64..5.0,
+            specs in prop::collection::vec(
+                (0.0f64..0.5, 0.0f64..100.0, 0.0f64..2.0), 0..5),
+        ) {
+            let b = Belief::new(mean, sigma).unwrap();
+            let ests: Vec<EstimatorSpec> = specs.iter()
+                .map(|&(cost, latency_us, noise_std)| EstimatorSpec { cost, latency_us, noise_std })
+                .collect();
+            let config = VoiConfig { value_of_success: 2.0, latency_price: 0.001 };
+            let d1 = decide(b, alt, &ests, &config).unwrap();
+            let d2 = decide(b, alt, &ests, &config).unwrap();
+            prop_assert_eq!(d1, d2);
+        }
+    }
+
+    #[test]
+    fn noisier_estimators_are_worth_less() {
+        let b = Belief::new(0.5, 0.3).unwrap();
+        let sharp = value_of_information(b, 0.5, 0.05).unwrap();
+        let blunt = value_of_information(b, 0.5, 1.0).unwrap();
+        assert!(sharp > blunt);
+    }
+
+    #[test]
+    fn greedy_step_prefers_the_higher_net_estimator() {
+        let b = Belief::new(0.5, 0.4).unwrap();
+        // Same noise, different price: the cheaper one must win.
+        let pricey = EstimatorSpec {
+            cost: 0.05,
+            latency_us: 0.0,
+            noise_std: 0.1,
+        };
+        let cheap = EstimatorSpec {
+            cost: 0.01,
+            latency_us: 0.0,
+            noise_std: 0.1,
+        };
+        assert_eq!(
+            decide(b, 0.5, &[pricey, cheap], &cfg()).unwrap(),
+            VoiDecision::Buy(1)
+        );
+    }
+
+    #[test]
+    fn latency_is_priced_into_the_purchase() {
+        let b = Belief::new(0.5, 0.4).unwrap();
+        let slow = EstimatorSpec {
+            cost: 0.0,
+            latency_us: 1_000_000.0,
+            noise_std: 0.1,
+        };
+        let config = VoiConfig {
+            value_of_success: 1.0,
+            latency_price: 1.0, // exorbitant: 1 currency unit per µs
+        };
+        assert_eq!(
+            decide(b, 0.5, &[slow], &config).unwrap(),
+            VoiDecision::Route
+        );
+    }
+
+    #[test]
+    fn norm_cdf_matches_known_values() {
+        assert!((norm_cdf(0.0) - 0.5).abs() < 1e-7);
+        assert!((norm_cdf(1.959_964) - 0.975).abs() < 1e-5);
+        assert!((norm_cdf(-1.959_964) - 0.025).abs() < 1e-5);
+    }
+}

--- a/crates/ruvector-tiny-dancer-core/src/voi.rs
+++ b/crates/ruvector-tiny-dancer-core/src/voi.rs
@@ -36,6 +36,16 @@
 //! `VoI` is maximized at `a = μ`, giving the upper bound `s·φ(0) = s/√(2π)` —
 //! no estimator purchase can ever be worth more than that in utility units.
 //!
+//! # Calibrating `value_of_success`
+//!
+//! That bound is roughly `0.4σ`, so on a `[0, 1]`-scale utility with a
+//! typical `σ ≈ 0.05` an estimator is worth at most `value_of_success × 0.02`.
+//! Leaving `value_of_success` at a nominal `1.0` therefore makes any
+//! estimator costing more than about two cents permanently unpurchasable, and
+//! a gate built on it degenerates into a never-buy switch that still looks
+//! configured. Express `value_of_success` as the currency value of a correct
+//! decision, and sanity-check with [`voi_upper_bound`].
+//!
 //! # Intended call sites
 //!
 //! [`decide`] is a standalone pure function so the same primitive can gate
@@ -84,7 +94,8 @@ fn norm_cdf(x: f64) -> f64 {
     let t = 1.0 / (1.0 + 0.327_591_1 * z);
     let poly = t
         * (0.254_829_592
-            + t * (-0.284_496_736 + t * (1.421_413_741 + t * (-1.453_152_027 + t * 1.061_405_429))));
+            + t * (-0.284_496_736
+                + t * (1.421_413_741 + t * (-1.453_152_027 + t * 1.061_405_429))));
     let erf = sign * (1.0 - poly * (-z * z).exp());
     0.5 * (1.0 + erf)
 }
@@ -103,7 +114,9 @@ impl Belief {
         require_finite("belief mean", mean)?;
         require_finite("belief std_dev", std_dev)?;
         if std_dev <= 0.0 {
-            return Err(invalid(format!("belief std_dev must be > 0, got {std_dev}")));
+            return Err(invalid(format!(
+                "belief std_dev must be > 0, got {std_dev}"
+            )));
         }
         Ok(Self { mean, std_dev })
     }
@@ -201,9 +214,18 @@ pub enum VoiDecision {
 /// Standard deviation `s` of the prior-predictive posterior mean:
 /// `s² = σ⁴/(σ² + τ²)`. `τ = 0` gives `s = σ` (a perfect estimator reveals
 /// the full prior uncertainty).
+///
+/// Evaluated as `σ / √(1 + (τ/σ)²)` rather than literally: the σ⁴ form
+/// underflows to `0/0 = NaN` for small-but-legal σ (σ = 1e-200 squares to
+/// zero), and a NaN ceiling silently defeats every `cost > bound` check
+/// downstream. The ratio form is exact for the same inputs and degrades to
+/// `0` — "this estimator reveals nothing" — when τ/σ overflows.
 fn predictive_mean_std(sigma: f64, tau: f64) -> f64 {
-    let s2 = sigma * sigma;
-    (s2 * s2 / (s2 + tau * tau)).sqrt()
+    if tau == 0.0 {
+        return sigma;
+    }
+    let ratio = tau / sigma;
+    sigma / (1.0 + ratio * ratio).sqrt()
 }
 
 /// `E[max(X, alt)]` for `X ~ N(mean, std²)`.
@@ -214,7 +236,22 @@ fn expected_max(mean: f64, std: f64, alt: f64) -> f64 {
 
 /// Value of information (utility units) of purchasing one observation with
 /// noise `noise_std`, given `belief` and a known outside option `alternative`.
-/// Non-negative by construction; clamped at 0 to absorb approximation error.
+///
+/// Guaranteed finite and non-negative: negatives (approximation error) and
+/// non-finite intermediates both clamp to `0`, i.e. "not worth buying" — the
+/// safe direction, since a clamped value can only suppress a purchase.
+///
+/// # Precision
+///
+/// [`norm_cdf`] uses the Abramowitz–Stegun 7.1.26 rational approximation
+/// (absolute error ≤ 1.5e-7). In [`expected_max`] that error is scaled by
+/// `mean`, so for utilities of large magnitude the deep tail (`|z|` large,
+/// true VoI near zero) can be overestimated by orders of magnitude relative
+/// to a vanishing true value. The bias is one-directional — it can trigger a
+/// worthless purchase, never suppress a worthwhile one — and is immaterial
+/// for `[0, 1]`-scale utilities like this router's scores. Callers reusing
+/// this primitive with large-magnitude utilities should either rescale to
+/// unit range or substitute a higher-precision cdf.
 pub fn value_of_information(belief: Belief, alternative: f64, noise_std: f64) -> Result<f64> {
     require_finite("alternative", alternative)?;
     require_finite("noise_std", noise_std)?;
@@ -223,17 +260,28 @@ pub fn value_of_information(belief: Belief, alternative: f64, noise_std: f64) ->
     }
     let s = predictive_mean_std(belief.std_dev, noise_std);
     let voi = expected_max(belief.mean, s, alternative) - belief.mean.max(alternative);
-    Ok(voi.max(0.0))
+    Ok(if voi.is_finite() { voi.max(0.0) } else { 0.0 })
 }
 
 /// Upper bound on [`value_of_information`] over every possible `alternative`:
-/// `s·φ(0) = s/√(2π)`, attained at `alternative = mean`.
+/// `s·φ(0) = s/√(2π)`, attained at `alternative = mean`. No estimator
+/// purchase can be worth more than this, so it is the natural sanity check
+/// for a cost model (`if cost > bound { never purchasable }`).
+///
+/// Guaranteed finite and non-negative: a non-finite intermediate is clamped
+/// to `0`, which reports "nothing is purchasable" rather than handing a
+/// caller a NaN ceiling that makes every `cost > bound` comparison false.
 pub fn voi_upper_bound(belief: Belief, noise_std: f64) -> Result<f64> {
     require_finite("noise_std", noise_std)?;
     if noise_std < 0.0 {
         return Err(invalid(format!("noise_std must be >= 0, got {noise_std}")));
     }
-    Ok(predictive_mean_std(belief.std_dev, noise_std) * INV_SQRT_2PI)
+    let bound = predictive_mean_std(belief.std_dev, noise_std) * INV_SQRT_2PI;
+    Ok(if bound.is_finite() {
+        bound.max(0.0)
+    } else {
+        0.0
+    })
 }
 
 /// One greedy step of the index policy: evaluate every estimator's net value
@@ -245,9 +293,29 @@ pub fn voi_upper_bound(belief: Belief, noise_std: f64) -> Result<f64> {
 /// the policy routes rather than buys.
 ///
 /// The caller purchases the returned estimator, feeds its observation through
-/// [`observe`], and calls `decide` again — the posterior tightens each round
-/// (see [`observe`]), so the loop terminates: VoI shrinks toward zero while
-/// costs stay fixed.
+/// [`observe`], and calls `decide` again; the posterior tightens each round
+/// (see [`observe`]), so VoI decays toward zero while costs stay fixed.
+///
+/// # Termination
+///
+/// That decay guarantees termination **only when every estimator has strictly
+/// positive monetized cost**. [`EstimatorSpec::validate`] permits `cost == 0`
+/// and `latency_us == 0`, and a free estimator is bought for as long as VoI
+/// stays strictly positive — which, decaying geometrically, it does
+/// indefinitely (a probe ran 100,000 rounds against a free estimator and was
+/// still returning `Buy`). A caller driving the repeated-purchase protocol
+/// must therefore either require `cost > 0` or impose its own round cap. This
+/// crate's router integration is unaffected: it makes a single bounded
+/// `decide` call over a one-element ladder and never loops.
+///
+/// # Noiseless estimators
+///
+/// `decide` may return [`VoiDecision::Buy`] for a spec with `noise_std == 0`,
+/// which [`observe`] deliberately refuses — a noiseless observation *is* the
+/// exact utility, so there is no posterior left to represent. That case exits
+/// the protocol rather than continuing it: purchase the oracle, take its
+/// value as ground truth, and route on it directly without calling
+/// [`observe`].
 pub fn decide(
     belief: Belief,
     alternative: f64,
@@ -372,7 +440,9 @@ mod tests {
         #[test]
         fn voi_respects_its_upper_bound(
             mean in -10.0f64..10.0,
-            sigma in 0.01f64..5.0,
+            // Range reaches into the subnormal-σ regime that made the
+            // literal σ⁴/(σ²+τ²) form return NaN.
+            sigma in prop::sample::select(vec![1e-300f64, 1e-200, 1e-8, 0.01, 0.5, 5.0]),
             alt in -10.0f64..10.0,
             tau in 0.0f64..5.0,
         ) {
@@ -464,6 +534,22 @@ mod tests {
             decide(b, 0.5, &[slow], &config).unwrap(),
             VoiDecision::Route
         );
+    }
+
+    #[test]
+    fn tiny_sigma_never_yields_a_nan_ceiling() {
+        // Regression: the literal σ⁴/(σ²+τ²) form underflowed to 0/0 here,
+        // and a NaN bound makes every `cost > bound` guard false — the
+        // caller then buys unconditionally.
+        for sigma in [1e-300, 1e-200, 1e-160, 1e-8] {
+            let b = Belief::new(0.0, sigma).unwrap();
+            for tau in [0.0, 1e-200, 1.0] {
+                let bound = voi_upper_bound(b, tau).unwrap();
+                assert!(bound.is_finite() && bound >= 0.0, "sigma={sigma} tau={tau}");
+                let voi = value_of_information(b, 0.0, tau).unwrap();
+                assert!(voi.is_finite() && voi >= 0.0, "sigma={sigma} tau={tau}");
+            }
+        }
     }
 
     #[test]

--- a/crates/ruvector-tiny-dancer-node/src/lib.rs
+++ b/crates/ruvector-tiny-dancer-node/src/lib.rs
@@ -50,6 +50,8 @@ impl From<RouterConfig> for CoreRouterConfig {
             circuit_breaker_threshold: config.circuit_breaker_threshold.unwrap_or(5),
             enable_quantization: config.enable_quantization.unwrap_or(true),
             database_path: config.database_path,
+            // VoI escalation gate (ADR-331) is not yet exposed over NAPI.
+            voi: None,
         }
     }
 }

--- a/crates/ruvector-tiny-dancer-wasm/src/lib.rs
+++ b/crates/ruvector-tiny-dancer-wasm/src/lib.rs
@@ -69,6 +69,8 @@ impl From<RouterConfig> for CoreRouterConfig {
             circuit_breaker_threshold: config.circuit_breaker_threshold,
             enable_quantization: config.enable_quantization,
             database_path: None,
+            // VoI escalation gate (ADR-331) is not yet exposed over wasm.
+            voi: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements the PIR Wave-4 WP28 Value-of-Information routing primitive (ADR-331), after **"Pandora's AI Model Routing Box: Efficient Allocation with Costly Value Estimation"** (arXiv:2608.20316; reproduction-from-description — the paper ships no code). Part of the PIR program, epic #837.

Routing is treated as information economics: a costlier estimator (a stronger model, a verifier, a deeper retrieval pass) is **purchased only when**

```
expected_quality_gain × value_of_success  >  estimator_cost + latency × latency_price
```

## What's here

- **`ruvector_tiny_dancer_core::voi`** (475 lines): `Belief` (Gaussian prior over candidate utility), `EstimatorSpec` (cost / latency / noise), `VoiConfig`, `VoiDecision`. Closed-form Gaussian VoI via the expected-improvement integral — prior-predictive posterior-mean std `s² = σ⁴/(σ²+τ²)`, `E[max(X,a)] = a·Φ(z) + μ·(1−Φ(z)) + s·φ(z)` — derivation in the module docs. Greedy index-policy `decide()` over an estimator ladder, Bayesian `observe()` update, `voi_upper_bound() = s·φ(0)`.
- **Router integration, off by default**: `RouterConfig.voi: Option<VoiGateConfig>` with `serde(default)` — absent in every existing config, zero behavior change. When set, lightweight-vs-powerful escalation becomes an estimator purchase against the confidence threshold; invalid gates are rejected at `Router::new`.
- **Numerical discipline** (Wave-3 non-finite-bypass lesson, #888): every input crosses a finiteness-validating constructor *before* any comparison; a NaN score reaching the gate errors loudly instead of silently picking a route.
- **Standalone pub API** documented for the other intended call sites (model selection, retrieval depth, verifier calls, agent spawning, escalation) — only the router integration is wired here.

## Tests

`cargo test -p ruvector-tiny-dancer-core`: **43 passed, 0 failed** (nextest is the CI runner; not installed locally). Property tests (proptest):

- never buys when cost exceeds the closed-form VoI upper bound
- VoI ∈ [0, s·φ(0)] always
- free perfect estimator always bought (within float representability — a >30σ-distant alternative underflows VoI to exact 0 = indifference, documented)
- posterior variance monotonically non-increasing across purchase chains
- decisions deterministic for identical inputs

`cargo check --all-targets` clean for `-core`, `-node`, `-wasm` (the two downstream `From<RouterConfig>` literals gained `voi: None`; gate not yet exposed over NAPI/wasm).

## Benchmark

Criterion micro-bench `voi_decision_3_estimators`: **43.1 ns** per decision (target: sub-microsecond) — negligible against the router's µs-scale inference path.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_016QSCkKnxDjqU49NVVpWMK5