### PR TITLE
fix(deps): resolve RUSTSEC-2026-0258 by dropping the h2 0.3.x chain

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -38,7 +38,9 @@ ignore = [
     "RUSTSEC-2024-0436",  # paste — transitive proc-macro, build-time only
     "RUSTSEC-2025-0119",  # number_prefix — transitive via indicatif rendering
     "RUSTSEC-2025-0124",  # rand_os — transitive, replaced by getrandom in modern code paths
-    "RUSTSEC-2025-0134",  # rustls-pemfile — transitive; rustls itself is current
+    # RUSTSEC-2025-0134 (rustls-pemfile 1.x) dropped: the only edge was
+    # reqwest 0.11 -> hyper 0.14, removed by the h2 RUSTSEC-2026-0258 fix.
+    # The tree now carries rustls-pemfile 2.2.0 only, which is unaffected.
     "RUSTSEC-2025-0141",  # bincode — unmaintained notice; we pin a known-good version
 
     # Added 2026-08-03. All four carry `patched = []` upstream — there is no

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ name = "a2a-swarm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "reqwest 0.12.28",
+ "reqwest",
  "rvagent-cli",
  "serde_json",
  "tokio",
@@ -219,7 +219,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -483,9 +483,9 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit 0.7.3",
@@ -500,7 +500,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
  "tower 0.5.3",
@@ -520,9 +520,9 @@ dependencies = [
  "form_urlencoded",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -534,7 +534,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower 0.5.3",
  "tower-layer",
@@ -552,12 +552,12 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -572,11 +572,11 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -604,7 +604,7 @@ dependencies = [
  "cargo-husky",
  "futures",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "mime",
  "serde",
  "serde_json",
@@ -626,7 +626,7 @@ dependencies = [
  "cookie",
  "http 1.4.2",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "mime",
  "pretty_assertions",
@@ -656,7 +656,7 @@ dependencies = [
  "cookie",
  "http 1.4.2",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "mime",
  "pretty_assertions",
@@ -1467,7 +1467,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2371,7 +2371,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2640,7 +2640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3865,28 +3865,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.12.1",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4032,7 +4013,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_derive",
- "winreg 0.10.1",
+ "winreg",
 ]
 
 [[package]]
@@ -4118,7 +4099,7 @@ dependencies = [
  "native-tls",
  "num_cpus",
  "rand 0.9.4",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4209,17 +4190,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -4237,7 +4207,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -4270,30 +4240,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
@@ -4302,9 +4248,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -4321,7 +4267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.2",
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "rustls",
  "tokio",
@@ -4336,24 +4282,11 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -4364,7 +4297,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -4383,14 +4316,14 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
- "hyper 1.10.1",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
- "system-configuration 0.7.0",
+ "socket2 0.5.10",
+ "system-configuration",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4728,7 +4661,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5274,7 +5207,7 @@ dependencies = [
  "base64 0.22.1",
  "hex",
  "regex-lite",
- "reqwest 0.12.28",
+ "reqwest",
  "ruvector-sona 0.2.1",
  "serde",
  "serde_json",
@@ -5302,7 +5235,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "rand 0.8.6",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "rusqlite",
  "ruvector-consciousness",
  "ruvector-delta-core",
@@ -5544,9 +5477,9 @@ dependencies = [
  "colored 3.1.1",
  "futures-core",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "log",
  "pin-project-lite",
@@ -6140,7 +6073,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7787,7 +7720,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7824,7 +7757,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8406,46 +8339,6 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg 0.50.0",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
@@ -8456,13 +8349,13 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.15",
+ "h2",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-rustls",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
@@ -8477,7 +8370,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -8666,7 +8559,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8682,15 +8575,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -8940,7 +8824,7 @@ dependencies = [
  "rand 0.8.6",
  "rand_distr 0.4.3",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest",
  "ruvector-core 2.3.0",
  "rvf-crypto",
  "rvf-types",
@@ -8997,7 +8881,7 @@ dependencies = [
  "flate2",
  "futures",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "indicatif",
  "lru 0.18.2",
@@ -9276,7 +9160,7 @@ dependencies = [
  "rand_distr 0.4.3",
  "rayon",
  "redb",
- "reqwest 0.12.28",
+ "reqwest",
  "rkyv",
  "ruvector-turboquant",
  "serde",
@@ -9702,7 +9586,7 @@ dependencies = [
  "dashmap 6.2.1",
  "futures",
  "hnsw_rs",
- "hyper 1.10.1",
+ "hyper",
  "lalrpop-util",
  "lru 0.18.2",
  "lz4",
@@ -9949,7 +9833,7 @@ dependencies = [
  "neural-trader-replay",
  "neural-trader-strategies",
  "rand 0.8.6",
- "reqwest 0.12.28",
+ "reqwest",
  "rsa",
  "serde",
  "serde_json",
@@ -10502,7 +10386,7 @@ dependencies = [
  "glob",
  "governor 0.6.3",
  "hmac 0.12.1",
- "hyper 1.10.1",
+ "hyper",
  "image 0.25.10",
  "imageproc",
  "indicatif",
@@ -10522,7 +10406,7 @@ dependencies = [
  "proptest",
  "rand 0.8.6",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest",
  "rusttype",
  "serde",
  "serde-wasm-bindgen",
@@ -10675,7 +10559,7 @@ dependencies = [
  "rand 0.8.6",
  "rand_distr 0.4.3",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest",
  "ruvector-core 2.3.0",
  "ruvector-diskann",
  "ruvector-hnsw-repair",
@@ -11296,7 +11180,7 @@ dependencies = [
  "rand 0.8.6",
  "rand_core 0.6.4",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest",
  "rvagent-core",
  "rvagent-middleware",
  "serde",
@@ -11326,8 +11210,8 @@ dependencies = [
  "axum-test 16.4.1",
  "chrono",
  "clap",
- "hyper 1.10.1",
- "reqwest 0.12.28",
+ "hyper",
+ "reqwest",
  "rvagent-backends",
  "rvagent-core",
  "rvagent-middleware",
@@ -11363,7 +11247,7 @@ dependencies = [
  "mockito",
  "parking_lot 0.12.5",
  "proptest",
- "reqwest 0.12.28",
+ "reqwest",
  "rvagent-core",
  "serde",
  "serde_json",
@@ -11397,7 +11281,7 @@ dependencies = [
  "rand 0.8.6",
  "rand_core 0.6.4",
  "ratatui",
- "reqwest 0.12.28",
+ "reqwest",
  "rvagent-a2a",
  "rvagent-backends",
  "rvagent-core",
@@ -11453,7 +11337,7 @@ dependencies = [
  "futures",
  "mockall",
  "proptest",
- "reqwest 0.11.27",
+ "reqwest",
  "rvagent-core",
  "rvagent-middleware",
  "rvagent-tools",
@@ -12224,7 +12108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12686,12 +12570,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -12754,34 +12632,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.13.0",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -12844,7 +12701,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12935,7 +12792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13335,17 +13192,17 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.15",
+ "h2",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
  "tokio-rustls",
@@ -13400,7 +13257,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -13419,7 +13276,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -13446,7 +13303,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "pin-project-lite",
  "tokio",
@@ -14449,7 +14306,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -14911,16 +14768,6 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "serde",
  "winapi",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/rvAgent/rvagent-mcp/Cargo.toml
+++ b/crates/rvAgent/rvagent-mcp/Cargo.toml
@@ -37,7 +37,7 @@ futures = "0.3"
 tokio = { version = "1.41", features = ["rt-multi-thread", "sync", "macros", "io-util", "io-std", "test-util"] }
 mockall = { workspace = true }
 proptest = { workspace = true }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12", features = ["json"] }
 
 # Workspace cleanup pass: research-tier crate, doc/style churn deferred. Correctness + suspicious lints stay denied.
 [lints.rust]

--- a/deny.toml
+++ b/deny.toml
@@ -108,10 +108,13 @@ ignore = [
     # legacy rand internals; modern paths use getrandom directly.
     "RUSTSEC-2025-0124",
 
-    # rustls-pemfile 1.x — unmaintained, replaced by rustls-pki-types'
-    # builtin PEM parser. Transitive via reqwest / tokio-tungstenite.
-    # Migration is a transitive bump; Dependabot tracking.
-    "RUSTSEC-2025-0134",
+    # NOTE: RUSTSEC-2025-0134 (rustls-pemfile 1.x, unmaintained) was
+    # removed from this list once the last rustls-pemfile 1.0.4 edge
+    # left the graph — it came in via reqwest 0.11 -> hyper 0.14, and
+    # that whole chain went away with the h2 RUSTSEC-2026-0258 fix.
+    # Only rustls-pemfile 2.2.0 remains, which the advisory doesn't
+    # cover. Keeping the entry made cargo-deny emit a permanent
+    # `advisory-not-detected` warning.
 
     # ttf-parser — unmaintained (RUSTSEC-2026-0192), "no safe upgrade
     # available" per the advisory itself. Pulled via three unrelated


### PR DESCRIPTION
## What was actually failing

`supply-chain` and `Security audit` were both red on **RUSTSEC-2026-0258** — *h2 unbounded empty DATA frames* (DoS, patched in `>= 0.4.16`), **not** on the `lru` advisory.

Worth stating plainly, because the two are easy to conflate in the same log:

| Advisory | Kind | Effect on CI |
|---|---|---|
| RUSTSEC-2026-0258 (`h2`) | `vulnerability` | **fails both jobs** |
| RUSTSEC-2026-0253 (`lru`) | `informational = "unsound"` | warning only — never failed |

`cargo audit` runs without `--deny warnings` (deliberately — see the comment in `supply-chain.yml`), so the `lru` entry surfaces as `warning: 2 allowed warnings found` and contributes nothing to the exit code. The `cargo deny` job's only `error[vulnerability]` lines are the two h2 ones. This PR fixes the thing that is red.

## The fix

Two h2 versions resolved and both were flagged:

- **h2 0.4.15** — semver-compatible, bumped to **0.4.18**.
- **h2 0.3.27** — no 0.3.x backport exists (the 0.3 line ends at 0.3.27), so it had to leave the graph. Its only path in was `reqwest 0.11.27 -> hyper 0.14.32`, and reqwest 0.11 is a **dev-dependency of exactly one crate**, `rvagent-mcp`.

`rvagent-mcp` was the lone holdout: its four siblings (`a2a`, `acp`, `backends`, `cli`) are already on reqwest 0.12, and `rvagent-acp` declares the identical `features = ["json"]`. The dependency is also **unreferenced** — the manifest line is the only mention of `reqwest` anywhere in the crate. So the bump aligns with the existing convention and touches no source code.

## Blast radius

One dev-dependency line, plus the lockfile. That single edit and `cargo update -p h2@0.4.15` collapse the entire legacy HTTP stack out of the tree — 12 crates removed, `Cargo.lock` net −153 lines:

> h2 0.3.27, hyper 0.14.32, hyper-tls 0.5.0, reqwest 0.11.27, http-body 0.4.6, rustls-pemfile 1.0.4, sync_wrapper 0.1.2, system-configuration 0.5.1, system-configuration-sys 0.5.0, winreg 0.50.0

The tree now carries a single `h2` (0.4.18), `hyper` (1.10.1), and `reqwest` (0.12.28).

Because `rustls-pemfile 1.0.4` went with it, the **RUSTSEC-2025-0134** ignore became obsolete in both policy files and cargo-deny began emitting a permanent `advisory-not-detected` warning for it. Retired it in both, per those files' own "this list is meant to shrink over time" policy. Only `rustls-pemfile 2.2.0` remains, which the advisory doesn't cover.

## Why RUSTSEC-2026-0253 (lru) is *not* fixed here

Per `.cargo/audit.toml`'s policy I tried the bump path first. It is genuinely unavailable for one half and a separate project for the other, so I wrote **no ignore entry** — the advisory isn't failing anything, and half of it has a real fix that deserves its own PR.

The advisory is `patched = [">= 0.18.2"]`, `unaffected = []` — no backport to either line. Our own crates already declare `lru = "0.18"`. The two flagged versions are transitive:

- **lru 0.16.4** via `lattice-embed`, which pins `lru ^0.16.3` at *every* published version **including the latest 0.9.0** (we're on 0.6.1). `^0.16.3` can never reach 0.18.2. **No bump path exists.** It's also optional — gated behind `ruvector-core`'s opt-in `lattice-embeddings` feature, which raises MSRV to 1.93, so it isn't in a default build at all.
- **lru 0.12.5** via `ratatui 0.29`, used only by `rvagent-cli`. **ratatui 0.30 drops the `lru` dependency outright**, so this half *is* fixable — but 0.29 → 0.30 also forces `crossterm 0.28 → 0.29` and the 0.30 restructuring into `ratatui-core` / `ratatui-crossterm` (which moves `backend::CrosstermBackend`). That reworks `crates/rvAgent/rvagent-cli/src/tui.rs`, a 420-line file importing a fair spread of layout/style/widget APIs.

Bundling a TUI API migration into a CI-unblocking dependency fix would be the wrong trade. **Recommended follow-up:** bump ratatui to 0.30 in `rvagent-cli` to clear lru 0.12.5; lru 0.16.4 stays until lattice-embed relaxes its pin upstream.

One caveat for whoever picks that up: `hailo-backend-audit.yml` runs `cargo audit --deny warnings` with a short inline ignore list that predates several current advisories (RUSTSEC-2026-0253 among them). It is path-filtered to the hailo crates and last ran 2026-08-03, so it isn't red right now, but it will fail on the lru warning whenever it next triggers. Out of scope here.

## Verification

All run locally against this branch:

- `cargo audit` — **exit 0** (was: `error: 2 vulnerabilities found!`). Remaining output is the 2 pre-existing allowed `lru` warnings.
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`, exit 0, and **zero** `advisory-not-detected` warnings.
- `cargo check --workspace --locked` — passes, exit 0. `--locked` succeeding also confirms the `lockfile-integrity` job's invariant.
- `cargo test -p rvagent-mcp` — **330 passed, 0 failed** (179 + 123 + 28).

The pre-existing informational noise (2x `bincode` unmaintained, `spin` yanked) is unrelated and unchanged.