### PR TITLE
feat(ruvllm): add TwinKV composable KV redundancy repair

### DIFF
--- a/crates/ruvllm/src/optimization/mod.rs
+++ b/crates/ruvllm/src/optimization/mod.rs
@@ -97,6 +97,7 @@
 pub mod metrics;
 pub mod realtime;
 pub mod sona_llm;
+pub mod twinkv;
 
 // Re-exports
 pub use metrics::{
@@ -109,4 +110,7 @@ pub use realtime::{
 pub use sona_llm::{
     AdaptationResult, ConsolidationStrategy, LearningLoopStats, OptimizationTrigger, SonaLlm,
     SonaLlmConfig, TrainingSample,
+};
+pub use twinkv::{
+    repair_retained_set, TwinKvConfig, TwinKvError, TwinKvRepair, TwinKvSwap,
 };

--- a/crates/ruvllm/src/optimization/mod.rs
+++ b/crates/ruvllm/src/optimization/mod.rs
@@ -111,6 +111,4 @@ pub use sona_llm::{
     AdaptationResult, ConsolidationStrategy, LearningLoopStats, OptimizationTrigger, SonaLlm,
     SonaLlmConfig, TrainingSample,
 };
-pub use twinkv::{
-    repair_retained_set, TwinKvConfig, TwinKvError, TwinKvRepair, TwinKvSwap,
-};
+pub use twinkv::{repair_retained_set, TwinKvConfig, TwinKvError, TwinKvRepair, TwinKvSwap};

--- a/crates/ruvllm/src/optimization/twinkv.rs
+++ b/crates/ruvllm/src/optimization/twinkv.rs
@@ -52,17 +52,28 @@ pub struct TwinKvRepair {
 pub enum TwinKvError {
     EmptyKeys,
     EmptyRetainedSet,
-    EmptyKeyVector { index: usize },
+    EmptyKeyVector {
+        index: usize,
+    },
     InconsistentKeyDimension {
         index: usize,
         expected: usize,
         actual: usize,
     },
-    NonFiniteKey { index: usize },
-    ZeroNormKey { index: usize },
+    NonFiniteKey {
+        index: usize,
+    },
+    ZeroNormKey {
+        index: usize,
+    },
     InvalidThreshold,
-    RetainedIndexOutOfRange { index: usize, key_count: usize },
-    DuplicateRetainedIndex { index: usize },
+    RetainedIndexOutOfRange {
+        index: usize,
+        key_count: usize,
+    },
+    DuplicateRetainedIndex {
+        index: usize,
+    },
 }
 
 impl Display for TwinKvError {

--- a/crates/ruvllm/src/optimization/twinkv.rs
+++ b/crates/ruvllm/src/optimization/twinkv.rs
@@ -1,0 +1,375 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+/// Configuration for the TwinKV style repair pass.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TwinKvConfig {
+    /// Cosine similarity above which two nonlocal keys are considered twins.
+    pub similarity_threshold: f32,
+    /// Adjacent positions within this distance are excluded from twin matching.
+    pub local_window: usize,
+    /// Leading positions that may never be evicted by the repair pass.
+    pub protected_sink_tokens: usize,
+    /// Trailing positions that may never be evicted by the repair pass.
+    pub protected_recent_tokens: usize,
+    /// Optional hard cap on swaps performed by one repair pass.
+    pub max_swaps: Option<usize>,
+}
+
+impl Default for TwinKvConfig {
+    fn default() -> Self {
+        Self {
+            similarity_threshold: 0.85,
+            local_window: 32,
+            protected_sink_tokens: 4,
+            protected_recent_tokens: 64,
+            max_swaps: None,
+        }
+    }
+}
+
+/// A single budget preserving replacement made by the repair pass.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TwinKvSwap {
+    pub admitted_orphan: usize,
+    pub evicted_donor: usize,
+    pub orphan_best_surviving_similarity: f32,
+    pub donor_best_surviving_similarity: f32,
+}
+
+/// Result of auditing and repairing an existing retained set.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TwinKvRepair {
+    /// Sorted retained positions after applying all swaps.
+    pub retained: Vec<usize>,
+    pub swaps: Vec<TwinKvSwap>,
+    pub orphan_count: usize,
+    pub donor_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TwinKvError {
+    EmptyKeys,
+    EmptyRetainedSet,
+    EmptyKeyVector { index: usize },
+    InconsistentKeyDimension {
+        index: usize,
+        expected: usize,
+        actual: usize,
+    },
+    NonFiniteKey { index: usize },
+    ZeroNormKey { index: usize },
+    InvalidThreshold,
+    RetainedIndexOutOfRange { index: usize, key_count: usize },
+    DuplicateRetainedIndex { index: usize },
+}
+
+impl Display for TwinKvError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyKeys => write!(f, "keys must not be empty"),
+            Self::EmptyRetainedSet => write!(f, "retained set must not be empty"),
+            Self::EmptyKeyVector { index } => write!(f, "key vector at index {index} is empty"),
+            Self::InconsistentKeyDimension {
+                index,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "key vector at index {index} has dimension {actual}, expected {expected}"
+            ),
+            Self::NonFiniteKey { index } => {
+                write!(f, "key vector at index {index} contains a non finite value")
+            }
+            Self::ZeroNormKey { index } => {
+                write!(f, "key vector at index {index} has zero norm")
+            }
+            Self::InvalidThreshold => write!(
+                f,
+                "similarity threshold must be finite and in the interval from negative one to one"
+            ),
+            Self::RetainedIndexOutOfRange { index, key_count } => write!(
+                f,
+                "retained index {index} is outside key range 0..{key_count}"
+            ),
+            Self::DuplicateRetainedIndex { index } => {
+                write!(f, "retained index {index} appears more than once")
+            }
+        }
+    }
+}
+
+impl Error for TwinKvError {}
+
+/// Repair an arbitrary KV eviction policy without changing its cache budget.
+///
+/// The input `retained` set is treated as the wrapped policy's immutable
+/// decision. For every token we compute its best nonlocal cosine similarity to
+/// a surviving retained token. Evicted tokens below the threshold are orphans.
+/// Retained, unprotected tokens at or above the threshold are redundant donors.
+/// The most severe orphans replace the most redundant donors one for one.
+///
+/// This implementation computes only similarities against the retained set,
+/// reducing the repair specific work from a full pairwise matrix to O(n K d),
+/// where K is the retained budget and d is key dimension.
+pub fn repair_retained_set(
+    keys: &[Vec<f32>],
+    retained: &[usize],
+    config: &TwinKvConfig,
+) -> Result<TwinKvRepair, TwinKvError> {
+    if keys.is_empty() {
+        return Err(TwinKvError::EmptyKeys);
+    }
+    if retained.is_empty() {
+        return Err(TwinKvError::EmptyRetainedSet);
+    }
+    if !config.similarity_threshold.is_finite()
+        || !(-1.0..=1.0).contains(&config.similarity_threshold)
+    {
+        return Err(TwinKvError::InvalidThreshold);
+    }
+
+    let dimension = keys[0].len();
+    if dimension == 0 {
+        return Err(TwinKvError::EmptyKeyVector { index: 0 });
+    }
+
+    let mut normalized = Vec::with_capacity(keys.len());
+    for (index, key) in keys.iter().enumerate() {
+        if key.is_empty() {
+            return Err(TwinKvError::EmptyKeyVector { index });
+        }
+        if key.len() != dimension {
+            return Err(TwinKvError::InconsistentKeyDimension {
+                index,
+                expected: dimension,
+                actual: key.len(),
+            });
+        }
+        if key.iter().any(|value| !value.is_finite()) {
+            return Err(TwinKvError::NonFiniteKey { index });
+        }
+
+        let norm_sq = key.iter().map(|value| value * value).sum::<f32>();
+        if !norm_sq.is_finite() || norm_sq <= f32::EPSILON {
+            return Err(TwinKvError::ZeroNormKey { index });
+        }
+        let inv_norm = norm_sq.sqrt().recip();
+        normalized.push(key.iter().map(|value| value * inv_norm).collect::<Vec<_>>());
+    }
+
+    let mut retained_set = BTreeSet::new();
+    for &index in retained {
+        if index >= keys.len() {
+            return Err(TwinKvError::RetainedIndexOutOfRange {
+                index,
+                key_count: keys.len(),
+            });
+        }
+        if !retained_set.insert(index) {
+            return Err(TwinKvError::DuplicateRetainedIndex { index });
+        }
+    }
+
+    let best_surviving = normalized
+        .iter()
+        .enumerate()
+        .map(|(index, key)| {
+            retained_set
+                .iter()
+                .copied()
+                .filter(|&candidate| {
+                    candidate != index && index.abs_diff(candidate) > config.local_window
+                })
+                .map(|candidate| cosine_from_normalized(key, &normalized[candidate]))
+                .fold(-1.0_f32, f32::max)
+        })
+        .collect::<Vec<_>>();
+
+    let mut orphans = (0..keys.len())
+        .filter(|index| !retained_set.contains(index))
+        .filter(|&index| best_surviving[index] < config.similarity_threshold)
+        .map(|index| (index, best_surviving[index]))
+        .collect::<Vec<_>>();
+
+    let mut donors = retained_set
+        .iter()
+        .copied()
+        .filter(|&index| !is_protected(index, keys.len(), config))
+        .filter(|&index| best_surviving[index] >= config.similarity_threshold)
+        .map(|index| (index, best_surviving[index]))
+        .collect::<Vec<_>>();
+
+    orphans.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+    donors.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+    let available_swaps = orphans.len().min(donors.len());
+    let swap_count = config
+        .max_swaps
+        .map(|limit| available_swaps.min(limit))
+        .unwrap_or(available_swaps);
+
+    let mut repaired = retained_set;
+    let mut swaps = Vec::with_capacity(swap_count);
+    for ((orphan, orphan_similarity), (donor, donor_similarity)) in orphans
+        .iter()
+        .take(swap_count)
+        .zip(donors.iter().take(swap_count))
+    {
+        repaired.remove(donor);
+        repaired.insert(*orphan);
+        swaps.push(TwinKvSwap {
+            admitted_orphan: *orphan,
+            evicted_donor: *donor,
+            orphan_best_surviving_similarity: *orphan_similarity,
+            donor_best_surviving_similarity: *donor_similarity,
+        });
+    }
+
+    debug_assert_eq!(repaired.len(), retained.len());
+
+    Ok(TwinKvRepair {
+        retained: repaired.into_iter().collect(),
+        swaps,
+        orphan_count: orphans.len(),
+        donor_count: donors.len(),
+    })
+}
+
+fn cosine_from_normalized(left: &[f32], right: &[f32]) -> f32 {
+    left.iter().zip(right).map(|(a, b)| a * b).sum::<f32>()
+}
+
+fn is_protected(index: usize, key_count: usize, config: &TwinKvConfig) -> bool {
+    index < config.protected_sink_tokens
+        || index >= key_count.saturating_sub(config.protected_recent_tokens)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> TwinKvConfig {
+        TwinKvConfig {
+            similarity_threshold: 0.95,
+            local_window: 0,
+            protected_sink_tokens: 1,
+            protected_recent_tokens: 0,
+            max_swaps: None,
+        }
+    }
+
+    #[test]
+    fn swaps_an_orphan_for_a_redundant_donor_without_changing_budget() {
+        let keys = vec![vec![1.0, 0.0], vec![1.0, 0.0], vec![0.0, 1.0]];
+        let result = repair_retained_set(&keys, &[0, 1], &test_config()).unwrap();
+
+        assert_eq!(result.retained, vec![0, 2]);
+        assert_eq!(result.swaps.len(), 1);
+        assert_eq!(result.swaps[0].evicted_donor, 1);
+        assert_eq!(result.swaps[0].admitted_orphan, 2);
+        assert_eq!(result.retained.len(), 2);
+    }
+
+    #[test]
+    fn returns_noop_when_evicted_information_has_a_surviving_twin() {
+        let keys = vec![vec![1.0, 0.0], vec![0.0, 1.0], vec![1.0, 0.0]];
+        let result = repair_retained_set(&keys, &[0, 1], &test_config()).unwrap();
+
+        assert_eq!(result.retained, vec![0, 1]);
+        assert!(result.swaps.is_empty());
+        assert_eq!(result.orphan_count, 0);
+    }
+
+    #[test]
+    fn excludes_adjacent_similarity_from_redundancy() {
+        let keys = vec![
+            vec![1.0, 0.0],
+            vec![1.0, 0.0],
+            vec![0.0, 1.0],
+            vec![0.0, 1.0],
+        ];
+        let mut config = test_config();
+        config.local_window = 1;
+        config.protected_sink_tokens = 0;
+
+        let result = repair_retained_set(&keys, &[0, 2], &config).unwrap();
+        assert!(result.swaps.is_empty());
+    }
+
+    #[test]
+    fn never_uses_protected_regions_as_donors() {
+        let keys = vec![
+            vec![1.0, 0.0],
+            vec![1.0, 0.0],
+            vec![0.0, 1.0],
+            vec![0.0, 1.0],
+        ];
+        let config = TwinKvConfig {
+            similarity_threshold: 0.95,
+            local_window: 0,
+            protected_sink_tokens: 2,
+            protected_recent_tokens: 0,
+            max_swaps: None,
+        };
+
+        let result = repair_retained_set(&keys, &[0, 1], &config).unwrap();
+        assert_eq!(result.retained, vec![0, 1]);
+        assert_eq!(result.donor_count, 0);
+    }
+
+    #[test]
+    fn obeys_swap_limit_and_is_deterministic() {
+        let keys = vec![
+            vec![1.0, 0.0, 0.0],
+            vec![1.0, 0.0, 0.0],
+            vec![0.0, 1.0, 0.0],
+            vec![0.0, 1.0, 0.0],
+            vec![0.0, 0.0, 1.0],
+            vec![0.0, -1.0, 0.0],
+        ];
+        let config = TwinKvConfig {
+            max_swaps: Some(1),
+            protected_sink_tokens: 0,
+            ..test_config()
+        };
+
+        let first = repair_retained_set(&keys, &[0, 1, 2, 3], &config).unwrap();
+        let second = repair_retained_set(&keys, &[0, 1, 2, 3], &config).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.swaps.len(), 1);
+        assert_eq!(first.retained.len(), 4);
+    }
+
+    #[test]
+    fn rejects_malformed_inputs() {
+        assert_eq!(
+            repair_retained_set(&[], &[0], &test_config()),
+            Err(TwinKvError::EmptyKeys)
+        );
+        assert_eq!(
+            repair_retained_set(&[vec![1.0]], &[], &test_config()),
+            Err(TwinKvError::EmptyRetainedSet)
+        );
+        assert_eq!(
+            repair_retained_set(&[vec![0.0, 0.0]], &[0], &test_config()),
+            Err(TwinKvError::ZeroNormKey { index: 0 })
+        );
+        assert_eq!(
+            repair_retained_set(&[vec![1.0], vec![1.0, 2.0]], &[0], &test_config()),
+            Err(TwinKvError::InconsistentKeyDimension {
+                index: 1,
+                expected: 1,
+                actual: 2,
+            })
+        );
+        assert_eq!(
+            repair_retained_set(&[vec![1.0]], &[1], &test_config()),
+            Err(TwinKvError::RetainedIndexOutOfRange {
+                index: 1,
+                key_count: 1,
+            })
+        );
+    }
+}

