### PR TITLE
release(npm): @ruvector/graph-node 2.1.0

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -17699,7 +17699,7 @@
     },
     "packages/graph-node": {
       "name": "@ruvector/graph-node",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -17708,11 +17708,11 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@ruvector/graph-node-darwin-arm64": "2.0.4",
-        "@ruvector/graph-node-darwin-x64": "2.0.4",
-        "@ruvector/graph-node-linux-arm64-gnu": "2.0.4",
-        "@ruvector/graph-node-linux-x64-gnu": "2.0.4",
-        "@ruvector/graph-node-win32-x64-msvc": "2.0.4"
+        "@ruvector/graph-node-darwin-arm64": "2.1.0",
+        "@ruvector/graph-node-darwin-x64": "2.1.0",
+        "@ruvector/graph-node-linux-arm64-gnu": "2.1.0",
+        "@ruvector/graph-node-linux-x64-gnu": "2.1.0",
+        "@ruvector/graph-node-win32-x64-msvc": "2.1.0"
       }
     },
     "packages/graph-wasm": {

--- a/npm/packages/graph-node/package.json
+++ b/npm/packages/graph-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ruvector/graph-node",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Native Node.js bindings for RuVector Graph Database with hypergraph support, Cypher queries, and persistence - 10x faster than WASM",
   "main": "index.js",
   "types": "index.d.ts",
@@ -33,11 +33,11 @@
     "@napi-rs/cli": "^2.18.0"
   },
   "optionalDependencies": {
-    "@ruvector/graph-node-linux-x64-gnu": "2.0.4",
-    "@ruvector/graph-node-linux-arm64-gnu": "2.0.4",
-    "@ruvector/graph-node-darwin-x64": "2.0.4",
-    "@ruvector/graph-node-darwin-arm64": "2.0.4",
-    "@ruvector/graph-node-win32-x64-msvc": "2.0.4"
+    "@ruvector/graph-node-linux-x64-gnu": "2.1.0",
+    "@ruvector/graph-node-linux-arm64-gnu": "2.1.0",
+    "@ruvector/graph-node-darwin-x64": "2.1.0",
+    "@ruvector/graph-node-darwin-arm64": "2.1.0",
+    "@ruvector/graph-node-win32-x64-msvc": "2.1.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Release commit for the #879 / #826 fix merged in #938. Two lines: `package.json` version + optionalDependency pins, and the matching workspace entry in `npm/package-lock.json`.

## Why this is a separate PR

`optional-deps-resolvable-on-npm` (`regression-guard.yml:351`, guarding #411) resolves every declared optionalDependency against the registry. A package therefore cannot declare its platform packages at a version that is not published yet — so **any** version bump fails CI until that version already exists on npm.

That makes the bump un-mergeable in the same PR as the fix, which is why #938 shipped at 2.0.4 and this carries the bump alone. Order:

1. ✅ #938 merged — fix on main at 2.0.4
2. ⏳ `build-graph-node.yml` dispatched on this branch with `publish=true` — builds 5 platforms, publishes `@ruvector/graph-node-{linux-x64-gnu,linux-arm64-gnu,darwin-x64,darwin-arm64,win32-x64-msvc}@2.1.0`, then `@ruvector/graph-node@2.1.0`
3. ⏳ guard re-runs green once those exist
4. ⏳ merge this

npm and `main` diverge only by the version line, only between steps 2 and 4.

## Why minor, not patch

`query()` gains behaviour rather than just fixing it: the label-less `MATCH (n)`, `WHERE` evaluation and relationship patterns all previously returned empty and now return rows. And unsupported constructs (`CREATE` via `query()`, variable-length paths, chained patterns) now **raise an error** where they previously returned an empty result set — a caller that was treating `[]` as "no matches" will now see a thrown error instead. That is the correct behaviour and the whole point of the fix, but it is a visible change, not a silent repair.

## Worth fixing separately

This chicken-and-egg is a standing tax on every native-package release here, not something specific to graph-node. The guard is right to exist — it caught a real skew in this very PR — but it cannot distinguish "a dependency that will never resolve" from "this repo's own platform packages, mid-release". Exempting `@ruvector/*` packages whose version equals the declaring workspace package's own version would keep the #411 protection while letting a release bump merge normally.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

https://claude.ai/code/session_017cMsrUW5PFR9fPahCwT5iA