### PR TITLE
fix(sota-bench): hard_regression must compare against the baseline, not an absolute threshold (issue #920)

### DIFF
--- a/crates/ruvector-sota-bench/harness/src/flywheel.ts
+++ b/crates/ruvector-sota-bench/harness/src/flywheel.ts
@@ -55,6 +55,10 @@ interface RuvectorScore extends Score {
   qps: number;
   memoryMb: number;
   peakRssBytes: number;
+  /** The absolute health thresholds this score tripped, itemised. The gate diffs
+   *  candidate against baseline over these; the inherited `regressed` boolean
+   *  cannot express "already true of the baseline". */
+  regressions: string[];
   vetoReasons: string[];
   observations: BenchmarkObservation[];
 }
@@ -76,6 +80,30 @@ function asRuvectorScore(score: Score): RuvectorScore {
   return score as RuvectorScore;
 }
 
+/**
+ * The regressions the candidate introduces that the baseline did not already
+ * carry, as `hard_regression:<name>` reasons.
+ *
+ * `regressions` itemises ABSOLUTE health thresholds (the 0.95 recall floor, the
+ * qps floor), so on any workload sitting under one of them the baseline trips it
+ * too. Gating on the candidate's own flag therefore made `hard_regression` a
+ * permanent no — it fired on 120/120 candidates in issue #920 and identified a
+ * candidate-introduced regression zero times. Only the set difference is
+ * attributable to the candidate; the absolute list stays a reported signal.
+ *
+ * A score that predates the itemised list fails closed on the boolean rather
+ * than opening the gate, and an unknown baseline counts every candidate
+ * regression as new.
+ */
+function candidateIntroducedRegressions(baseline: RuvectorScore, candidate: RuvectorScore): string[] {
+  if (!Array.isArray(candidate.regressions)) return candidate.regressed ? ["hard_regression"] : [];
+  const inherited = new Set(Array.isArray(baseline.regressions) ? baseline.regressions : []);
+  return [...new Set(candidate.regressions)]
+    .filter((name) => !inherited.has(name))
+    .sort()
+    .map((name) => `hard_regression:${name}`);
+}
+
 export function ruvectorPromotionRule(evidence: {
   baseline: Score;
   candidate: Score;
@@ -88,7 +116,7 @@ export function ruvectorPromotionRule(evidence: {
   if (decision.outcome !== "pass") reasons.push(`paired_confirmation_${decision.outcome}`);
   if (candidate.recallAt10 < baseline.recallAt10) reasons.push("recall_regressed");
   if (candidate.costPerWin > baseline.costPerWin * 1.05) reasons.push("resource_cost_worsened");
-  if (candidate.regressed) reasons.push("hard_regression");
+  reasons.push(...candidateIntroducedRegressions(baseline, candidate));
   reasons.push(...candidate.vetoReasons);
   if (evidence.anchor && evidence.anchor.candidate < evidence.anchor.baseline) reasons.push("anchor_regressed");
   return { promote: reasons.length === 0, reasons };
@@ -149,6 +177,7 @@ async function toScore(
     memoryMb: aggregate.memoryMb,
     peakRssBytes: Math.max(...observations.map((observation) => observation.resources.processPeakRssBytes)),
     costPerWin: aggregate.memoryMb * Math.max(aggregate.p99Us, 1) / Math.max(aggregate.qps, 1),
+    regressions: aggregate.regressions,
     regressed: aggregate.regressions.length > 0 || vetoReasons.length > 0,
     vetoReasons,
     observations,

--- a/crates/ruvector-sota-bench/harness/test/flywheel.test.ts
+++ b/crates/ruvector-sota-bench/harness/test/flywheel.test.ts
@@ -3,7 +3,126 @@ import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { runRuvectorFlywheel } from "../src/flywheel.js";
+import type { Score } from "@metaharness/flywheel";
+import { runRuvectorFlywheel, ruvectorPromotionRule } from "../src/flywheel.js";
+
+/** Build a gate-visible score. Defaults keep every gate other than
+ *  `hard_regression` silent, so a reason list is attributable to one check. */
+function gateScore(overrides: {
+  primarySamples?: number[];
+  recallAt10?: number;
+  costPerWin?: number;
+  regressions?: string[];
+  vetoReasons?: string[];
+}): Score {
+  const primarySamples = overrides.primarySamples ?? [0.9, 0.9, 0.9, 0.9, 0.9];
+  const recallAt10 = overrides.recallAt10 ?? 0.9;
+  const regressions = overrides.regressions ?? [];
+  const vetoReasons = overrides.vetoReasons ?? [];
+  return {
+    primary: primarySamples[0]!,
+    primarySamples,
+    noopRate: 1 - recallAt10,
+    recallAt10,
+    qps: 2_000,
+    memoryMb: 40,
+    peakRssBytes: 0,
+    costPerWin: overrides.costPerWin ?? 1,
+    regressed: regressions.length > 0 || vetoReasons.length > 0,
+    regressions,
+    vetoReasons,
+    observations: [],
+  } as unknown as Score;
+}
+
+const hardRegressions = (reasons: string[]) =>
+  reasons.filter((reason) => reason === "hard_regression" || reason.startsWith("hard_regression:"));
+
+test("hard_regression stays silent when the candidate inherits the baseline's regressions", () => {
+  const regressions = ["recall_below_0.95"];
+  const { reasons } = ruvectorPromotionRule({
+    baseline: gateScore({ regressions }),
+    candidate: gateScore({ regressions }),
+  });
+  assert.deepEqual(hardRegressions(reasons), []);
+});
+
+test("hard_regression fires and names a regression the candidate adds to the baseline's", () => {
+  const { reasons } = ruvectorPromotionRule({
+    baseline: gateScore({ regressions: ["recall_below_0.95"] }),
+    candidate: gateScore({ regressions: ["recall_below_0.95", "qps_below_baseline_floor"] }),
+  });
+  assert.deepEqual(hardRegressions(reasons), ["hard_regression:qps_below_baseline_floor"]);
+});
+
+test("hard_regression fires when the candidate trades one regression for a different one", () => {
+  const { reasons } = ruvectorPromotionRule({
+    baseline: gateScore({ regressions: ["recall_below_0.95"] }),
+    candidate: gateScore({ regressions: ["qps_below_baseline_floor"] }),
+  });
+  assert.deepEqual(hardRegressions(reasons), ["hard_regression:qps_below_baseline_floor"]);
+});
+
+test("hard_regression fires when a clean baseline is replaced by a regressing candidate", () => {
+  const { reasons } = ruvectorPromotionRule({
+    baseline: gateScore({}),
+    candidate: gateScore({ regressions: ["recall_below_0.95", "qps_below_baseline_floor"] }),
+  });
+  assert.deepEqual(hardRegressions(reasons), [
+    "hard_regression:qps_below_baseline_floor",
+    "hard_regression:recall_below_0.95",
+  ]);
+});
+
+test("hard_regression stays silent when neither side regresses", () => {
+  const { reasons } = ruvectorPromotionRule({ baseline: gateScore({}), candidate: gateScore({}) });
+  assert.deepEqual(hardRegressions(reasons), []);
+});
+
+test("a score with no itemised regressions still fails closed on the boolean", () => {
+  const legacy = gateScore({});
+  delete (legacy as unknown as Record<string, unknown>).regressions;
+  (legacy as unknown as Record<string, unknown>).regressed = true;
+  const { reasons } = ruvectorPromotionRule({ baseline: gateScore({}), candidate: legacy });
+  assert.deepEqual(hardRegressions(reasons), ["hard_regression"]);
+});
+
+test("vetoes remain absolute and are not diffed against the baseline", () => {
+  const vetoReasons = ["redblue_live_credential_detected"];
+  const { promote, reasons } = ruvectorPromotionRule({
+    baseline: gateScore({ vetoReasons }),
+    candidate: gateScore({ vetoReasons }),
+  });
+  assert.equal(promote, false);
+  assert.ok(reasons.includes("redblue_live_credential_detected"));
+});
+
+// The real baseline/candidate pair from the 30-generation acceptance run in issue
+// #920: `adapt m`, strictly better on primary, recall, qps, p99 and cost, rejected
+// with `hard_regression` as its sole reason because both sides sat below the
+// absolute 0.95 recall floor.
+test("the issue #920 rejected candidate is no longer blocked by hard_regression", () => {
+  const baseline = gateScore({
+    primarySamples: [
+      0.8781716212500001, 0.8597841212500001, 0.5462757812500001,
+      0.8648141012499999, 0.6410117651373053,
+    ],
+    recallAt10: 0.888,
+    costPerWin: 22.6502708788278,
+    regressions: ["recall_below_0.95"],
+  });
+  const candidate = gateScore({
+    primarySamples: [
+      0.9473974412499999, 0.9617474412500001, 0.9590824612500001,
+      0.9598274412500001, 0.9593016212500001,
+    ],
+    recallAt10: 0.9359999999999999,
+    costPerWin: 0.693375479272705,
+    regressions: ["recall_below_0.95"],
+  });
+  const { reasons } = ruvectorPromotionRule({ baseline, candidate });
+  assert.deepEqual(hardRegressions(reasons), []);
+});
 
 test("flywheel emits a replay-verified bundle and cannot authorize a PR", async () => {
   const outputDir = await mkdtemp(join(tmpdir(), "ruvector-flywheel-test-"));


### PR DESCRIPTION
Fixes #920. Part of epic #837.

## The bug

`aggregateReports` (`crates/ruvector-sota-bench/harness/src/metrics.ts:83-86`) itemises **absolute** health thresholds — `recallAt10 < 0.95` and `qps < BASELINE_QPS * 0.8`. `toScore` collapsed that list to a boolean, and `ruvectorPromotionRule` gated on the candidate's boolean alone with no comparison to the baseline:

```ts
if (candidate.regressed) reasons.push("hard_regression");
```

On any workload whose absolute recall sits below 0.95 the **baseline** already trips the threshold, so every candidate does too, so `hard_regression` fires unconditionally and nothing can ever be promoted. In the 30-generation run recorded in #920 it fired on **120/120** candidates and identified a candidate-introduced regression **zero** times — including on a candidate that was strictly better on primary, recall, qps, p99 and cost, and whose *only* rejection reason was `hard_regression`.

## The fix

1. `RuvectorScore` carries the itemised `regressions: string[]` alongside the existing boolean, which is left unchanged for the `@metaharness/flywheel` `Score` contract.
2. The gate fires only on the set difference `candidate.regressions \ baseline.regressions`, emitting one reason per new regression named as `hard_regression:<name>` so a rejection is diagnosable.
3. The absolute thresholds stay as reported health signals; they are simply no longer standalone promotion gates.

A score that lacks the itemised list falls back to failing closed on the boolean, so an evaluator that predates this change cannot silently open the gate.

## This loosens a safety gate

Everything else is untouched and was verified to already compare against the baseline:

| Reason code | Comparison | Touched |
|---|---|---|
| `paired_confirmation_*` | `pairedBootstrapDecision(baseline.primarySamples, candidate.primarySamples)` — paired per-item deltas | no |
| `recall_regressed` | `candidate.recallAt10 < baseline.recallAt10` | no |
| `resource_cost_worsened` | `candidate.costPerWin > baseline.costPerWin * 1.05` | no |
| `anchor_regressed` | `anchor.candidate < anchor.baseline` | no |
| veto reasons | absolute by design — pushed unconditionally, never diffed | no |

The Pareto gate, veto composition and the holdout/anchor disjointness assertion are unmodified.

## Tests

Eight assertions on `ruvectorPromotionRule` in `test/flywheel.test.ts`. Against `main` **5 of them fail**; all 8 pass after the fix. Full suite: 129 passed, 0 failed, 1 pre-existing opt-in skip (`RVF_ADAPTER_IT=1`).

| Test | Before | After |
|---|---|---|
| shared regression set → NOT fired (the stuck case) | fail | pass |
| candidate adds a regression → fired, names the new one | fail | pass |
| candidate has a *different* regression → fired | fail | pass |
| clean baseline, regressing candidate → fired, names both | fail | pass |
| both clean → NOT fired | pass | pass |
| score without the itemised list → fails closed on the boolean | pass | pass |
| vetoes stay absolute, not diffed against the baseline | pass | pass |
| the real #920 rejected candidate → no longer blocked by `hard_regression` | fail | pass |

The last test uses the genuine baseline/candidate scores (including per-item `primarySamples`) from the `adapt m` candidate in the #920 run, and asserts specifically on the absence of `hard_regression` rather than on promotion.

## Note on the #920 histogram

The reason `pareto_dominated_by_baseline` in the issue's histogram comes from `feat/pir-wp31-optimization-manifest`, which is not yet merged — that branch adds the in-repo Pareto gate and a `p99Us` field on the score. This PR is based on `main`, where that gate does not exist. The `hard_regression` defect is byte-identical on both branches, so this fix applies unchanged there.

## Verification

`npm ci --ignore-scripts`, `npm run check`, `npm test`, `npm run doctor`, and `cargo check -p ruvector-sota-bench --bin sota-all` all pass.

**Do not merge** pending adversarial review.