--- a/docs/adr/ADR-330-twinkv-kv-redundancy-repair.md
+++ b/docs/adr/ADR-330-twinkv-kv-redundancy-repair.md
@@ -1,0 +1,62 @@
+# ADR 330: KV redundancy repair as a composable cache optimization
+
+Status: Proposed
+
+Date: 2026 08 29
+
+## Context
+
+TwinKV, arXiv 2608.27128, reports that attention magnitude was statistically unrelated to leave one out causal utility in its controlled long context probe, with Spearman rho near zero. The paper proposes a training free repair pass that audits any existing KV eviction policy after selection.
+
+The repair identifies two structural mistakes. An orphan is an evicted token with no sufficiently similar surviving key outside a local exclusion window. A donor is a retained unprotected token with a sufficiently similar surviving key. The repair swaps severe orphans for redundant donors while preserving the exact original cache budget.
+
+The originating team reports mixed but useful results across Qwen3 4B and Llama 3.2 1B. It improves some wrapped policies substantially, is near even for others, and regresses on a few shot classification structure. This is not evidence that every cache policy should always enable the repair.
+
+## Decision
+
+Add an opt in TwinKV style repair primitive under `ruvllm::optimization`.
+
+The RuV implementation computes best surviving similarity directly against the retained set. This follows the repair equation while avoiding construction of the full pairwise similarity matrix. Repair specific work is O(n K d), where n is context length, K is retained budget, and d is key dimension.
+
+The primitive is policy agnostic. It accepts key vectors and a retained position set. It returns a repaired retained set plus explicit swap receipts. It does not own the underlying eviction score, cache allocation, model execution, or authority decisions.
+
+## Invariants
+
+1. The retained budget is exactly preserved.
+2. Protected sink and recent positions are never selected as donors.
+3. Local neighbors inside the exclusion window cannot establish redundancy.
+4. Malformed, non finite, zero norm, inconsistent dimension, duplicate, and out of range inputs fail closed.
+5. Equal inputs produce deterministic retained sets and swap receipts.
+6. No model call or training step is introduced.
+7. The feature remains opt in until matched benchmark reproduction establishes a positive workload specific effect.
+
+## Contradictions and limits
+
+The published effect is not universal. ExpectedAttention on Qwen3 4B often loses because the baseline is already near a ceiling. TREC style few shot exemplars also regress because template similarity can look like semantic redundancy.
+
+The fixed similarity threshold is architecture sensitive. The paper uses 0.85 for Qwen3 4B and 0.90 for Llama 3.2 1B. Production integration therefore must keep threshold policy explicit and versioned rather than treating one threshold as universal.
+
+Raw post RoPE similarity also needs special handling for nonuniform rotary schedules such as LongRoPE. This initial primitive assumes the caller supplies a representation where cosine similarity is meaningful for the target architecture.
+
+## Validation plan
+
+Reproduce the wrapped policy alone and wrapped policy plus repair on identical samples, seeds, model revisions, tokenizer revisions, cache ratios, and hardware.
+
+Initial ladder:
+
+1. Qwen3 4B at compression ratios 0.3, 0.5, and 0.7.
+2. Llama 3.2 1B at the same ratios.
+3. LongBench, RULER, and a short context no harm control.
+4. At least one existing RuV cache policy.
+
+Report task score, cache bytes, prefill latency, repair latency, decode throughput, peak memory, energy when available, swap count, orphan count, donor count, failures, and variance.
+
+Promotion requires a positive mean quality effect on the target workload, no material short context regression, exact budget preservation, and repair overhead small enough that end to end latency remains favorable.
+
+## Security and governance
+
+This primitive only changes which cached positions survive. It must not alter execution permissions, model identity, policy authority, or evaluation state. Configuration and benchmark provenance should be recorded in RVF or the existing witness path before any adaptive threshold learning is enabled.
+
+## Rollback
+
+Disable the repair pass and retain the original eviction set. No state migration is required.

