### PR TITLE
ci: pin Tiny Dancer build toolchain to 1.97.0 to fix aarch64-musl zig link drift (#900)

### DIFF
--- a/.github/workflows/build-tiny-dancer.yml
+++ b/.github/workflows/build-tiny-dancer.yml
@@ -80,7 +80,17 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
-          toolchain: stable
+          # Pinned, not `stable` (#900): both sides of the zig cross-compile
+          # must move together. Stable 1.98.0 (2026-08-18) began emitting the
+          # Cortex-A53 erratum flag `--fix-cortex-a53-843419` for
+          # aarch64-unknown-linux-musl, which zig's linker rejects as an
+          # unsupported linker arg — verified against zig 0.13.0 through
+          # 0.16.0, so bumping zig instead is not an option today. 1.97.0 is
+          # the newest stable whose target spec predates the flag (verified by
+          # reproducing the failed link with 1.98.0 and re-linking cleanly
+          # with 1.97.0 against the same zig 0.13.0). When bumping this pin,
+          # re-check the aarch64-musl `--zig` job first.
+          toolchain: "1.97.0"
           targets: ${{ matrix.settings.target }}
 
       - name: Cache Rust


### PR DESCRIPTION
## Summary

The separate CI PR that #900 asked for. `Build Tiny Dancer linux-arm64-musl` fails on every PR touching tiny-dancer paths with:

```
error: unsupported linker arg: --fix-cortex-a53-843419
error: could not compile `redb` (lib) due to 1 previous error
```

Fixes #900.

## Root cause, pinned down empirically

#900 diagnosed rust-toolchain/zig drift and offered two candidate fixes (pin rustc, or bump zig). Both were tested locally before choosing:

- **Bumping zig does not work.** A minimal aarch64-musl shared-object link with `-Wl,--fix-cortex-a53-843419` was run against zig **0.13.0, 0.14.1, 0.15.2, and 0.16.0** — every version rejects the flag with the same `unsupported linker arg` error, so no available zig release fixes this.
- **The flag arrived in stable 1.98.0 (2026-08-18).** The exact CI failure reproduces locally with a minimal cdylib (`rustc 1.98.0` + `zig cc -target aarch64-linux-musl` as linker, `-C target-feature=-crt-static`), and the same link stops emitting the flag on **1.97.0** with the same zig. That timeline matches the workflow's last green run on 2026-08-03 (1.97-era stable) and the failures starting 2026-08-22.

So the fix is the other half of #900's recommendation: pin `toolchain: "1.97.0"` next to the existing `zig 0.13.0` pin, so both sides of the cross-compile move together deliberately instead of drifting apart silently while the path-filtered workflow doesn't run. The pin carries a comment explaining exactly why and what to re-check when bumping it.

## Change

One file: `.github/workflows/build-tiny-dancer.yml`, `toolchain: stable` → `toolchain: "1.97.0"` plus the explanatory comment. No other workflow combines zig with an aarch64-musl target, so this is the whole blast radius.

## Validation

- Failure reproduced locally on 1.98.0 + zig 0.13.0 (identical `unsupported linker arg: --fix-cortex-a53-843419`, failing in a third-party dep before first-party code).
- Same link succeeds on 1.97.0 + zig 0.13.0.
- Flag rejection confirmed on zig 0.13.0 → 0.16.0, ruling out the zig-bump alternative.

Note: the `pull_request` path filter for this workflow doesn't include the workflow file itself, so this PR won't show the Tiny Dancer matrix in its own checks; the fix takes effect on tiny-dancer-touching PRs (e.g. #933) once merged.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_01L5ffi8NiKAQNabK3D5t2gK

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5ffi8NiKAQNabK3D5t2gK)_