### PR TITLE
fix(mincut-gated-transformer): clear the Rust 1.98 clippy denial and a platform-fragile timer test

### DIFF
--- a/crates/ruvector-mincut-gated-transformer/src/kernel/bench_utils.rs
+++ b/crates/ruvector-mincut-gated-transformer/src/kernel/bench_utils.rs
@@ -373,7 +373,12 @@ mod tests {
     fn test_timer_reset() {
         let mut timer = Timer::new();
 
+        // Span a measurable interval rather than start/stop back to back: on
+        // aarch64 `elapsed_cycles` reads `cntvct_el0`, which ticks at ~24 MHz
+        // on Apple Silicon, so an empty interval legitimately reads zero and
+        // a `> 0` assertion fails deterministically there.
         timer.start();
+        std::thread::sleep(core::time::Duration::from_millis(1));
         timer.stop();
         let first = timer.elapsed_cycles();
 
@@ -381,6 +386,7 @@ mod tests {
         assert_eq!(timer.elapsed_cycles(), 0);
 
         timer.start();
+        std::thread::sleep(core::time::Duration::from_millis(1));
         timer.stop();
         let second = timer.elapsed_cycles();
 

--- a/crates/ruvector-mincut-gated-transformer/src/mamba.rs
+++ b/crates/ruvector-mincut-gated-transformer/src/mamba.rs
@@ -122,12 +122,8 @@ impl MambaState {
 
     /// Reset state to zeros
     pub fn reset(&mut self) {
-        for x in &mut self.h {
-            *x = 0.0;
-        }
-        for x in &mut self.conv_state {
-            *x = 0.0;
-        }
+        self.h.fill(0.0);
+        self.conv_state.fill(0.0);
     }
 }
 


### PR DESCRIPTION
Two independent pre-existing defects in one crate.

## 1. `Clippy (deny warnings)` — the last lint standing between that job and green

The workspace-wide `Clippy (deny warnings)` job fails on a **single** new Rust 1.98 lint:

```
error: manually filling a slice
  --> crates/ruvector-mincut-gated-transformer/src/mamba.rs:125:9
```

`MambaState::reset` zeroed two vectors with manual loops. Replaced with `slice::fill`. Semantically identical.

## 2. `test_timer_reset` fails deterministically on aarch64

Unrelated to the above, found while verifying it. `elapsed_cycles()` reads `cntvct_el0` on aarch64, which ticks at **~24 MHz** on Apple Silicon — so a back-to-back `start(); stop();` spans **zero** ticks and `assert!(first > 0)` cannot hold. It fails 3/3 on unmodified `main` on this hardware, and 3/3 with the clippy fix applied, so it is pre-existing and not a flake — it is a test asserting that a zero-work interval takes measurable time.

The interval now spans 1 ms (~24,000 ticks on that counter, still meaningful against x86_64's `rdtsc`). The test's actual subject — that `reset()` zeroes the counter — is untouched.

This crate is not in the main CI test shard (only the `-wasm` variant appears, and it is excluded elsewhere), which is why a deterministically failing test has been sitting green.

## Verification

- `cargo test -p ruvector-mincut-gated-transformer --locked` → **218 passed, 0 failed** (was 217 passed / 1 failed)
- `cargo clippy -p ruvector-mincut-gated-transformer --all-targets --locked -- -D warnings` → 0 errors
- `cargo fmt -p ruvector-mincut-gated-transformer -- --check` → clean
- No dependency or lockfile changes

Pairs with #904 (rustfmt drift). Together those two should take `Clippy + fmt` fully green; the remaining red is `cargo audit`/`cargo deny` on the inherited `lru`/`h2` advisories, which need their own dependency work.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_016QSCkKnxDjqU49NVVpWMK5