--- a/docs/research/2026-08-29-twinkv-reproduction.md
+++ b/docs/research/2026-08-29-twinkv-reproduction.md
@@ -1,0 +1,60 @@
+# TwinKV reproduction protocol
+
+Source: arXiv 2608.27128, submitted 2026 08 27.
+
+Evidence class: originating team report. No RuV model level reproduction yet.
+
+## Baseline and candidate
+
+Baseline: existing RuV KV eviction policy alone.
+
+Candidate: identical policy and retained budget followed by `repair_retained_set`.
+
+## Environment record
+
+Pin model revision, tokenizer revision, RuVector commit, Rust toolchain, inference backend, driver, accelerator, operating system, cache precision, batch size, context length, and compression ratio.
+
+## Workloads
+
+1. LongBench representative tasks including one code task, one multi hop QA task, and TREC as an expected negative control.
+2. RULER at 4K, 8K, and 16K context.
+3. A short context accuracy control.
+4. One real RuV agent workload with long tool and repository context.
+
+## Models
+
+1. Qwen3 4B, initial similarity threshold 0.85.
+2. Llama 3.2 1B, initial similarity threshold 0.90.
+
+Pin exact model revisions before running.
+
+## Metrics
+
+For every condition report baseline and candidate task score, absolute delta, relative delta, prefill latency, repair latency, decode throughput, cache bytes, peak memory, energy when measurable, swap count, orphan count, donor count, and failure count.
+
+Use identical examples and seeds. Report variance across at least three seeds where decoding is stochastic.
+
+## Ablations
+
+1. Similarity threshold ladder around the paper value.
+2. Local window 0, 16, 32, and 64.
+3. Repair specific O(n K d) implementation versus full pairwise audit on a bounded context to confirm decision equivalence.
+4. Max swap cap.
+5. Random budget preserving swap negative control.
+
+## Degradation tests
+
+1. Zero norm keys.
+2. Non finite keys.
+3. Inconsistent dimensions.
+4. Duplicate retained positions.
+5. Missing protected sink or recent positions from the wrapped policy.
+6. Extremely low and high compression.
+7. TREC style repeated templates.
+8. LongRoPE or another nonuniform rotary schedule before architecture specific correction is enabled.
+
+## Acceptance gate
+
+Graduate only when the target workload shows a positive mean quality effect, short context control does not regress by more than 0.5 absolute points, retained budget is preserved in every case, and measured repair overhead does not erase the end to end latency or memory benefit of eviction.
+
+Record negative policies and task structures. Do not enable globally from a positive result on one model or benchmark.


### PR DESCRIPTION
Implements the bounded TwinKV repair primitive tracked in #945.

Changes include a policy agnostic repair pass under ruvLLM optimization, exact cache budget preservation, protected sink and recent regions, local similarity exclusion, deterministic orphan and donor ranking, malformed input rejection, unit tests, ADR 330, and a full reproduction protocol.

The implementation deliberately computes only against the retained set for O(n K d) repair specific work rather than constructing the full pairwise matrix used by the paper implementation.

This PR is draft because model level benchmark reproduction is not complete. Do not merge until matched baseline versus candidate tests demonstrate a workload specific gain, short context controls remain stable, and repair latency does not erase the cache benefit.