### PR TITLE
fix(rvf): bump @ruvector/rvf pin ^0.1.0 → ^0.3.4 (string-id data loss in npx ruvector)

### DIFF
--- a/npm/packages/ruvector/package.json
+++ b/npm/packages/ruvector/package.json
@@ -89,7 +89,7 @@
     "@metaharness/weight-eft": "^0.1.1",
     "@metaharness/workspace-lens": "^0.1.2",
     "@metaharness/workspace-probe": "^0.1.1",
-    "@ruvector/rvf": "^0.1.0",
+    "@ruvector/rvf": "^0.3.4",
     "@ruvector/tiny-dancer": "^0.1.22",
     "metaharness": "^0.4.7"
   },

--- a/npm/packages/rvf-mcp-server/package.json
+++ b/npm/packages/rvf-mcp-server/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "@ruvector/rvf": "^0.1.2",
+    "@ruvector/rvf": "^0.3.4",
     "express": "^4.18.0",
     "zod": "^3.22.0"
   },


### PR DESCRIPTION
## Problem

`npx ruvector rvf …` silently loses data with non-numeric ids. Building a store with string ids (e.g. `rel:chris-keil`) and then `status`/`query` shows only **1 vector** no matter how many were ingested, and `query` never matches.

**Root cause:** the CLI resolves `@ruvector/rvf` at **`^0.1.0` → 0.1.9**, whose NAPI backend does `ids = entries.map(e => Number(e.id))`. Non-numeric strings become `NaN`, so the native i64 HNSW collapses every vector onto one label. `status: totalVectors:1`, a single `query` hit at dist≈1, and `compact` shrinking the file are all *correct* readings of a 1-vector store — not separate bugs. 0.1.9 also silently dropped per-vector `metadata`.

## This is already fixed in `@ruvector/rvf@0.3.4` — the CLI just can't reach it

`0.3.4` (published) adds `resolveLabel` (a persisted string↔numeric-label map) and **rejects metadata loudly** instead of dropping it. But `^0.1.0` (and `rvf-mcp-server`'s `^0.1.2`) cannot resolve to `0.3.x`, so users stay on the broken `0.1.9`.

## Change

Bump the `@ruvector/rvf` pin `^0.1.0`/`^0.1.2` → `^0.3.4` in:
- `npm/packages/ruvector` (CLI)
- `npm/packages/rvf-mcp-server`

## Verification (against real `@ruvector/rvf@0.3.4`)

```
create(dim=4, cosine); ingestBatch([{id:'rel:chris',vector:[1,0,0,0]},{id:'rel:bo',[0,1,0,0]},{id:'org:cog',[0,0,1,0]}])
status()  -> { totalVectors: 3, ... }                         # was 1 on 0.1.9
query([1,0,0,0],3) -> [{id:"rel:chris",distance:0}, {id:"rel:bo",1}, {id:"org:cog",1}]   # string ids resolved, exact match dist 0
ingestBatch([{id:'x',vector:[0,0,0,1],metadata:{…}}]) -> throws "Per-vector metadata is not yet supported by this SDK (see #704)"  # loud, not silent
```

The CLI wrapper (`RvfDatabase.create/.open`, `ingestBatch`, `query`, `status`, `compact`) is API-compatible with 0.3.4 — a drop-in bump.

## Scope / not included

- **Republish is required** for `npx ruvector` and `@ruvector/rvf-mcp-server` users to receive this — a maintainer release step, not part of this PR.
- The monorepo `npm/package-lock.json` should be regenerated (`npm install`) so the resolved tree picks up 0.3.4; not regenerated here to keep the diff reviewable.
- Metadata is *rejected loudly* in 0.3.4, not supported (#704) — callers needing per-vector metadata should keep a sidecar for now.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)
