### PR TITLE
ci: enforce the ADR duplicate-number gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,25 @@ jobs:
       - name: Check crates/ for orphan crates (PIR #859)
         run: node scripts/workspace-check.mjs
 
+  adr-numbering:
+    name: ADR numbering guard
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '20'
+
+      # scripts/adr-index.mjs has always exited 1 on a duplicate ADR number,
+      # but nothing invoked it, so duplicates reached review green. See
+      # ADR-316 for the numbering policy.
+      - name: Check docs/adr/ for duplicate ADR numbers (ADR-316)
+        run: node scripts/adr-index.mjs --check
+
   frozen-weights:
     name: Frozen-weights structural gate
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Why

`scripts/adr-index.mjs --check` has always exited `1` on a duplicate ADR number — but **no workflow ever invoked it**:

```
$ grep -rn 'scripts/adr' .github/
(no matches)
```

So the duplicate-number policy in ADR-316 has been enforced only by whoever remembered to run the script by hand.

This is not hypothetical. **#902 added a second `ADR-332`** alongside the `ADR-332` merged earlier the same day — on a branch that already contained that merge — and every check passed. The gate caught it immediately once run manually:

```
$ node scripts/adr-index.mjs --check
ADR duplicate-number check FAILED:
  - NEW duplicate 332: docs/adr/ADR-332-rf-sensing-modality-router.md,
                       docs/adr/ADR-332-SCOPE-SHARDED-CONTEXT-INDEX.md
$ echo $?
1
```

A gate wired to nothing is indistinguishable from no gate.

## What

Adds an `adr-numbering` job to `Workspace CI`, mirroring the existing `workspace-membership` guard — same pinned `actions/checkout` and `actions/setup-node`, same 10-minute bound. One `node scripts/adr-index.mjs --check` step.

## Verification

- Workflow YAML parses; `adr-numbering` registers alongside the existing jobs
- `node scripts/adr-index.mjs --check` passes on this branch (364 ADR files, no duplicates outside the frozen historical list)
- No Rust code, dependency, or lockfile changes

Note the script already tolerates the repo's frozen historical duplicates, so this does not retroactively fail existing ADRs — it only blocks *new* collisions.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_016QSCkKnxDjqU49NVVpWMK5