### PR TITLE
style: apply cargo fmt --all to clear repository-wide rustfmt drift

### DIFF
--- a/crates/mcp-gate/src/bin/schema_cache_bench.rs
+++ b/crates/mcp-gate/src/bin/schema_cache_bench.rs
@@ -20,7 +20,10 @@ struct Lcg(u64);
 
 impl Lcg {
     fn next(&mut self) -> u64 {
-        self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
         self.0
     }
 }

--- a/crates/mcp-gate/src/schema_cache.rs
+++ b/crates/mcp-gate/src/schema_cache.rs
@@ -75,7 +75,9 @@ pub enum SchemaCacheError {
     /// `actual` is the encoded length at the point the encoder bailed — a
     /// lower bound on the full canonical size, since encoding stops as soon
     /// as the ceiling is crossed.
-    #[error("schema too large: canonical encoding is at least {actual} bytes, ceiling is {ceiling}")]
+    #[error(
+        "schema too large: canonical encoding is at least {actual} bytes, ceiling is {ceiling}"
+    )]
     SchemaTooLarge { actual: usize, ceiling: usize },
     /// The requested assembly would exceed the configured total-bytes
     /// ceiling (guards against amplification via long orders repeating
@@ -233,9 +235,7 @@ fn compile_block(canonical: &str) -> String {
 /// Compile an ordered set of schemas from scratch, with no cache involved.
 /// This is the reference the cache's assembly must match byte-for-byte, and
 /// the cold baseline in the benchmark.
-pub fn compile_fresh(
-    values: &[&serde_json::Value],
-) -> Result<String, SchemaCacheError> {
+pub fn compile_fresh(values: &[&serde_json::Value]) -> Result<String, SchemaCacheError> {
     let mut out = String::new();
     for value in values {
         out.push_str(&compile_block(&canonicalize(value)?));
@@ -312,10 +312,7 @@ impl SchemaResourceCache {
     /// Canonicalize, identify, and (if new) compile and store the schema.
     /// Idempotent: the same content always yields the same [`ResourceId`],
     /// and a resident identity skips recompilation.
-    pub fn insert(
-        &mut self,
-        value: &serde_json::Value,
-    ) -> Result<ResourceId, SchemaCacheError> {
+    pub fn insert(&mut self, value: &serde_json::Value) -> Result<ResourceId, SchemaCacheError> {
         if self.config.capacity == 0 {
             return Err(SchemaCacheError::ZeroCapacity);
         }
@@ -375,10 +372,7 @@ impl SchemaResourceCache {
         let mut out = String::with_capacity(total);
         for id in order {
             self.tick += 1;
-            let entry = self
-                .entries
-                .get_mut(id)
-                .expect("residency validated above");
+            let entry = self.entries.get_mut(id).expect("residency validated above");
             entry.last_used = self.tick;
             out.push_str(&entry.block);
         }
@@ -446,14 +440,11 @@ mod tests {
     #[test]
     fn identity_stable_under_key_reordering_and_whitespace() {
         // Same content, different textual key order and formatting.
-        let v1: serde_json::Value = serde_json::from_str(
-            r#"{"b": [1, 2], "a": {"y": true, "x": null}}"#,
-        )
-        .unwrap();
-        let v2: serde_json::Value = serde_json::from_str(
-            "{\n  \"a\": {\"x\": null, \"y\": true},\n  \"b\": [1,2]\n}",
-        )
-        .unwrap();
+        let v1: serde_json::Value =
+            serde_json::from_str(r#"{"b": [1, 2], "a": {"y": true, "x": null}}"#).unwrap();
+        let v2: serde_json::Value =
+            serde_json::from_str("{\n  \"a\": {\"x\": null, \"y\": true},\n  \"b\": [1,2]\n}")
+                .unwrap();
         let mut cache = SchemaResourceCache::new();
         let id1 = cache.insert(&v1).unwrap();
         let id2 = cache.insert(&v2).unwrap();
@@ -502,10 +493,7 @@ mod tests {
         assert!(cache.contains(&c));
         // Assembling with the evicted identity is a loud error, not a
         // silent recompile.
-        assert_eq!(
-            cache.assemble(&[b]),
-            Err(SchemaCacheError::NotResident(b))
-        );
+        assert_eq!(cache.assemble(&[b]), Err(SchemaCacheError::NotResident(b)));
     }
 
     #[test]

--- a/crates/ruvector-agent-memory/src/arbitration.rs
+++ b/crates/ruvector-agent-memory/src/arbitration.rs
@@ -304,7 +304,9 @@ pub fn arbitrate(
 ) -> Result<ArbitrationOutcome, ArbitrationError> {
     // ── Config choke point ──────────────────────────────────────────────────
     if config.half_life_ns == 0 {
-        return Err(ArbitrationError::InvalidConfig("half_life_ns must be non-zero"));
+        return Err(ArbitrationError::InvalidConfig(
+            "half_life_ns must be non-zero",
+        ));
     }
     config.reliability.validate()?;
 
@@ -350,7 +352,9 @@ pub fn arbitrate(
                 .ok_or(ArbitrationError::UnknownObservation(*atomic))?;
             let c = obs.confidence as f64;
             if !c.is_finite() || !(0.0..=1.0).contains(&c) {
-                return Err(ArbitrationError::ConfidenceInvalid(NodeRef::Observation(*atomic)));
+                return Err(ArbitrationError::ConfidenceInvalid(NodeRef::Observation(
+                    *atomic,
+                )));
             }
             reliability = reliability.min(config.reliability.for_code(obs.source.kind.code()));
             freshness = freshness.min(freshness_of(obs.time_ns, config));
@@ -456,10 +460,7 @@ pub fn arbitrate(
     // `!(arbitrated <= bound)` sends NaN into the error path instead.
     #[allow(clippy::neg_cmp_op_on_partial_ord)]
     if !(arbitrated <= naive + 1e-9) {
-        return Err(ArbitrationError::DowngradeInvariantViolated {
-            naive,
-            arbitrated,
-        });
+        return Err(ArbitrationError::DowngradeInvariantViolated { naive, arbitrated });
     }
 
     let verdict = ArbitrationVerdict {
@@ -492,10 +493,7 @@ fn freshness_of(time_ns: u64, config: &ArbitrationConfig) -> f64 {
     (0.5f64).powf(age / config.half_life_ns as f64)
 }
 
-fn node_confidence(
-    graph: &CausalEpisodicGraph,
-    node: NodeRef,
-) -> Result<f64, ArbitrationError> {
+fn node_confidence(graph: &CausalEpisodicGraph, node: NodeRef) -> Result<f64, ArbitrationError> {
     match node {
         NodeRef::Observation(id) => graph
             .observation(id)

--- a/crates/ruvector-agent-memory/src/diagnostic.rs
+++ b/crates/ruvector-agent-memory/src/diagnostic.rs
@@ -676,8 +676,8 @@ pub fn gate_and_apply<S: WitnessSink, G: ProofGate>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ops::{LedgerState, MemoryWitnessLog};
     use crate::ledger::{AlwaysAdmitGate, TransactionalLedger};
+    use crate::ops::{LedgerState, MemoryWitnessLog};
 
     fn stage_policy(stage: MemoryStage, v: u32, strat: &str) -> MemoryPolicy {
         MemoryPolicy::new(stage.as_str(), v, stage, strat, strat.as_bytes())
@@ -706,9 +706,9 @@ mod tests {
 
     /// A trace concentrating the change on one stage (near-1.0 coverage).
     fn localizable_to(stage: MemoryStage) -> DiagnosticTrace {
-        let signals = MemoryStage::ALL.iter().map(|&s| {
-            StageSignal::new(s, if s == stage { 0.90 } else { 0.03 })
-        });
+        let signals = MemoryStage::ALL
+            .iter()
+            .map(|&s| StageSignal::new(s, if s == stage { 0.90 } else { 0.03 }));
         DiagnosticTrace::staged(0.031, signals)
     }
 
@@ -726,8 +726,14 @@ mod tests {
         assert_eq!(base.get(MemoryStage::Retrieval).strategy(), "hnsw");
         // New set carries the superseding artifact; other stages unchanged.
         assert_eq!(mutated.get(MemoryStage::Retrieval).version(), 2);
-        assert_eq!(mutated.get(MemoryStage::Retrieval).strategy(), "graph-traversal");
-        assert_eq!(mutated.get(MemoryStage::Ingestion), base.get(MemoryStage::Ingestion));
+        assert_eq!(
+            mutated.get(MemoryStage::Retrieval).strategy(),
+            "graph-traversal"
+        );
+        assert_eq!(
+            mutated.get(MemoryStage::Ingestion),
+            base.get(MemoryStage::Ingestion)
+        );
         // Distinct content hashes = distinct diagnosable identities.
         assert_ne!(
             base.get(MemoryStage::Retrieval).content_hash(),
@@ -763,7 +769,8 @@ mod tests {
         }
 
         // Governed application: add + proof-gated accept through the WP4 ledger.
-        let mut ledger = TransactionalLedger::new(MemoryWitnessLog::default(), AlwaysAdmitGate::default());
+        let mut ledger =
+            TransactionalLedger::new(MemoryWitnessLog::default(), AlwaysAdmitGate::default());
         let applied = gate_and_apply(
             &mut ledger,
             &candidate,
@@ -774,7 +781,9 @@ mod tests {
         )
         .unwrap();
 
-        let id = applied.ledger_entry.expect("promotion creates a ledger entry");
+        let id = applied
+            .ledger_entry
+            .expect("promotion creates a ledger entry");
         assert!(applied.decision.is_promoted());
         // The promoted artifact is Accepted knowledge.
         assert_eq!(ledger.state_of(id), Some(LedgerState::Accepted));
@@ -866,7 +875,9 @@ mod tests {
     fn result_only_log_is_non_diagnosable_and_blocks() {
         // Even with paired improvement AND no protected regression, a
         // result-only log cannot localize a stage — the paper's 0% baseline.
-        let result_only = DiagnosticTrace::ResultOnly { outcome_delta: 0.031 };
+        let result_only = DiagnosticTrace::ResultOnly {
+            outcome_delta: 0.031,
+        };
         assert_eq!(diagnostic_coverage(&result_only), 0.0);
         assert_eq!(localized_stage(&result_only), None);
 
@@ -880,7 +891,8 @@ mod tests {
         );
 
         let candidate = MemoryPolicy::retrieval(RetrievalStrategy::Temporal, 2, b"temporal");
-        let mut ledger = TransactionalLedger::new(MemoryWitnessLog::default(), AlwaysAdmitGate::default());
+        let mut ledger =
+            TransactionalLedger::new(MemoryWitnessLog::default(), AlwaysAdmitGate::default());
         let applied =
             apply_gated_promotion(&mut ledger, &candidate, decision, "wp22-gate").unwrap();
         assert!(applied.ledger_entry.is_none());
@@ -918,9 +930,10 @@ mod tests {
 
         // Retained Pending (monitored), never accepted.
         let mut ledger = TransactionalLedger::unguarded();
-        let applied =
-            apply_gated_promotion(&mut ledger, &bm25, decision, "wp22-gate").unwrap();
-        let id = applied.ledger_entry.expect("monitored flag is retained as a candidate");
+        let applied = apply_gated_promotion(&mut ledger, &bm25, decision, "wp22-gate").unwrap();
+        let id = applied
+            .ledger_entry
+            .expect("monitored flag is retained as a candidate");
         assert_eq!(ledger.state_of(id), Some(LedgerState::Pending));
         assert!(ledger.entries_in(LedgerState::Accepted).is_empty());
     }
@@ -971,7 +984,11 @@ mod tests {
         let unattributed = DiagnosticTrace::staged(
             0.1,
             [
-                StageSignal { stage: MemoryStage::Ingestion, attributed: false, localization: 5.0 },
+                StageSignal {
+                    stage: MemoryStage::Ingestion,
+                    attributed: false,
+                    localization: 5.0,
+                },
                 StageSignal::new(MemoryStage::Retrieval, 0.9),
             ],
         );

--- a/crates/ruvector-agent-memory/src/fusion.rs
+++ b/crates/ruvector-agent-memory/src/fusion.rs
@@ -113,7 +113,11 @@ impl std::fmt::Display for FusionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FusionError::SignatureInvalid(id) => {
-                write!(f, "observation {} failed signature verification", id.to_hex())
+                write!(
+                    f,
+                    "observation {} failed signature verification",
+                    id.to_hex()
+                )
             }
             FusionError::TenantMismatch { expected, got } => write!(
                 f,
@@ -405,7 +409,6 @@ impl CausalEpisodicGraph {
                 .ok_or(FusionError::UnknownCluster(id)),
         }
     }
-
 }
 
 #[cfg(test)]
@@ -444,7 +447,15 @@ mod tests {
     fn cross_tenant_observation_rejected() {
         let kp = Ed25519Keypair::generate(&mut OsRng);
         let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
-        let foreign = signed(&kp, SourceKind::AgentObservation, "a", "globex", 0.9, vec![], b"x");
+        let foreign = signed(
+            &kp,
+            SourceKind::AgentObservation,
+            "a",
+            "globex",
+            0.9,
+            vec![],
+            b"x",
+        );
         match graph.ingest(foreign) {
             Err(FusionError::TenantMismatch { .. }) => {}
             other => panic!("expected TenantMismatch, got {other:?}"),
@@ -456,7 +467,15 @@ mod tests {
         let kp = Ed25519Keypair::generate(&mut OsRng);
         let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
         let ghost = ObservationId([9u8; 32]);
-        let child = signed(&kp, SourceKind::AgentObservation, "a", "acme", 0.8, vec![ghost], b"c");
+        let child = signed(
+            &kp,
+            SourceKind::AgentObservation,
+            "a",
+            "acme",
+            0.8,
+            vec![ghost],
+            b"c",
+        );
         match graph.ingest(child) {
             Err(FusionError::UnresolvedParent { .. }) => {}
             other => panic!("expected UnresolvedParent, got {other:?}"),

--- a/crates/ruvector-agent-memory/src/lib.rs
+++ b/crates/ruvector-agent-memory/src/lib.rs
@@ -71,10 +71,10 @@ pub use fusion::{CausalEpisodicGraph, ClusterId, FusedCluster, FusionError, Node
 #[cfg(feature = "proof-gate")]
 pub use ledger::WriteGateAdapter;
 pub use ledger::{replay_history, AlwaysAdmitGate, LedgerEntry, ProofGate, TransactionalLedger};
+pub use memory::{MemoryEntry, MemoryStore, SearchResult};
 pub use observation::{
     AtomicObservation, ObservationError, ObservationId, ObservationSource, SourceKind, Tenant,
 };
-pub use memory::{MemoryEntry, MemoryStore, SearchResult};
 pub use ops::{
     AcceptanceReceipt, EvidenceGrade, LedgerError, LedgerState, LedgerWitnessRecord, MemoryOp,
     MemoryWitnessLog, NoopWitnessSink, TransitionKind, TransitionRecord, WitnessSink,

--- a/crates/ruvector-agent-memory/src/main.rs
+++ b/crates/ruvector-agent-memory/src/main.rs
@@ -373,7 +373,11 @@ fn run_arbitration_bench() {
     };
 
     let roots: Vec<ObservationId> = (0..N_ROOTS)
-        .map(|i| graph.ingest(sign(&(i as u32).to_le_bytes(), 0, vec![], &keypair)).unwrap())
+        .map(|i| {
+            graph
+                .ingest(sign(&(i as u32).to_le_bytes(), 0, vec![], &keypair))
+                .unwrap()
+        })
         .collect();
     // Per-root latest descendant, so derivation chains deepen over time.
     let mut latest: Vec<ObservationId> = roots.clone();
@@ -382,7 +386,12 @@ fn run_arbitration_bench() {
         let r = rng.gen_range(0..N_ROOTS);
         let parent = latest[r];
         let id = graph
-            .ingest(sign(&(1_000_000 + i as u32).to_le_bytes(), 1 + i as u64, vec![parent], &keypair))
+            .ingest(sign(
+                &(1_000_000 + i as u32).to_le_bytes(),
+                1 + i as u64,
+                vec![parent],
+                &keypair,
+            ))
             .unwrap();
         latest[r] = id;
         memories.push(NodeRef::Observation(id));
@@ -411,7 +420,10 @@ fn run_arbitration_bench() {
     let arb_us = t1.elapsed().as_micros();
     let verdict = outcome.verdict();
 
-    println!("  Memories        : {} ({} origins, {} derived)", N_DERIVED, N_ROOTS, N_DERIVED);
+    println!(
+        "  Memories        : {} ({} origins, {} derived)",
+        N_DERIVED, N_ROOTS, N_DERIVED
+    );
     println!("  Naive vote      : {naive:.1} supporting confidence ({naive_us} µs)");
     println!(
         "  Arbitrated      : {:.1} effective confidence across {} lineages ({} µs)",

--- a/crates/ruvector-agent-memory/src/observation.rs
+++ b/crates/ruvector-agent-memory/src/observation.rs
@@ -306,7 +306,10 @@ mod tests {
         assert!(obs.verify());
 
         obs.payload = b"forged".to_vec();
-        assert!(!obs.verify(), "post-signing mutation must break the signature");
+        assert!(
+            !obs.verify(),
+            "post-signing mutation must break the signature"
+        );
     }
 
     #[test]

--- a/crates/ruvector-agent-memory/tests/arbitration.rs
+++ b/crates/ruvector-agent-memory/tests/arbitration.rs
@@ -75,7 +75,15 @@ fn ten_memories_one_source_is_one_lineage() {
     for i in 0..10u8 {
         let parents = if i % 2 == 0 { vec![root] } else { vec![prev] };
         let id = graph
-            .ingest(signed(&keypair, "agent", "acme", 0.9, 10 + i as u64, parents, &[i]))
+            .ingest(signed(
+                &keypair,
+                "agent",
+                "acme",
+                0.9,
+                10 + i as u64,
+                parents,
+                &[i],
+            ))
             .unwrap();
         derived.push(NodeRef::Observation(id));
         prev = id;
@@ -100,7 +108,15 @@ fn ten_memories_one_source_is_one_lineage() {
         .map(|i| {
             NodeRef::Observation(
                 graph2
-                    .ingest(signed(&keypair, "witness", "acme", 0.9, 10, vec![], &[i, 0xff]))
+                    .ingest(signed(
+                        &keypair,
+                        "witness",
+                        "acme",
+                        0.9,
+                        10,
+                        vec![],
+                        &[i, 0xff],
+                    ))
                     .unwrap(),
             )
         })
@@ -124,7 +140,11 @@ fn mixed_ancestry_clusters_and_bridges() {
     let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
 
     let roots: Vec<ObservationId> = (0..3u8)
-        .map(|i| graph.ingest(signed(&keypair, "origin", "acme", 0.8, 0, vec![], &[i])).unwrap())
+        .map(|i| {
+            graph
+                .ingest(signed(&keypair, "origin", "acme", 0.8, 0, vec![], &[i]))
+                .unwrap()
+        })
         .collect();
 
     // 4 memories from root 0, 3 from root 1, 3 from root 2.
@@ -132,7 +152,15 @@ fn mixed_ancestry_clusters_and_bridges() {
     for (r, count) in roots.iter().zip([4u8, 3, 3]) {
         for i in 0..count {
             let id = graph
-                .ingest(signed(&keypair, "agent", "acme", 0.8, 5, vec![*r], &[i, r.0[0]]))
+                .ingest(signed(
+                    &keypair,
+                    "agent",
+                    "acme",
+                    0.8,
+                    5,
+                    vec![*r],
+                    &[i, r.0[0]],
+                ))
                 .unwrap();
             memories.push(NodeRef::Observation(id));
         }
@@ -142,7 +170,15 @@ fn mixed_ancestry_clusters_and_bridges() {
 
     // A bridging memory citing roots 0 and 1 merges them into one lineage.
     let bridge = graph
-        .ingest(signed(&keypair, "agent", "acme", 0.8, 6, vec![roots[0], roots[1]], b"bridge"))
+        .ingest(signed(
+            &keypair,
+            "agent",
+            "acme",
+            0.8,
+            6,
+            vec![roots[0], roots[1]],
+            b"bridge",
+        ))
         .unwrap();
     let mut with_bridge = memories.clone();
     with_bridge.push(NodeRef::Observation(bridge));
@@ -230,7 +266,9 @@ fn nan_confidence_rejected_at_choke_point() {
     obs.confidence = f32::NAN;
     // Re-sign the mutated content so it verifies and ingests cleanly.
     obs.signature = ed25519_sign(&keypair.secret_key(), &obs.id().0);
-    let id = graph.ingest(obs).expect("ingest does not range-check confidence");
+    let id = graph
+        .ingest(obs)
+        .expect("ingest does not range-check confidence");
 
     let err = arbitrate(&graph, &[NodeRef::Observation(id)], &config()).unwrap_err();
     match err {
@@ -246,11 +284,19 @@ fn cross_tenant_node_is_unknown() {
     let keypair = kp();
     let mut acme = CausalEpisodicGraph::new(Tenant::new("acme"));
     let mut globex = CausalEpisodicGraph::new(Tenant::new("globex"));
-    let a = acme.ingest(signed(&keypair, "a", "acme", 0.9, 0, vec![], b"a")).unwrap();
-    let g = globex.ingest(signed(&keypair, "g", "globex", 0.9, 0, vec![], b"g")).unwrap();
+    let a = acme
+        .ingest(signed(&keypair, "a", "acme", 0.9, 0, vec![], b"a"))
+        .unwrap();
+    let g = globex
+        .ingest(signed(&keypair, "g", "globex", 0.9, 0, vec![], b"g"))
+        .unwrap();
 
-    let err = arbitrate(&acme, &[NodeRef::Observation(a), NodeRef::Observation(g)], &config())
-        .unwrap_err();
+    let err = arbitrate(
+        &acme,
+        &[NodeRef::Observation(a), NodeRef::Observation(g)],
+        &config(),
+    )
+    .unwrap_err();
     match err {
         ArbitrationError::UnknownObservation(id) => assert_eq!(id, g),
         other => panic!("expected UnknownObservation, got {other:?}"),
@@ -263,11 +309,15 @@ fn cross_tenant_node_is_unknown() {
 fn insufficient_independent_evidence_names_over_represented_roots() {
     let keypair = kp();
     let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
-    let root = graph.ingest(signed(&keypair, "o", "acme", 0.9, 0, vec![], b"r")).unwrap();
+    let root = graph
+        .ingest(signed(&keypair, "o", "acme", 0.9, 0, vec![], b"r"))
+        .unwrap();
     let memories: Vec<NodeRef> = (0..5u8)
         .map(|i| {
             NodeRef::Observation(
-                graph.ingest(signed(&keypair, "a", "acme", 0.9, 1, vec![root], &[i])).unwrap(),
+                graph
+                    .ingest(signed(&keypair, "a", "acme", 0.9, 1, vec![root], &[i]))
+                    .unwrap(),
             )
         })
         .collect();
@@ -294,7 +344,9 @@ fn insufficient_independent_evidence_names_over_represented_roots() {
 fn invalid_config_and_empty_set_rejected() {
     let keypair = kp();
     let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
-    let id = graph.ingest(signed(&keypair, "a", "acme", 0.9, 0, vec![], b"x")).unwrap();
+    let id = graph
+        .ingest(signed(&keypair, "a", "acme", 0.9, 0, vec![], b"x"))
+        .unwrap();
     let node = [NodeRef::Observation(id)];
 
     let mut cfg = config();
@@ -331,7 +383,9 @@ fn content_copying_yields_no_correlation_downgrade_under_default_reliability() {
 
     // One genuine origin, then 20 agents asserting the same claim with no
     // declared derivation — the astroturfing shape the module cannot detect.
-    graph.ingest(signed(&keypair, "origin", "acme", 0.9, 0, vec![], b"rumor")).unwrap();
+    graph
+        .ingest(signed(&keypair, "origin", "acme", 0.9, 0, vec![], b"rumor"))
+        .unwrap();
     let copies: Vec<NodeRef> = (0..20u8)
         .map(|i| {
             NodeRef::Observation(
@@ -373,8 +427,12 @@ fn fuse_rejects_non_finite_member_confidence() {
     let mut poisoned = signed(&keypair, "evil", "acme", 0.5, 0, vec![], b"nan");
     poisoned.confidence = f32::NAN;
     poisoned.signature = ed25519_sign(&keypair.secret_key(), &poisoned.id().0);
-    let bad = graph.ingest(poisoned).expect("ingest does not range-check confidence");
-    let good = graph.ingest(signed(&keypair, "ok", "acme", 0.9, 0, vec![], b"ok")).unwrap();
+    let bad = graph
+        .ingest(poisoned)
+        .expect("ingest does not range-check confidence");
+    let good = graph
+        .ingest(signed(&keypair, "ok", "acme", 0.9, 0, vec![], b"ok"))
+        .unwrap();
 
     // Lone NaN member: must not become +inf.
     assert!(matches!(
@@ -383,7 +441,10 @@ fn fuse_rejects_non_finite_member_confidence() {
     ));
     // NaN alongside a valid member: must not silently vanish into 0.9.
     assert!(matches!(
-        graph.fuse(&[NodeRef::Observation(bad), NodeRef::Observation(good)], "mixed"),
+        graph.fuse(
+            &[NodeRef::Observation(bad), NodeRef::Observation(good)],
+            "mixed"
+        ),
         Err(FusionError::MemberConfidenceInvalid(_))
     ));
     // A well-formed fusion still succeeds and keeps the weakest link.
@@ -397,7 +458,9 @@ fn fuse_rejects_non_finite_member_confidence() {
 fn fused_cluster_shares_lineage_with_its_origins() {
     let keypair = kp();
     let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
-    let root = graph.ingest(signed(&keypair, "o", "acme", 0.9, 0, vec![], b"r")).unwrap();
+    let root = graph
+        .ingest(signed(&keypair, "o", "acme", 0.9, 0, vec![], b"r"))
+        .unwrap();
     let child = graph
         .ingest(signed(&keypair, "a", "acme", 0.8, 1, vec![root], b"c"))
         .unwrap();

--- a/crates/ruvector-agent-memory/tests/atomic_observation_fusion.rs
+++ b/crates/ruvector-agent-memory/tests/atomic_observation_fusion.rs
@@ -8,11 +8,11 @@
 //! explicitly distinct from the unrelated `memfuse/memfuse` OSS project.
 
 use rand::rngs::OsRng;
+use ruvector_agent_memory::ops::{LedgerState, MemoryWitnessLog};
 use ruvector_agent_memory::{
     AlwaysAdmitGate, AtomicObservation, CausalEpisodicGraph, FusionError, NodeRef, ObservationId,
     ObservationSource, SourceKind, Tenant, TransactionalLedger,
 };
-use ruvector_agent_memory::ops::{LedgerState, MemoryWitnessLog};
 use rvf_types::Ed25519Keypair;
 
 /// Sign an observation from a fresh per-source keypair (each source authenticates
@@ -64,7 +64,14 @@ fn atomic_observation_signature_round_trip() {
 fn multi_source_fusion_into_graph() {
     // Three heterogeneous source kinds converging into one tenant's graph.
     let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
-    let rf = observe(SourceKind::RuViewRf, "rf-antenna-2", "acme", 0.80, vec![], b"rf-burst");
+    let rf = observe(
+        SourceKind::RuViewRf,
+        "rf-antenna-2",
+        "acme",
+        0.80,
+        vec![],
+        b"rf-burst",
+    );
     let net = observe(
         SourceKind::NetworkTelemetry,
         "netprobe-7",
@@ -109,9 +116,30 @@ fn multi_source_fusion_into_graph() {
 fn provenance_resolves_derived_node_to_atomic_sources() {
     let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
 
-    let rf = observe(SourceKind::RuViewRf, "rf-1", "acme", 0.6, vec![], b"rf-evidence");
-    let net = observe(SourceKind::NetworkTelemetry, "net-1", "acme", 0.9, vec![], b"net-evidence");
-    let user = observe(SourceKind::UserActivity, "user-1", "acme", 0.8, vec![], b"user-evidence");
+    let rf = observe(
+        SourceKind::RuViewRf,
+        "rf-1",
+        "acme",
+        0.6,
+        vec![],
+        b"rf-evidence",
+    );
+    let net = observe(
+        SourceKind::NetworkTelemetry,
+        "net-1",
+        "acme",
+        0.9,
+        vec![],
+        b"net-evidence",
+    );
+    let user = observe(
+        SourceKind::UserActivity,
+        "user-1",
+        "acme",
+        0.8,
+        vec![],
+        b"user-evidence",
+    );
 
     let rf_id = graph.ingest(rf).unwrap();
     let net_id = graph.ingest(net).unwrap();
@@ -133,7 +161,9 @@ fn provenance_resolves_derived_node_to_atomic_sources() {
         .unwrap();
 
     // Provenance of the derived node B is exactly the three atomic sources.
-    let provenance = graph.resolve_provenance(NodeRef::Cluster(cluster_b)).unwrap();
+    let provenance = graph
+        .resolve_provenance(NodeRef::Cluster(cluster_b))
+        .unwrap();
     let expected: std::collections::BTreeSet<ObservationId> =
         [rf_id, net_id, user_id].into_iter().collect();
     assert_eq!(
@@ -150,7 +180,9 @@ fn provenance_resolves_derived_node_to_atomic_sources() {
     assert_eq!(graph.observation(rf_id).unwrap().payload, b"rf-evidence");
 
     // Provenance of an intermediate cluster is its two atomic sources only.
-    let prov_a = graph.resolve_provenance(NodeRef::Cluster(cluster_a)).unwrap();
+    let prov_a = graph
+        .resolve_provenance(NodeRef::Cluster(cluster_a))
+        .unwrap();
     assert_eq!(prov_a, [rf_id, net_id].into_iter().collect());
 }
 
@@ -158,7 +190,14 @@ fn provenance_resolves_derived_node_to_atomic_sources() {
 fn confidence_and_tenant_carried_through_fusion() {
     let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
     let a = observe(SourceKind::RuViewRf, "rf", "acme", 0.9, vec![], b"a");
-    let b = observe(SourceKind::NetworkTelemetry, "net", "acme", 0.4, vec![], b"b");
+    let b = observe(
+        SourceKind::NetworkTelemetry,
+        "net",
+        "acme",
+        0.4,
+        vec![],
+        b"b",
+    );
     let c = observe(SourceKind::UserActivity, "user", "acme", 0.7, vec![], b"c");
 
     let a_id = graph.ingest(a).unwrap();
@@ -186,7 +225,14 @@ fn confidence_and_tenant_carried_through_fusion() {
 #[test]
 fn tampered_observation_is_rejected_at_ingest() {
     let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
-    let mut obs = observe(SourceKind::AgentObservation, "a", "acme", 0.9, vec![], b"authentic");
+    let mut obs = observe(
+        SourceKind::AgentObservation,
+        "a",
+        "acme",
+        0.9,
+        vec![],
+        b"authentic",
+    );
     assert!(obs.verify());
 
     // A compromised or malfunctioning source flips the evidence after signing.
@@ -196,7 +242,11 @@ fn tampered_observation_is_rejected_at_ingest() {
         Err(FusionError::SignatureInvalid(_)) => {}
         other => panic!("tampered observation must be rejected, got {other:?}"),
     }
-    assert_eq!(graph.observation_count(), 0, "nothing tampered enters the graph");
+    assert_eq!(
+        graph.observation_count(),
+        0,
+        "nothing tampered enters the graph"
+    );
 }
 
 /// ADR-320 §3 transactional integrity: an observation entering memory is a
@@ -205,9 +255,17 @@ fn tampered_observation_is_rejected_at_ingest() {
 #[test]
 fn governed_ingest_composes_with_wp4_ledger() {
     let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
-    let mut ledger = TransactionalLedger::new(MemoryWitnessLog::default(), AlwaysAdmitGate::default());
+    let mut ledger =
+        TransactionalLedger::new(MemoryWitnessLog::default(), AlwaysAdmitGate::default());
 
-    let parent = observe(SourceKind::RuViewRf, "rf", "acme", 0.9, vec![], b"parent-evidence");
+    let parent = observe(
+        SourceKind::RuViewRf,
+        "rf",
+        "acme",
+        0.9,
+        vec![],
+        b"parent-evidence",
+    );
     let (parent_id, parent_entry) = graph
         .ingest_governed(parent, &mut ledger, "fusion-layer")
         .unwrap();
@@ -232,7 +290,10 @@ fn governed_ingest_composes_with_wp4_ledger() {
     assert_eq!(graph.ledger_id(child_id), Some(child_entry));
 
     // The causal parent became a ledger dependency edge.
-    assert_eq!(ledger.entry(child_entry).unwrap().depends_on, vec![parent_entry]);
+    assert_eq!(
+        ledger.entry(child_entry).unwrap().depends_on,
+        vec![parent_entry]
+    );
 
     // Witness chain over the governed transitions is intact and non-empty.
     assert!(ledger.witness_sink().verify_chain());
@@ -241,7 +302,10 @@ fn governed_ingest_composes_with_wp4_ledger() {
     // Provenance still resolves through the governed graph.
     let cluster = graph
         .fuse(
-            &[NodeRef::Observation(parent_id), NodeRef::Observation(child_id)],
+            &[
+                NodeRef::Observation(parent_id),
+                NodeRef::Observation(child_id),
+            ],
             "lineage",
         )
         .unwrap();
@@ -256,13 +320,22 @@ fn governed_ingest_composes_with_wp4_ledger() {
 #[test]
 fn deep_fuse_chain_provenance_is_depth_safe() {
     let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
-    let obs = observe(SourceKind::RuViewRf, "rf", "acme", 0.5, vec![], b"root-evidence");
+    let obs = observe(
+        SourceKind::RuViewRf,
+        "rf",
+        "acme",
+        0.5,
+        vec![],
+        b"root-evidence",
+    );
     let obs_id = graph.ingest(obs).unwrap();
 
     // 200_000 levels deep — far past what the recursive version could survive,
     // but linear and fast iteratively.
     const DEPTH: usize = 200_000;
-    let mut current = graph.fuse(&[NodeRef::Observation(obs_id)], "level-0").unwrap();
+    let mut current = graph
+        .fuse(&[NodeRef::Observation(obs_id)], "level-0")
+        .unwrap();
     for level in 1..DEPTH {
         current = graph
             .fuse(&[NodeRef::Cluster(current)], format!("level-{level}"))
@@ -280,7 +353,8 @@ fn deep_fuse_chain_provenance_is_depth_safe() {
 #[test]
 fn governed_ingest_rejects_ungoverned_parent() {
     let mut graph = CausalEpisodicGraph::new(Tenant::new("acme"));
-    let mut ledger = TransactionalLedger::new(MemoryWitnessLog::default(), AlwaysAdmitGate::default());
+    let mut ledger =
+        TransactionalLedger::new(MemoryWitnessLog::default(), AlwaysAdmitGate::default());
 
     // Parent admitted on the pure path (no ledger entry)...
     let parent = observe(SourceKind::RuViewRf, "rf", "acme", 0.9, vec![], b"p");

--- a/crates/ruvector-bet4-ivf-bench/examples/ivf_pruning_sweep.rs
+++ b/crates/ruvector-bet4-ivf-bench/examples/ivf_pruning_sweep.rs
@@ -40,7 +40,10 @@ fn main() {
     let t = Instant::now();
     let corpus8 = project_topm(&corpus, 8, 60);
     println!("# PCA done in {:?}\n", t.elapsed());
-    run_regime("PCA-8 (low-dim control — bound should be TIGHT, B&B should WIN)", &corpus8);
+    run_regime(
+        "PCA-8 (low-dim control — bound should be TIGHT, B&B should WIN)",
+        &corpus8,
+    );
 }
 
 fn run_regime(label: &str, corpus: &[Vec<f32>]) {
@@ -87,15 +90,21 @@ fn run_regime(label: &str, corpus: &[Vec<f32>]) {
         let eval_ratio = plain.evals / bnb_skip.evals.max(1.0);
         let wall_ratio = plain.wall_ns as f64 / bnb_skip.wall_ns.max(1) as f64;
 
-        println!("\n## nclusters={nc_eff}  (build {build:?})  exact-regime prune={:.1}%", prune_frac * 100.0);
+        println!(
+            "\n## nclusters={nc_eff}  (build {build:?})  exact-regime prune={:.1}%",
+            prune_frac * 100.0
+        );
         print_row("plain nprobe   (incumbent)", &plain);
         print_row("B&B  LB-order  (BET-2 kernel)", &bnb_lb);
         print_row("B&B  steelman  (cdist+LB-skip)", &bnb_skip);
-        println!(
-            "   steelman vs incumbent: eval {eval_ratio:.2}x   wall {wall_ratio:.2}x"
-        );
+        println!("   steelman vs incumbent: eval {eval_ratio:.2}x   wall {wall_ratio:.2}x");
 
-        cells.push(Cell { nc: nc_eff, eval_ratio, wall_ratio, prune_frac });
+        cells.push(Cell {
+            nc: nc_eff,
+            eval_ratio,
+            wall_ratio,
+            prune_frac,
+        });
     }
 
     verdict(label, &cells);
@@ -137,7 +146,12 @@ fn matched<F>(
 where
     F: Fn(&[f32], usize) -> (Vec<usize>, usize),
 {
-    let mut last = Matched { knob: 0, recall: 0.0, evals: 0.0, wall_ns: 0 };
+    let mut last = Matched {
+        knob: 0,
+        recall: 0.0,
+        evals: 0.0,
+        wall_ns: 0,
+    };
     for &knob in grid {
         let t = Instant::now();
         let mut rec = 0.0;
@@ -178,8 +192,12 @@ fn ids(res: &[SearchResult]) -> Vec<usize> {
 }
 
 fn verdict(label: &str, cells: &[Cell]) {
-    let all_win = cells.iter().all(|c| c.eval_ratio >= 2.0 && c.wall_ratio > 1.0);
-    let any_kill = cells.iter().any(|c| c.eval_ratio < 1.5 || c.wall_ratio < 1.0);
+    let all_win = cells
+        .iter()
+        .all(|c| c.eval_ratio >= 2.0 && c.wall_ratio > 1.0);
+    let any_kill = cells
+        .iter()
+        .any(|c| c.eval_ratio < 1.5 || c.wall_ratio < 1.0);
     let v = if all_win {
         "WIN (≥2× evals AND wall-clock win across all nclusters)"
     } else if any_kill {
@@ -191,7 +209,10 @@ fn verdict(label: &str, cells: &[Cell]) {
     for c in cells {
         println!(
             "      nclusters={:<5} steelman eval={:.2}x wall={:.2}x  exact-prune={:.1}%",
-            c.nc, c.eval_ratio, c.wall_ratio, c.prune_frac * 100.0
+            c.nc,
+            c.eval_ratio,
+            c.wall_ratio,
+            c.prune_frac * 100.0
         );
     }
     println!("      => {v}");

--- a/crates/ruvector-bet4-ivf-bench/examples/pq_pruning_sweep.rs
+++ b/crates/ruvector-bet4-ivf-bench/examples/pq_pruning_sweep.rs
@@ -53,8 +53,7 @@ fn main() {
 
     // Track, per nclusters, the verdict per scale to find the crossover and the gate.
     // (nclusters, [(N, full_win, best_ratio)]).
-    let mut win_at: Vec<PerNcVerdicts> =
-        NCLUSTERS.iter().map(|&nc| (nc, Vec::new())).collect();
+    let mut win_at: Vec<PerNcVerdicts> = NCLUSTERS.iter().map(|&nc| (nc, Vec::new())).collect();
 
     for &n_req in &scales {
         let corpus = match load_feat_csv(&data, n_req) {
@@ -72,7 +71,10 @@ fn main() {
             .iter()
             .map(|&q| brute_force_topk(&corpus, &corpus[q], K))
             .collect();
-        println!("════════ N={n} dim={dim}  (truth in {:?}) ════════", t_truth.elapsed());
+        println!(
+            "════════ N={n} dim={dim}  (truth in {:?}) ════════",
+            t_truth.elapsed()
+        );
 
         for (nc_i, &nc) in NCLUSTERS.iter().enumerate() {
             let t_b = Instant::now();
@@ -205,12 +207,10 @@ fn main() {
     let scales_ge_50k: Vec<usize> = scales.iter().copied().filter(|&n| n >= 50_000).collect();
     let mut any_full_win = false;
     for &n in &scales_ge_50k {
-        let all_nc_win = NCLUSTERS.iter().enumerate().all(|(i, _)| {
-            win_at[i]
-                .1
-                .iter()
-                .any(|&(nn, win, _)| nn == n && win)
-        });
+        let all_nc_win = NCLUSTERS
+            .iter()
+            .enumerate()
+            .all(|(i, _)| win_at[i].1.iter().any(|&(nn, win, _)| nn == n && win));
         if all_nc_win {
             any_full_win = true;
             println!("  N={n}: WIN at ALL nclusters → gate WIN condition met");
@@ -232,7 +232,9 @@ fn main() {
 
 /// Geometric-ish nprobe grid up to `nc`, dense at the low end where the tuned optimum lives.
 fn nprobe_grid(nc: usize) -> Vec<usize> {
-    let mut g = vec![1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 128, 192, 256, 384, 512, 768];
+    let mut g = vec![
+        1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 128, 192, 256, 384, 512, 768,
+    ];
     g.push(nc);
     g.retain(|&x| x <= nc);
     g.sort_unstable();

--- a/crates/ruvector-bet4-ivf-bench/src/pq.rs
+++ b/crates/ruvector-bet4-ivf-bench/src/pq.rs
@@ -128,7 +128,13 @@ impl PqIvf {
         max_iter: usize,
         seed: u64,
     ) -> Self {
-        Self::from_parts(&build_ivf(corpus, nclusters, max_iter, seed), corpus, m, max_iter, seed)
+        Self::from_parts(
+            &build_ivf(corpus, nclusters, max_iter, seed),
+            corpus,
+            m,
+            max_iter,
+            seed,
+        )
     }
 
     /// Construct from a pre-built shared [`IvfParts`] (skips re-clustering) and train the `m`-sub
@@ -159,7 +165,8 @@ impl PqIvf {
             let hi = lo + sub;
             let subvecs: Vec<Vec<f32>> = corpus.iter().map(|v| v[lo..hi].to_vec()).collect();
             let kc_pq = PQ_CENTROIDS.min(n).max(1);
-            let (subcentroids, subassign) = kmeans::train(&subvecs, kc_pq, max_iter, seed + 1 + j as u64);
+            let (subcentroids, subassign) =
+                kmeans::train(&subvecs, kc_pq, max_iter, seed + 1 + j as u64);
             for (code_row, &c) in codes.iter_mut().zip(subassign.iter()) {
                 code_row[j] = c as u8;
             }

--- a/crates/ruvector-bet4-ivf-bench/tests/pq_gate.rs
+++ b/crates/ruvector-bet4-ivf-bench/tests/pq_gate.rs
@@ -55,7 +55,11 @@ fn pq_full_rerank_is_exact() {
         let (res, cost) = pq.search_adc_rerank(&corpus[q], k, nc, n);
         let got: Vec<usize> = res.iter().map(|r| r.id).collect();
         acc += recall_at_k(&truth, &got, k);
-        assert_eq!(cost.rerank, cost.adc_members.min(n), "full pool must re-rank all scanned");
+        assert_eq!(
+            cost.rerank,
+            cost.adc_members.min(n),
+            "full pool must re-rank all scanned"
+        );
     }
     let recall = acc / nq as f64;
     assert!(
@@ -96,5 +100,8 @@ fn early_abandon_matches_full_l2() {
     );
     // Early abandonment can never touch more than every dim of every scanned member.
     let dim = corpus[0].len();
-    assert!(dims_ab <= members * dim, "abandon cannot exceed a full scan");
+    assert!(
+        dims_ab <= members * dim,
+        "abandon cannot exceed a full scan"
+    );
 }

--- a/crates/ruvllm/src/kv_migration/tests.rs
+++ b/crates/ruvllm/src/kv_migration/tests.rs
@@ -286,7 +286,10 @@ fn degenerate_pairs_in_mixed_validation_score_as_failures() {
     let report = gate.assess(&mapper).unwrap();
     assert_eq!(report.decision, GateDecision::Reprefill);
     let degen = &report.layers[2];
-    assert_eq!(degen.key_cosine, -1.0, "degenerate cosine must be a failure");
+    assert_eq!(
+        degen.key_cosine, -1.0,
+        "degenerate cosine must be a failure"
+    );
     assert_eq!(degen.value_cosine, -1.0);
     assert!(degen.key_relative_error.is_infinite());
     assert!(degen.value_relative_error.is_infinite());
@@ -337,8 +340,7 @@ fn dim_mismatched_validation_is_explicitly_rejected() {
 #[test]
 fn from_flat_dimension_overflow_is_rejected() {
     let flat = vec![0.0f32; 8];
-    let err =
-        LayerKvTensor::from_flat(&flat, &flat, (usize::MAX / 4) + 2, 4).unwrap_err();
+    let err = LayerKvTensor::from_flat(&flat, &flat, (usize::MAX / 4) + 2, 4).unwrap_err();
     assert!(err.to_string().contains("overflow"), "{err}");
 }
 

--- a/crates/ruvllm/src/shard_placement/planner.rs
+++ b/crates/ruvllm/src/shard_placement/planner.rs
@@ -314,8 +314,7 @@ impl PlacementPlanner {
             None => {
                 // Every shard is individually placeable, but cumulative
                 // capacity cannot hold them all — reject, do not overcommit.
-                let fleet_available_mb: u64 =
-                    nodes.iter().map(|n| n.available_memory_mb).sum();
+                let fleet_available_mb: u64 = nodes.iter().map(|n| n.available_memory_mb).sum();
                 let stuck = &shards[deepest.min(shards.len() - 1)];
                 return Err(PlacementRejection::CapacityExhausted {
                     shard: stuck.id.clone(),

--- a/crates/ruvllm/src/shard_placement/policy.rs
+++ b/crates/ruvllm/src/shard_placement/policy.rs
@@ -62,11 +62,7 @@ impl std::fmt::Display for ConstraintViolation {
                 "trust: shard requires tier >= {required} but node is {node_tier}"
             ),
             ConstraintViolation::Capability { missing } => {
-                let list = missing
-                    .iter()
-                    .cloned()
-                    .collect::<Vec<_>>()
-                    .join(", ");
+                let list = missing.iter().cloned().collect::<Vec<_>>().join(", ");
                 write!(f, "capability: node is missing [{list}]")
             }
             ConstraintViolation::Capacity {

--- a/crates/ruvllm/src/shard_placement/tests.rs
+++ b/crates/ruvllm/src/shard_placement/tests.rs
@@ -47,7 +47,11 @@ fn assert_plan_respects_constraints(
         let node = node_by_id(&a.node);
         // Residency.
         if let Some(zone) = &shard.residency {
-            assert_eq!(&node.residency_zone, zone, "residency respected for {}", a.shard);
+            assert_eq!(
+                &node.residency_zone, zone,
+                "residency respected for {}",
+                a.shard
+            );
         }
         // Trust.
         assert!(
@@ -231,7 +235,8 @@ fn picks_lowest_latency_cost_among_feasible() {
     let shards = vec![ModelShard::new("stage-0", 0, 4000)];
     // Both nodes are fully eligible; they differ only in latency.
     let nodes = vec![
-        FleetNode::new("slow", ResidencyZone::new("us"), TrustTier(5), 8000).with_profile(30.0, 1.0),
+        FleetNode::new("slow", ResidencyZone::new("us"), TrustTier(5), 8000)
+            .with_profile(30.0, 1.0),
         FleetNode::new("fast", ResidencyZone::new("us"), TrustTier(5), 8000).with_profile(5.0, 1.0),
     ];
 
@@ -317,7 +322,10 @@ fn four_node_seventy_b_fits_collectively_not_singly() {
     );
     // Precondition: it DOES fit collectively.
     let fleet_mb: u64 = nodes.iter().map(|n| n.available_memory_mb).sum();
-    assert!(fleet_mb >= total_model_mb, "test premise: fleet holds it jointly");
+    assert!(
+        fleet_mb >= total_model_mb,
+        "test premise: fleet holds it jointly"
+    );
 
     let plan = PlacementPlanner::default().plan(&shards, &nodes).unwrap();
     assert_plan_respects_constraints(&plan, &shards, &nodes);
@@ -447,7 +455,14 @@ fn oversized_request_is_rejected_before_search() {
     // One node over the node cap with a single shard.
     let one_shard = vec![ModelShard::new("stage-0", 0, 1)];
     let too_many_nodes: Vec<FleetNode> = (0..=MAX_NODES)
-        .map(|i| FleetNode::new(format!("n{i}"), ResidencyZone::new("us"), TrustTier(9), 1000))
+        .map(|i| {
+            FleetNode::new(
+                format!("n{i}"),
+                ResidencyZone::new("us"),
+                TrustTier(9),
+                1000,
+            )
+        })
         .collect();
     match PlacementPlanner::default()
         .plan(&one_shard, &too_many_nodes)

--- a/crates/rvAgent/latentmesh-thoughtmap/src/capability.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/capability.rs
@@ -252,9 +252,7 @@ mod tests {
             profile(2, vec![1.0, 0.0, 0.0], 1.0, 1.0, 10), // excluded below
             profile(3, vec![0.9, 0.1, 0.0], 0.8, 1.0, 10),
         ];
-        let sel = view
-            .select_peer(&candidates, &query, &[PeerId(2)])
-            .unwrap();
+        let sel = view.select_peer(&candidates, &query, &[PeerId(2)]).unwrap();
         assert_eq!(sel.peer, PeerId(3));
     }
 

--- a/crates/rvAgent/latentmesh-thoughtmap/src/causal.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/causal.rs
@@ -26,7 +26,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::thoughtmap::{ThoughtMap, StepId};
+use crate::thoughtmap::{StepId, ThoughtMap};
 use crate::transport::LatentMessage;
 use crate::vecmath::{cosine, mean};
 
@@ -182,10 +182,16 @@ mod tests {
         let v = ControlledReplacementVerifier::default();
 
         let nan = msg(9, vec![f32::NAN, 0.0, 0.0], a);
-        assert!(!v.verify(&map, &nan).is_accepted(), "NaN must not be accepted");
+        assert!(
+            !v.verify(&map, &nan).is_accepted(),
+            "NaN must not be accepted"
+        );
 
         let inf = msg(9, vec![f32::INFINITY, 0.0, 0.0], a);
-        assert!(!v.verify(&map, &inf).is_accepted(), "inf must not be accepted");
+        assert!(
+            !v.verify(&map, &inf).is_accepted(),
+            "inf must not be accepted"
+        );
     }
 
     #[test]

--- a/crates/rvAgent/latentmesh-thoughtmap/src/engine.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/engine.rs
@@ -65,7 +65,12 @@ pub struct ReasoningEngine<V: CausalVerifier> {
 }
 
 impl<V: CausalVerifier> ReasoningEngine<V> {
-    pub fn new(map: ThoughtMap, verifier: V, quarantine: Quarantine, policy: DeadEndPolicy) -> Self {
+    pub fn new(
+        map: ThoughtMap,
+        verifier: V,
+        quarantine: Quarantine,
+        policy: DeadEndPolicy,
+    ) -> Self {
         Self {
             map,
             quarantine,

--- a/crates/rvAgent/latentmesh-thoughtmap/src/lib.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/src/lib.rs
@@ -59,14 +59,10 @@ pub mod transport;
 mod vecmath;
 
 pub use capability::{CapabilityVector, LocalView, PeerId, PeerProfile, PeerSelection, Query};
-pub use causal::{
-    CausalVerdict, CausalVerifier, ControlledReplacementVerifier, RejectReason,
-};
+pub use causal::{CausalVerdict, CausalVerifier, ControlledReplacementVerifier, RejectReason};
 pub use engine::{Incorporation, ReasoningEngine, RejectionKind, ROOT_STEP};
 pub use quarantine::{Anomaly, PeerReputation, Quarantine};
-pub use thoughtmap::{
-    StepId, ThoughtEdge, ThoughtGraphBackend, ThoughtMap, ThoughtNode,
-};
+pub use thoughtmap::{StepId, ThoughtEdge, ThoughtGraphBackend, ThoughtMap, ThoughtNode};
 pub use topology::{DeadEndPolicy, TopologyCause, TopologyChange};
 pub use transport::{
     integrity_tag, CausalTag, InProcessTransport, LatentMessage, LatentState, LatentTransport,

--- a/crates/rvAgent/latentmesh-thoughtmap/tests/acceptance.rs
+++ b/crates/rvAgent/latentmesh-thoughtmap/tests/acceptance.rs
@@ -5,7 +5,7 @@
 
 use latentmesh_thoughtmap::{
     integrity_tag, CausalTag, ControlledReplacementVerifier, DeadEndPolicy, Incorporation,
-    LatentMessage, LocalView, PeerId, PeerProfile, Query, Quarantine, ReasoningEngine,
+    LatentMessage, LocalView, PeerId, PeerProfile, Quarantine, Query, ReasoningEngine,
     RejectReason, RejectionKind, ThoughtGraphBackend, ThoughtMap, ROOT_STEP,
 };
 
@@ -71,8 +71,16 @@ fn local_peer_selection_is_decentralized_and_query_dependent() {
     let pick_a = view.select_peer(&candidates, &q_a, &[]).unwrap();
     let pick_b = view.select_peer(&candidates, &q_b, &[]).unwrap();
 
-    assert_eq!(pick_a.peer, PeerId(10), "query A → specialist A, chosen locally");
-    assert_eq!(pick_b.peer, PeerId(11), "query B → specialist B, chosen locally");
+    assert_eq!(
+        pick_a.peer,
+        PeerId(10),
+        "query A → specialist A, chosen locally"
+    );
+    assert_eq!(
+        pick_b.peer,
+        PeerId(11),
+        "query B → specialist B, chosen locally"
+    );
     assert_ne!(
         pick_a.peer, pick_b.peer,
         "same peers, different query → different specialization (no static role)"
@@ -185,7 +193,11 @@ fn infinite_latent_is_rejected() {
             Incorporation::Rejected(RejectionKind::NonFinite)
         );
     }
-    assert_eq!(engine.map.node_count(), before, "no inf latent may be stored");
+    assert_eq!(
+        engine.map.node_count(),
+        before,
+        "no inf latent may be stored"
+    );
 }
 
 // 3c — CASCADE PROOF: a rejected non-finite injection must NOT poison the
@@ -270,7 +282,10 @@ fn dead_end_continues_from_state_and_is_swappable() {
         .handle_dead_end(d, &view, &candidates, &query, &[], PeerId(1))
         .expect("non-quarantined trigger yields a change");
     assert!(change.continued, "continue, NOT restart");
-    assert_eq!(change.resume_from, d, "resume from current state, not the root");
+    assert_eq!(
+        change.resume_from, d,
+        "resume from current state, not the root"
+    );
     assert_eq!(change.new_peer, Some(PeerId(20)), "re-routed to a new peer");
 
     // Swap the policy → Restart resumes from ROOT and discards progress.
@@ -297,7 +312,10 @@ fn misbehaving_peer_is_quarantined_and_cannot_churn_topology() {
             Incorporation::Rejected(RejectionKind::Causal(_))
         ));
     }
-    assert!(engine.quarantine.is_quarantined(bad), "sustained anomalies quarantine the peer");
+    assert!(
+        engine.quarantine.is_quarantined(bad),
+        "sustained anomalies quarantine the peer"
+    );
 
     let nodes_after_rejects = engine.map.node_count();
 
@@ -305,7 +323,10 @@ fn misbehaving_peer_is_quarantined_and_cannot_churn_topology() {
     // It must be DAMPENED (not incorporated) purely because it is quarantined —
     // a bad actor cannot buy its way back into the map with one good message.
     let good_but_quarantined = signed_msg(bad.0, 0, vec![0.97, 0.03, 0.0], ROOT_STEP);
-    assert_eq!(engine.incorporate(&good_but_quarantined), Incorporation::Dampened);
+    assert_eq!(
+        engine.incorporate(&good_but_quarantined),
+        Incorporation::Dampened
+    );
     assert_eq!(
         engine.map.node_count(),
         nodes_after_rejects,
@@ -316,7 +337,10 @@ fn misbehaving_peer_is_quarantined_and_cannot_churn_topology() {
     let view = LocalView::new(PeerId(1), vec![1.0, 1.0, 1.0], 10);
     let query = Query::new(1, vec![1.0, 0.0, 0.0]);
     let churn = engine.handle_dead_end(ROOT_STEP, &view, &[], &query, &[], bad);
-    assert!(churn.is_none(), "quarantined peer cannot trigger topology churn");
+    assert!(
+        churn.is_none(),
+        "quarantined peer cannot trigger topology churn"
+    );
 }
 
 // 6 — Topology changes remain attributable (every change names its cause + trigger).
@@ -351,11 +375,27 @@ fn rerouting_skips_quarantined_candidates() {
     let view = LocalView::new(PeerId(1), vec![1.0, 1.0, 1.0], 10);
     let query = Query::new(1, vec![1.0, 0.0, 0.0]);
     let candidates = vec![
-        PeerProfile { id: bad, skill: vec![1.0, 0.0, 0.0], trust: 0.9, cost: 1.0, last_active_step: 10 },
-        PeerProfile { id: PeerId(21), skill: vec![1.0, 0.0, 0.0], trust: 0.9, cost: 1.0, last_active_step: 10 },
+        PeerProfile {
+            id: bad,
+            skill: vec![1.0, 0.0, 0.0],
+            trust: 0.9,
+            cost: 1.0,
+            last_active_step: 10,
+        },
+        PeerProfile {
+            id: PeerId(21),
+            skill: vec![1.0, 0.0, 0.0],
+            trust: 0.9,
+            cost: 1.0,
+            last_active_step: 10,
+        },
     ];
     let change = engine
         .handle_dead_end(d, &view, &candidates, &query, &[], PeerId(1))
         .unwrap();
-    assert_eq!(change.new_peer, Some(PeerId(21)), "re-route skips the quarantined peer");
+    assert_eq!(
+        change.new_peer,
+        Some(PeerId(21)),
+        "re-route skips the quarantined peer"
+    );
 }


### PR DESCRIPTION
## Why

The `Clippy + fmt` workflow runs `cargo fmt --all --check` (`.github/workflows/clippy-fmt.yml:48`), and that job has been failing on `main` independently of any single PR — **23 files, 95 hunks**.

Every one of them comes from PIR work packages that ran *scoped* fmt checks (`cargo fmt -p <crate>`) or none at all, rather than the workspace-wide check CI actually enforces. My own Wave-4 work is part of the cause: `mcp-gate/src/schema_cache.rs` (7 hunks) and `ruvector-agent-memory` (~25 hunks incl. `arbitration.rs`) are mine.

**A permanently red gate stops being a gate.** It masks genuine formatting regressions, and it forces every subsequent PR to spend a paragraph arguing that its red CI is someone else's fault — #902 had to do exactly that. Clearing it makes the next real regression visible.

## What

`cargo fmt --all`. Formatting only, no semantic change.

Files touched, by origin:
- `crates/ruvector-agent-memory/` (src + tests) — PIR WP18/WP22/WP27
- `crates/mcp-gate/` — PIR WP26
- `crates/ruvllm/{shard_placement,kv_migration}/` — PIR WP13/WP20
- `crates/rvAgent/latentmesh-thoughtmap/` — PIR WP23
- `crates/ruvector-bet4-ivf-bench/`

## Verification

- `cargo fmt --all --check` → clean afterwards (was 95 diffs)
- `cargo test -p ruvector-agent-memory -p mcp-gate --locked` → all suites pass
- No `Cargo.toml`/`Cargo.lock` changes; no dependency changes

## Deliberately not included

This does **not** touch the other two baseline CI failures, which are unrelated and need their own fixes:
- `cargo audit` / `cargo deny` — RUSTSEC-2026-0253 (`lru`) and RUSTSEC-2026-0258 (`h2`) in unrelated dependency trees
- Clippy `-D warnings` — new Rust 1.98 lints in generated Hailo code and `ruvector-mincut`

No overlap with the files in open PR #902, so it should not conflict.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_016QSCkKnxDjqU49NVVpWMK5