### PR TITLE
docs(adr-337): correct three statements that understate the overhead problem

### DIFF
--- a/crates/mcp-gate/src/monitor/detector.rs
+++ b/crates/mcp-gate/src/monitor/detector.rs
@@ -140,7 +140,13 @@ pub trait TinyDetector {
     /// *larger* declared value inflates the ceiling and makes the guard more
     /// permissive — so the one field that exists to catch a never-escalate
     /// ladder could be used to wave one through. Deriving it from the
-    /// detector removes the divergence rather than bounding it.
+    /// detector *bounds* the divergence rather than removing it. Nothing
+    /// cross-checks this against what [`TinyDetector::score`] actually
+    /// carries, so an implementation may still declare one figure and
+    /// produce another; the (0,1] bound caps how far apart they can be, and
+    /// residual inflation at the legal maximum reaches 44x at sigma=0.05.
+    /// Requiring a trait implementation rather than a config value is what
+    /// changed -- the divergence itself is still there.
     ///
     /// A detector whose uncertainty varies per input should report the
     /// **largest** value it can return, since that is the most permissive

--- a/crates/mcp-gate/src/monitor/mod.rs
+++ b/crates/mcp-gate/src/monitor/mod.rs
@@ -57,7 +57,8 @@
 //! So the target holds only when the first investigator actually settles the
 //! question. When it does not, the belief stays near the escalation
 //! threshold, every further rung still looks worth buying, and the ladder
-//! spends [`MonitorConfig::max_rounds`] rungs on every operation — four
+//! spends [`MonitorConfig::max_rounds`] rungs on every operation it
+//! *inspects* — four
 //! rounds of a 200 ms investigator against a 20 ms workload is 40× the
 //! budget on its own.
 //!

--- a/docs/adr/ADR-337-adaptive-runtime-monitoring-voi-escalation.md
+++ b/docs/adr/ADR-337-adaptive-runtime-monitoring-voi-escalation.md
@@ -191,12 +191,22 @@ disproved.** The corrected reasoning:
 | Investigator **resolves** the ambiguity (posterior 0.2) | **2.6%** | 20 |
 | Investigator **leaves it ambiguous** (0.5), latency priced | **108%** | 80 |
 | Same, latency unpriced | **205%** | 80 |
+| Ambiguous, **all-mandatory stream** (the actual worst case) | **1075%** | — |
+
+The first three rows are measured on a **10%-mandatory** mix, which is why
+the rung count divides to 0.4 per operation rather than `max_rounds`. An
+adversarial stream is not 10% mandatory: against an all-mandatory stream
+the same configuration measures **1075%**, an order of magnitude worse
+than the 108% figure. Quote 1075% as the worst case, not 108%.
 
 **The limiter is the belief update, not the price.** When the first rung
 settles the question, VoI collapses and the ladder stops — 2.6%,
 comfortably inside target. When it does not, the belief sits at the
 escalation threshold, every further rung still looks worth buying, and the
-ladder spends `max_rounds` on **every** operation. Pricing latency roughly
+ladder spends `max_rounds` on **every operation it inspects** — which is
+every operation that enters the ladder at all, not every operation seen.
+An all-benign 200-operation stream buys 0 rungs; an all-mandatory one buys
+800, exactly 4.00 per operation. Pricing latency roughly
 halves overhead by shifting the *mix* toward cheaper rungs; it does not
 reduce the *count*.
 
@@ -210,9 +220,18 @@ So the honest statement is:
   economics.** An investigator that returns "maybe" is not a cheaper
   investigator; it is an unbounded one.
 
-The 108% and 205% figures are the realistic bad case and are far outside
-target. They, not the 0.06%, are what a reader needs in order to size
-this.
+The 108%, 205% and 1075% figures are the realistic bad cases and are far
+outside target. They, not the 0.06%, are what a reader needs in order to
+size this.
+
+One further caveat on all of these numbers: they are a **declared-cost
+model**, not a wall-clock measurement. The account charges each rung its
+declared latency *and* separately charges the wall-clock of the whole
+inspection, so a real investigator that genuinely takes its declared
+latency is billed roughly twice (measured 2.46x on a single 300 ms rung).
+The direction is conservative — it overstates cost and so cannot conceal a
+budget breach — but `fraction()` should be read as a model until that is
+corrected.
 
 ### "100% inspection of mandatory classes" — now measurable (fixed at `5d81fb1`)
 


### PR DESCRIPTION
ADR-337 merged in #911 and is being read now. Three of its statements are wrong **in the direction that makes the problem look smaller**, so this lands ahead of the code fixes — wrong merged documentation propagates faster than an unfixed accounting bug, and costs nothing to correct.

Docs and comments only. No behaviour change.

## 1. The worst case is 1075%, not 108%

The 108% figure was presented as the realistic bad case. It is the **10%-mandatory mix** — which is why its rung count divides to 0.4 per operation rather than `max_rounds`. Against an **all-mandatory stream** the same configuration measures **1075%**.

An adversarial stream is not 10% mandatory. The table now carries the all-mandatory row and says which number to size against.

## 2. "Every operation" → "every operation it inspects"

80 rungs over 200 operations cannot be "`max_rounds` on every operation." It is every operation that **enters the ladder**: an all-benign 200-operation stream buys **0** rungs; an all-mandatory one buys **800**, exactly 4.00 each.

## 3. The divergence is bounded, not removed

`detector.rs` claimed that sourcing uncertainty from `TinyDetector` "removes the divergence rather than bounding it." **It bounds it.** Nothing cross-checks the declared figure against what `score()` actually carries, so an implementation may declare one value and produce another; the (0,1] bound caps how far apart they can be, with residual inflation reaching **44× at σ=0.05**.

What genuinely changed is the risk class — exploiting it now requires writing a trait implementation, which is code-review-visible, rather than editing a config value under deadline. That is worth stating accurately rather than overclaiming.

## Also recorded: the figures are a model, not a measurement

The account charges each rung its **declared** latency *and* separately charges the wall-clock of the whole inspection, so a real investigator that actually takes its declared latency is billed roughly twice — **2.46×** measured on a single 300 ms rung. The direction is conservative (it overstates cost and cannot conceal a budget breach), but `fraction()` should be read as a declared-cost model until that is corrected.

## Verification

- `cargo test -p mcp-gate --lib` → 42 pass
- `cargo fmt -p mcp-gate --check` → clean
- `node scripts/adr-index.mjs --check` → passes

Follows #919 (merged). The remaining code fixes — the double-count, the uncertainty cross-check, better `dd` markers, and the mis-named overhead test — are tracked separately and **must land before `monitor` is wired into the request path**.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_016QSCkKnxDjqU49NVVpWMK5